### PR TITLE
quickwin dockerization

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:jessie-slim
+
+LABEL MAINTAINER="theonlydoo <theonlydoo@gmail.com>"
+
+WORKDIR /app
+
+ADD https://github.com/guardicore/monkey/releases/download/1.5.2/infection_monkey_1.5.2_deb.tgz .
+
+RUN tar xvf infection_monkey_1.5.2_deb.tgz  \
+    && apt-get -yqq update                  \
+    && apt-get -yqq upgrade                 \
+    && apt-get -yqq install python-pip      \
+                            libssl-dev      \
+                            supervisor      \
+    && dpkg -i *.deb    
+
+COPY stack.conf /etc/supervisor/conf.d/stack.conf
+
+ENTRYPOINT [ "supervisord", "-n", "-c", "/etc/supervisor/supervisord.conf" ]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,11 @@
+# Improvements needed
+
+* Remove embedded mongodb from .deb, it forbids installation on a `debian:stretch` distro.
+* Package monkey for system's python usage.
+* Fix package number: (I installed the 1.5.2)
+```
+ii  gc-monkey-island           1.0                      amd64        Guardicore Infection Monkey Island installation package
+```
+* Use .deb dependencies for mongodb setup?
+* Use docker-compose for stack construction.
+* Remove the .sh script from the systemd unit file (`/var/monkey_island/ubuntu/systemd/start_server.sh`) which only does a `cd && localpython run`

--- a/docker/stack.conf
+++ b/docker/stack.conf
@@ -1,0 +1,4 @@
+[program:mongod]
+command=/var/monkey_island/bin/mongodb/bin/mongod --quiet --dbpath /var/monkey_island/db
+[program:monkey]
+command=/var/monkey_island/ubuntu/systemd/start_server.sh


### PR DESCRIPTION
# Feature / Fixes
* https://github.com/guardicore/monkey/issues/122

##  Changes
  - add dockerfile
  - add docker/readme.md
  - add supervisord as a workaround for the embedded mongodb issue raised in the readme.
