### PR TITLE
long was removed in Python 3

### DIFF
--- a/infection_monkey/exploit/tools.py
+++ b/infection_monkey/exploit/tools.py
@@ -405,7 +405,7 @@ def get_interface_to_target(dst):
         for d, m, gw, i, a in routes:
             aa = atol(a)
             if aa == dst:
-                pathes.append((0xffffffffL, ("lo", a, "0.0.0.0")))
+                pathes.append((0xffffffff, ("lo", a, "0.0.0.0")))
             if (dst & m) == (d & m):
                 pathes.append((m, (i, a, gw)))
         if not pathes:

--- a/infection_monkey/network/info.py
+++ b/infection_monkey/network/info.py
@@ -10,6 +10,11 @@ from subprocess import check_output
 from random import randint
 from common.network.network_range import CidrRange
 
+try:
+    long        # Python 2
+except NameError:
+    long = int  # Python 3
+
 
 def get_host_subnets():
     """
@@ -93,8 +98,8 @@ else:
                     ifaddr = socket.inet_ntoa(ifreq[20:24])
                 else:
                     continue
-            routes.append((socket.htonl(long(dst, 16)) & 0xffffffffL,
-                           socket.htonl(long(msk, 16)) & 0xffffffffL,
+            routes.append((socket.htonl(long(dst, 16)) & 0xffffffff,
+                           socket.htonl(long(msk, 16)) & 0xffffffff,
                            socket.inet_ntoa(struct.pack("I", long(gw, 16))),
                            iff, ifaddr))
 


### PR DESCRIPTION
# Feature / Fixes
> Changes/Fixes the following feature

Part of a bite-sized approach to #119

* [X] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Have you successfully tested your changes locally?

* Example screenshot/log transcript of the feature working

##  Changes
  - Define long in Python 3
  - The trailing L on numeric literals is no longer required in Python 2 and is a Syntax Error in Python 3
  -
