### PR TITLE
Travis CI for automated testing of all pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+group: travis_latest
+language: python
+cache: pip
+python:
+    - 2.7
+    - 3.6
+    #- nightly
+    #- pypy
+    #- pypy3
+matrix:
+    allow_failures:
+        - python: nightly
+        - python: pypy
+        - python: pypy3
+install:
+    #- pip install -r requirements.txt
+    - pip install flake8  # pytest  # add another testing frameworks later
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - true  # pytest --capture=sys  # add other tests here
+notifications:
+    on_success: change
+    on_failure: change # `always` will be the setting once code changes slow down


### PR DESCRIPTION
Travis Continuous Integration is free for all open source projects like this one.  This config file would have Travis CI run [flake8](http://flake8.pycqa.org) tests to find Python syntax errors and undefined names in all pull requests _before_ they are reviewed.  To turn Travis CI on, visit https://travis-ci.com/guardicore

# Feature / Fixes
> Changes/Fixes the following feature

* [X] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Have you successfully tested your changes locally?

* Example screenshot/log transcript of the feature working

##  Changes
  - Add Travis CI to do automated testing of pull requests before they are reviewed
  -
  -
