### PR TITLE
ftp.py: Undefined name local_ip --> self.local_ip

### DIFF
--- a/infection_monkey/transport/ftp.py
+++ b/infection_monkey/transport/ftp.py
@@ -83,7 +83,7 @@ class FTPServer(threading.Thread):
     def PASV(self,cmd):
         self.pasv_mode = True
         self.servsock = socket.socket(socket.AF_INET,socket.SOCK_STREAM)
-        self.servsock.bind((local_ip,0))
+        self.servsock.bind((self.local_ip,0))
         self.servsock.listen(1)
         ip, port = self.servsock.getsockname()
         self.conn.send('227 Entering Passive Mode (%s,%u,%u).\r\n' %


### PR DESCRIPTION
__local_ip__ is an __undefined name__ in this context (could raise [__NameError__](https://docs.python.org/3/library/exceptions.html#NameError) at runtime) so this PR recommends the use of __self.local_ip__ instead.  

flake8 testing of https://github.com/guardicore/monkey on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./infection_monkey/transport/ftp.py:86:29: F821 undefined name 'local_ip'
        self.servsock.bind((local_ip,0))
                            ^
```