### PR TITLE
Monkey will now compile without Mimikatz

### DIFF
--- a/infection_monkey/monkey.spec
+++ b/infection_monkey/monkey.spec
@@ -7,16 +7,18 @@ a = Analysis(['main.py'],
              hookspath=None,
              runtime_hooks=None)
 
-             
+
 a.binaries  += [('sc_monkey_runner32.so', '.\\bin\\sc_monkey_runner32.so', 'BINARY')]
 a.binaries  += [('sc_monkey_runner64.so', '.\\bin\\sc_monkey_runner64.so', 'BINARY')]
 
 if platform.system().find("Windows")>= 0:
     a.datas = [i for i in a.datas if i[0].find('Include') < 0]
     if platform.architecture()[0] == "32bit":
-        a.binaries  += [('mk.dll', '.\\bin\\mk32.dll', 'BINARY')]
+        if os.path.isfile('.\\bin\\mk32.dll'):
+            a.binaries  += [('mk.dll', '.\\bin\\mk32.dll', 'BINARY')]
     else:
-        a.binaries  += [('mk.dll', '.\\bin\\mk64.dll', 'BINARY')]
+        if os.path.isfile('.\\bin\\mk64.dll'):
+            a.binaries  += [('mk.dll', '.\\bin\\mk64.dll', 'BINARY')]
 
 pyz = PYZ(a.pure)
 exe = EXE(pyz,


### PR DESCRIPTION
# Feature / Fixes
You can now compile the Monkey binary on Windows without Mimikatz.
This feature is useful for two use cases
1. Development
2. Environments where we want to run the Monkey without Mimikatz to avoid overly aggressive AV.

* [X] Have you added an explanation of what your changes do and why you'd like to include them?
* [X] Have you successfully tested your changes locally?
