### PR TITLE
Changed constructor to have default paths set to None for convienience

### DIFF
--- a/infection_monkey/exploit/web_rce.py
+++ b/infection_monkey/exploit/web_rce.py
@@ -21,7 +21,7 @@ WIN_ARCH_64 = "64"
 
 class WebRCE(HostExploiter):
 
-    def __init__(self, host, monkey_target_paths):
+    def __init__(self, host, monkey_target_paths=None):
         """
         :param host: Host that we'll attack
         :param monkey_target_paths: Where to upload the monkey at the target host system.


### PR DESCRIPTION
# Feature / Fixes
Small fix that sets default monkey path to None in constructor's annotation (now you dont need to pass "None" while creating instance of framework to have default values)
