### PR TITLE
Improved error handling if firewall does not allow to open http server

### DIFF
--- a/infection_monkey/exploit/tools.py
+++ b/infection_monkey/exploit/tools.py
@@ -407,6 +407,7 @@ class HTTPTools(object):
             local_ip = get_interface_to_target(host.ip_addr)
 
         if not firewall.listen_allowed():
+            LOG.error("Firewall is not allowed to listen for incomming ports. Aborting")
             return None, None
 
         httpd = LockedHTTPServer(local_ip, local_port, src_path, lock)

--- a/infection_monkey/exploit/web_rce.py
+++ b/infection_monkey/exploit/web_rce.py
@@ -95,7 +95,7 @@ class WebRCE(HostExploiter):
         # Upload the right monkey to target
         data = self.upload_monkey(self.vulnerable_urls[0], exploit_config['upload_commands'])
 
-        if data is not False and data['response'] is False:
+        if data is False:
             return False
 
         # Change permissions to transform monkey into executable file
@@ -341,7 +341,11 @@ class WebRCE(HostExploiter):
         http_thread.join(DOWNLOAD_TIMEOUT)
         http_thread.stop()
         LOG.info("Uploading process finished")
-        return {'response': resp, 'path': paths['dest_path']}
+        # If response is false exploiter failed
+        if resp is False:
+            return resp
+        else:
+            return {'response': resp, 'path': paths['dest_path']}
 
     def change_permissions(self, url, path, command=None):
         """


### PR DESCRIPTION
# Feature / Fixes
> In the case that firewall blocks user from opening http server LOG shows that and web_rce framework does not spit errors.
