### PR TITLE
from six import text_type, from six.moves import xrange

### DIFF
--- a/infection_monkey/exploit/hadoop.py
+++ b/infection_monkey/exploit/hadoop.py
@@ -9,6 +9,7 @@ import random
 import string
 import logging
 from exploit.web_rce import WebRCE
+from six.moves import xrange
 from tools import HTTPTools, build_monkey_commandline, get_monkey_depth
 import posixpath
 from model import MONKEY_ARG, ID_STRING

--- a/infection_monkey/exploit/struts2.py
+++ b/infection_monkey/exploit/struts2.py
@@ -9,6 +9,7 @@ import unicodedata
 import re
 
 import logging
+from six import text_type
 from web_rce import WebRCE
 
 __author__ = "VakarisZ"
@@ -78,7 +79,7 @@ class Struts2Exploiter(WebRCE):
                   "(@org.apache.commons.io.IOUtils@copy(#process.getInputStream(),#ros))." \
                   "(#ros.flush())}" % cmd
         # Turns payload ascii just for consistency
-        if isinstance(payload, unicode):
+        if isinstance(payload, text_type):
             payload = unicodedata.normalize('NFKD', payload).encode('ascii', 'ignore')
         headers = {'User-Agent': 'Mozilla/5.0', 'Content-Type': payload}
         try:

--- a/monkey_island/cc/services/report.py
+++ b/monkey_island/cc/services/report.py
@@ -416,7 +416,7 @@ class ReportService:
             ip_in_src = None
             ip_in_dst = None
             for ip_addr in monkey['ip_addresses']:
-                if source_subnet_range.is_in_range(unicode(ip_addr)):
+                if source_subnet_range.is_in_range(text_type(ip_addr)):
                     ip_in_src = ip_addr
                     break
 
@@ -425,7 +425,7 @@ class ReportService:
                 continue
 
             for ip_addr in monkey['ip_addresses']:
-                if target_subnet_range.is_in_range(unicode(ip_addr)):
+                if target_subnet_range.is_in_range(text_type(ip_addr)):
                     ip_in_dst = ip_addr
                     break
 
@@ -461,7 +461,7 @@ class ReportService:
         scans.rewind()  # If we iterated over scans already we need to rewind.
         for scan in scans:
             target_ip = scan['data']['machine']['ip_addr']
-            if target_subnet_range.is_in_range(unicode(target_ip)):
+            if target_subnet_range.is_in_range(text_type(target_ip)):
                 monkey = NodeService.get_monkey_by_guid(scan['monkey_guid'])
                 cross_segment_ip = ReportService.get_ip_in_src_and_not_in_dst(monkey['ip_addresses'],
                                                                               source_subnet_range,


### PR DESCRIPTION
# Feature / Fixes
> Changes/Fixes the following feature

Use the six module to avoid _undefined name_ (raises NameError) issues from __unicode()__ and __xrange()__ which were both removed in Python 3.  These changes do the right thing in both Python2 and Python 3.

[flake8](http://flake8.pycqa.org) testing of https://github.com/guardicore/monkey on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./monkey_island/cc/services/report.py:419:52: F821 undefined name 'unicode'
                if source_subnet_range.is_in_range(unicode(ip_addr)):
                                                   ^
./monkey_island/cc/services/report.py:428:52: F821 undefined name 'unicode'
                if target_subnet_range.is_in_range(unicode(ip_addr)):
                                                   ^
./monkey_island/cc/services/report.py:464:48: F821 undefined name 'unicode'
            if target_subnet_range.is_in_range(unicode(target_ip)):
                                               ^
./infection_monkey/exploit/hadoop.py:65:89: F821 undefined name 'xrange'
        rand_name = ID_STRING + "".join([random.choice(string.ascii_lowercase) for _ in xrange(self.RAN_STR_LEN)])
                                                                                        ^
./infection_monkey/exploit/struts2.py:81:32: F821 undefined name 'unicode'
        if isinstance(payload, unicode):
                               ^
5     F821 undefined name 'xrange'
5
```

* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Have you successfully tested your changes locally?

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__

* Example screenshot/log transcript of the feature working

##  Changes
  -
  -
  -
