### PR TITLE
Fix typo in tcp_scan_ports

### DIFF
--- a/monkey/infection_monkey/network/tools.py
+++ b/monkey/infection_monkey/network/tools.py
@@ -128,10 +128,9 @@ def check_tcp_ports(ip, ports, timeout=DEFAULT_TIMEOUT, get_banner=False):
 
         if len(possible_ports) != 0:
             timeout = int(round(timeout))  # clamp to integer, to avoid checking input
-            time_left = timeout
             sockets_to_try = possible_ports[:]
             connected_ports_sockets = []
-            while (time_left >= 0) and len(sockets_to_try):
+            while (timeout >= 0) and len(sockets_to_try):
                 sock_objects = [s[1] for s in sockets_to_try]
 
                 _, writeable_sockets, _ = select.select(sock_objects, sock_objects, sock_objects, 0)


### PR DESCRIPTION
# Feature / Fixes
Fixes the port scanner to not timeout due to typo

* [X] Have you added an explanation of what your changes do and why you'd like to include them?
* [X] Have you successfully tested your changes locally?

* Example screenshot/log transcript of the feature working
![image](https://user-images.githubusercontent.com/15857396/45691948-4befdc80-bb62-11e8-8390-cfba62ee3b59.png)
![image](https://user-images.githubusercontent.com/15857396/45691966-59a56200-bb62-11e8-9f81-24b879bfc588.png)

