### PR TITLE
Domain name to ip translation

### DIFF
--- a/monkey/common/network/network_range.py
+++ b/monkey/common/network/network_range.py
@@ -5,8 +5,12 @@ from abc import ABCMeta, abstractmethod
 
 import ipaddress
 from six import text_type
+import logging
+import re
 
 __author__ = 'itamar'
+
+LOG = logging.getLogger(__name__)
 
 
 class NetworkRange(object):
@@ -111,7 +115,7 @@ class IpRange(NetworkRange):
 class SingleIpRange(NetworkRange):
     def __init__(self, ip_address, shuffle=True):
         super(SingleIpRange, self).__init__(shuffle=shuffle)
-        self._ip_address = ip_address
+        self._ip_address, self.domain_name = self.string_to_host(ip_address)
 
     def __repr__(self):
         return "<SingleIpRange %s>" % (self._ip_address,)
@@ -121,3 +125,26 @@ class SingleIpRange(NetworkRange):
 
     def _get_range(self):
         return [SingleIpRange._ip_to_number(self._ip_address)]
+
+    @staticmethod
+    def string_to_host(string):
+        """
+        Converts the string that user entered in "Scan IP/subnet list" to dict of domain name and ip
+        :param string: String that was entered in "Scan IP/subnet list"
+        :return: A tuple in format (IP, domain_name). Eg. (192.168.55.1, www.google.com)
+        """
+        # The most common use case is to enter ip/range into "Scan IP/subnet list"
+        domain_name = ''
+        ip = string
+
+        # If a string was entered instead of IP we presume that it was domain name and translate it
+        if re.search('[a-zA-Z]', string):
+            try:
+                ip = socket.gethostbyname(string)
+                domain_name = string
+            except socket.error:
+                LOG.error(
+                    "You'r specified host: {} is neither found as domain name nor it's an IP address".format(string))
+                return socket.error
+        return ip, domain_name
+

--- a/monkey/common/network/network_range.py
+++ b/monkey/common/network/network_range.py
@@ -6,7 +6,6 @@ from abc import ABCMeta, abstractmethod
 import ipaddress
 from six import text_type
 import logging
-import re
 
 __author__ = 'itamar'
 

--- a/monkey/common/network/network_range.py
+++ b/monkey/common/network/network_range.py
@@ -51,11 +51,22 @@ class NetworkRange(object):
         address_str = address_str.strip()
         if not address_str:  # Empty string
             return None
-        if -1 != address_str.find('-'):
+        if NetworkRange.check_if_range(address_str):
             return IpRange(ip_range=address_str)
         if -1 != address_str.find('/'):
             return CidrRange(cidr_range=address_str)
         return SingleIpRange(ip_address=address_str)
+
+    @staticmethod
+    def check_if_range(address_str):
+        if -1 != address_str.find('-'):
+            ips = address_str.split('-')
+            try:
+                ipaddress.ip_address(ips[0]) and ipaddress.ip_address(ips[1])
+            except ValueError as e:
+                return False
+            return True
+        return False
 
     @staticmethod
     def _ip_to_number(address):

--- a/monkey/common/network/network_range.py
+++ b/monkey/common/network/network_range.py
@@ -120,11 +120,27 @@ class SingleIpRange(NetworkRange):
     def __repr__(self):
         return "<SingleIpRange %s>" % (self._ip_address,)
 
+    def __iter__(self):
+        """
+        We have to check if we have an IP to return, because user could have entered invalid
+        domain name and no IP was found
+        :return: IP if there is one
+        """
+        if self.ip_found():
+            yield self._number_to_ip(self.get_range()[0])
+
     def is_in_range(self, ip_address):
         return self._ip_address == ip_address
 
     def _get_range(self):
         return [SingleIpRange._ip_to_number(self._ip_address)]
+
+    def ip_found(self):
+        """
+        Checks if we could translate domain name entered into IP address
+        :return: True if dns found domain name and false otherwise
+        """
+        return hasattr(self, "_ip_address") and self._ip_address
 
     @staticmethod
     def string_to_host(string):
@@ -144,7 +160,7 @@ class SingleIpRange(NetworkRange):
                 domain_name = string
             except socket.error:
                 LOG.error(
-                    "You'r specified host: {} is neither found as domain name nor it's an IP address".format(string))
-                return socket.error
+                    "You'r specified host: {} is not found as a domain name and it's not an IP address".format(string))
+                return None, string
         return ip, domain_name
 

--- a/monkey/infection_monkey/model/host.py
+++ b/monkey/infection_monkey/model/host.py
@@ -4,7 +4,7 @@ __author__ = 'itamar'
 class VictimHost(object):
     def __init__(self, ip_addr, domain_name=''):
         self.ip_addr = ip_addr
-        self.domain_name = domain_name
+        self.domain_name = str(domain_name)
         self.os = {}
         self.services = {}
         self.monkey_exe = None

--- a/monkey/infection_monkey/model/host.py
+++ b/monkey/infection_monkey/model/host.py
@@ -2,8 +2,9 @@ __author__ = 'itamar'
 
 
 class VictimHost(object):
-    def __init__(self, ip_addr):
+    def __init__(self, ip_addr, domain_name=''):
         self.ip_addr = ip_addr
+        self.domain_name = domain_name
         self.os = {}
         self.services = {}
         self.monkey_exe = None

--- a/monkey/infection_monkey/network/network_scanner.py
+++ b/monkey/infection_monkey/network/network_scanner.py
@@ -7,6 +7,7 @@ from infection_monkey.network.info import local_ips, get_interfaces_ranges
 from infection_monkey.model import VictimHost
 from infection_monkey.network import HostScanner
 from infection_monkey.network import TcpScanner, PingScanner
+
 __author__ = 'itamar'
 
 LOG = logging.getLogger(__name__)
@@ -78,7 +79,10 @@ class NetworkScanner(object):
         for net_range in self._ranges:
             LOG.debug("Scanning for potential victims in the network %r", net_range)
             for ip_addr in net_range:
-                victim = VictimHost(ip_addr)
+                if hasattr(net_range, 'domain_name'):
+                    victim = VictimHost(ip_addr, net_range.domain_name)
+                else:
+                    victim = VictimHost(ip_addr)
                 if stop_callback and stop_callback():
                     LOG.debug("Got stop signal")
                     break

--- a/monkey/monkey_island/cc/resources/telemetry.py
+++ b/monkey/monkey_island/cc/resources/telemetry.py
@@ -90,10 +90,11 @@ class Telemetry(flask_restful.Resource):
     @staticmethod
     def get_edge_by_scan_or_exploit_telemetry(telemetry_json):
         dst_ip = telemetry_json['data']['machine']['ip_addr']
+        dst_domain_name = telemetry_json['data']['machine']['domain_name']
         src_monkey = NodeService.get_monkey_by_guid(telemetry_json['monkey_guid'])
         dst_node = NodeService.get_monkey_by_ip(dst_ip)
         if dst_node is None:
-            dst_node = NodeService.get_or_create_node(dst_ip)
+            dst_node = NodeService.get_or_create_node(dst_ip, dst_domain_name)
 
         return EdgeService.get_or_create_edge(src_monkey["_id"], dst_node["_id"])
 
@@ -144,6 +145,7 @@ class Telemetry(flask_restful.Resource):
         edge = Telemetry.get_edge_by_scan_or_exploit_telemetry(telemetry_json)
         data = copy.deepcopy(telemetry_json['data']['machine'])
         ip_address = data.pop("ip_addr")
+        domain_name = data.pop("domain_name")
         new_scan = \
             {
                 "timestamp": telemetry_json["timestamp"],
@@ -153,7 +155,7 @@ class Telemetry(flask_restful.Resource):
         mongo.db.edge.update(
             {"_id": edge["_id"]},
             {"$push": {"scans": new_scan},
-             "$set": {"ip_address": ip_address}}
+             "$set": {"ip_address": ip_address, 'domain_name': domain_name}}
         )
 
         node = mongo.db.node.find_one({"_id": edge["to"]})

--- a/monkey/monkey_island/cc/services/config.py
+++ b/monkey/monkey_island/cc/services/config.py
@@ -10,6 +10,7 @@ from cc.encryptor import encryptor
 from cc.environment.environment import env
 from cc.utils import local_ip_addresses
 from config_schema import SCHEMA
+
 __author__ = "itay.mizeretz"
 
 logger = logging.getLogger(__name__)

--- a/monkey/monkey_island/cc/services/node.py
+++ b/monkey/monkey_island/cc/services/node.py
@@ -63,9 +63,10 @@ class NodeService:
 
     @staticmethod
     def get_node_label(node):
+        domain_name = node["domain_name"]
         if node["domain_name"]:
-            node["domain_name"] = " ("+node["domain_name"]+")"
-        return node["os"]["version"] + " : " + node["ip_addresses"][0] + node["domain_name"]
+            domain_name = " ("+node["domain_name"]+")"
+        return node["os"]["version"] + " : " + node["ip_addresses"][0] + domain_name
 
     @staticmethod
     def _cmp_exploits_by_timestamp(exploit_1, exploit_2):

--- a/monkey/monkey_island/cc/services/node.py
+++ b/monkey/monkey_island/cc/services/node.py
@@ -41,6 +41,7 @@ class NodeService:
             # node is uninfected
             new_node = NodeService.node_to_net_node(node, for_report)
             new_node["ip_addresses"] = node["ip_addresses"]
+            new_node["domain_name"] = node["domain_name"]
 
         for edge in edges:
             accessible_from_nodes.append(NodeService.get_monkey_label(NodeService.get_monkey_by_id(edge["from"])))
@@ -62,7 +63,9 @@ class NodeService:
 
     @staticmethod
     def get_node_label(node):
-        return node["os"]["version"] + " : " + node["ip_addresses"][0]
+        if node["domain_name"]:
+            node["domain_name"] = " ("+node["domain_name"]+")"
+        return node["os"]["version"] + " : " + node["ip_addresses"][0] + node["domain_name"]
 
     @staticmethod
     def _cmp_exploits_by_timestamp(exploit_1, exploit_2):
@@ -137,6 +140,7 @@ class NodeService:
                 "group": NodeService.get_monkey_group(monkey),
                 "os": NodeService.get_monkey_os(monkey),
                 "dead": monkey["dead"],
+                "domain_name": ""
             }
 
     @staticmethod
@@ -176,10 +180,11 @@ class NodeService:
                              upsert=False)
 
     @staticmethod
-    def insert_node(ip_address):
+    def insert_node(ip_address, domain_name=''):
         new_node_insert_result = mongo.db.node.insert_one(
             {
                 "ip_addresses": [ip_address],
+                "domain_name": domain_name,
                 "exploited": False,
                 "creds": [],
                 "os":
@@ -191,10 +196,10 @@ class NodeService:
         return mongo.db.node.find_one({"_id": new_node_insert_result.inserted_id})
 
     @staticmethod
-    def get_or_create_node(ip_address):
+    def get_or_create_node(ip_address, domain_name=''):
         new_node = mongo.db.node.find_one({"ip_addresses": ip_address})
         if new_node is None:
-            new_node = NodeService.insert_node(ip_address)
+            new_node = NodeService.insert_node(ip_address, domain_name)
         return new_node
 
     @staticmethod
@@ -261,6 +266,7 @@ class NodeService:
     def get_monkey_island_node():
         island_node = NodeService.get_monkey_island_pseudo_net_node()
         island_node["ip_addresses"] = local_ip_addresses()
+        island_node["domain_name"] = ""
         return island_node
 
     @staticmethod

--- a/monkey/monkey_island/cc/services/node.py
+++ b/monkey/monkey_island/cc/services/node.py
@@ -6,6 +6,7 @@ import cc.services.log
 from cc.database import mongo
 from cc.services.edge import EdgeService
 from cc.utils import local_ip_addresses
+import socket
 
 __author__ = "itay.mizeretz"
 
@@ -267,7 +268,7 @@ class NodeService:
     def get_monkey_island_node():
         island_node = NodeService.get_monkey_island_pseudo_net_node()
         island_node["ip_addresses"] = local_ip_addresses()
-        island_node["domain_name"] = ""
+        island_node["domain_name"] = socket.gethostname()
         return island_node
 
     @staticmethod

--- a/monkey/monkey_island/cc/services/node.py
+++ b/monkey/monkey_island/cc/services/node.py
@@ -63,7 +63,7 @@ class NodeService:
 
     @staticmethod
     def get_node_label(node):
-        domain_name = node["domain_name"]
+        domain_name = ""
         if node["domain_name"]:
             domain_name = " ("+node["domain_name"]+")"
         return node["os"]["version"] + " : " + node["ip_addresses"][0] + domain_name

--- a/monkey/monkey_island/cc/services/report.py
+++ b/monkey/monkey_island/cc/services/report.py
@@ -131,7 +131,8 @@ class ReportService:
                         list((x['hostname'] for x in
                          (NodeService.get_displayed_node_by_id(edge['from'], True)
                           for edge in EdgeService.get_displayed_edges_by_to(node['id'], True)))),
-                    'services': node['services']
+                    'services': node['services'],
+                    'domain_name': node['domain_name']
                 })
 
         logger.info('Scanned nodes generated for reporting')
@@ -151,6 +152,7 @@ class ReportService:
             {
                 'label': monkey['label'],
                 'ip_addresses': monkey['ip_addresses'],
+                'domain_name': node['domain_name'],
                 'exploits': list(set(
                     [ReportService.EXPLOIT_DISPLAY_DICT[exploit['exploiter']] for exploit in monkey['exploits'] if
                      exploit['result']]))

--- a/monkey/monkey_island/cc/ui/src/components/report-components/BreachedServers.js
+++ b/monkey/monkey_island/cc/ui/src/components/report-components/BreachedServers.js
@@ -10,7 +10,8 @@ const columns = [
     Header: 'Breached Servers',
     columns: [
       {Header: 'Machine', accessor: 'label'},
-      {Header: 'IP Addresses', id: 'ip_addresses', accessor: x => renderArray(x.ip_addresses)},
+      {Header: 'IP Addresses', id: 'ip_addresses',
+       accessor: x => renderArray(x.ip_addresses)+(x.domain_name ? " ("+x.domain_name+")" : "")},
       {Header: 'Exploits', id: 'exploits', accessor: x => renderArray(x.exploits)}
       ]
   }

--- a/monkey/monkey_island/cc/ui/src/components/report-components/BreachedServers.js
+++ b/monkey/monkey_island/cc/ui/src/components/report-components/BreachedServers.js
@@ -5,13 +5,17 @@ let renderArray = function(val) {
   return <div>{val.map(x => <div>{x}</div>)}</div>;
 };
 
+let renderIpAddresses = function (val) {
+  return <div>{renderArray(val.ip_addresses)} {(val.domain_name ? " (".concat(val.domain_name, ")") : "")} </div>;
+};
+
 const columns = [
   {
     Header: 'Breached Servers',
     columns: [
       {Header: 'Machine', accessor: 'label'},
       {Header: 'IP Addresses', id: 'ip_addresses',
-       accessor: x => renderArray(x.ip_addresses)+(x.domain_name ? " ("+x.domain_name+")" : "")},
+       accessor: x => renderIpAddresses(x)},
       {Header: 'Exploits', id: 'exploits', accessor: x => renderArray(x.exploits)}
       ]
   }

--- a/monkey/monkey_island/cc/ui/src/components/report-components/ScannedServers.js
+++ b/monkey/monkey_island/cc/ui/src/components/report-components/ScannedServers.js
@@ -5,13 +5,17 @@ let renderArray = function(val) {
   return <div>{val.map(x => <div>{x}</div>)}</div>;
 };
 
+let renderIpAddresses = function (val) {
+  return <div>{renderArray(val.ip_addresses)} {(val.domain_name ? " (".concat(val.domain_name, ")") : "")} </div>;
+};
+
 const columns = [
   {
     Header: 'Scanned Servers',
     columns: [
       { Header: 'Machine', accessor: 'label'},
       { Header: 'IP Addresses', id: 'ip_addresses',
-        accessor: x => renderArray(x.ip_addresses)+(x.domain_name ? " ("+x.domain_name+")" : "")},
+        accessor: x => renderIpAddresses(x)},
       { Header: 'Accessible From', id: 'accessible_from_nodes', accessor: x => renderArray(x.accessible_from_nodes)},
       { Header: 'Services', id: 'services', accessor: x => renderArray(x.services)}
     ]

--- a/monkey/monkey_island/cc/ui/src/components/report-components/ScannedServers.js
+++ b/monkey/monkey_island/cc/ui/src/components/report-components/ScannedServers.js
@@ -10,7 +10,8 @@ const columns = [
     Header: 'Scanned Servers',
     columns: [
       { Header: 'Machine', accessor: 'label'},
-      { Header: 'IP Addresses', id: 'ip_addresses', accessor: x => renderArray(x.ip_addresses)},
+      { Header: 'IP Addresses', id: 'ip_addresses',
+        accessor: x => renderArray(x.ip_addresses)+(x.domain_name ? " ("+x.domain_name+")" : "")},
       { Header: 'Accessible From', id: 'accessible_from_nodes', accessor: x => renderArray(x.accessible_from_nodes)},
       { Header: 'Services', id: 'services', accessor: x => renderArray(x.services)}
     ]


### PR DESCRIPTION
# Feature / Fixes
> Domain name can now be entered alongside IP's to scan. If domain name gets successfully translated and scanned it's added to corresponding parts of report and map.

# Test cases:
- [x] Domain name entered, not breached
- [x] IP entered, breached. 
- [x] Domain couldn't be translated to IP. Monkey island gets error log and continues with other machines.

![domain_name](https://user-images.githubusercontent.com/36815064/46347736-45c72900-c655-11e8-95cd-f8ae517d5c18.PNG)
![domain_name_map](https://user-images.githubusercontent.com/36815064/46347747-4cee3700-c655-11e8-9111-064d8100eb31.PNG)



