### PR TITLE
Fix/bugfix for 1.6

### DIFF
--- a/monkey/monkey_island/cc/main.py
+++ b/monkey/monkey_island/cc/main.py
@@ -1,6 +1,7 @@
 from __future__ import print_function  # In python 2.7
 
 import os
+import os.path
 import sys
 import time
 import logging
@@ -12,7 +13,8 @@ if BASE_PATH not in sys.path:
 
 from cc.island_logger import json_setup_logging
 # This is here in order to catch EVERYTHING, some functions are being called on imports the log init needs to be on top.
-json_setup_logging(default_path='.\\monkey_island\\cc\\island_logger_default_config.json', default_level=logging.DEBUG)
+json_setup_logging(default_path=os.path.join(BASE_PATH, 'cc', 'island_logger_default_config.json'),
+                   default_level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 from cc.app import init_app

--- a/monkey/monkey_island/cc/resources/monkey_configuration.py
+++ b/monkey/monkey_island/cc/resources/monkey_configuration.py
@@ -1,7 +1,7 @@
 import json
 
 import flask_restful
-from flask import request, jsonify
+from flask import request, jsonify, abort
 
 from cc.auth import jwt_required
 from cc.services.config import ConfigService
@@ -20,5 +20,6 @@ class MonkeyConfiguration(flask_restful.Resource):
         if 'reset' in config_json:
             ConfigService.reset_config()
         else:
-            ConfigService.update_config(config_json, should_encrypt=True)
+            if not ConfigService.update_config(config_json, should_encrypt=True):
+                abort(400)
         return self.get()

--- a/monkey/monkey_island/cc/services/config.py
+++ b/monkey/monkey_island/cc/services/config.py
@@ -977,9 +977,14 @@ class ConfigService:
     @staticmethod
     def update_config(config_json, should_encrypt):
         if should_encrypt:
-            ConfigService.encrypt_config(config_json)
+            try:
+                ConfigService.encrypt_config(config_json)
+            except KeyError as e:
+                logger.error('Bad configuration file was submitted.')
+                return False
         mongo.db.config.update({'name': 'newconfig'}, {"$set": config_json}, upsert=True)
         logger.info('monkey config was updated')
+        return True
 
     @staticmethod
     def init_default_config():

--- a/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
@@ -50,6 +50,13 @@ class ConfigurePageComponent extends AuthComponent {
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify(this.state.configuration)
       })
+      .then(res => {
+        if (!res.ok)
+        {
+          throw Error()
+        }
+        return res;
+      })
       .then(res => res.json())
       .then(res => {
         this.setState({
@@ -58,6 +65,9 @@ class ConfigurePageComponent extends AuthComponent {
           configuration: res.configuration
         });
         this.props.onStatusChange();
+      }).catch(error => {
+        console.log('bad configuration');
+        this.setState({lastAction: 'invalid_configuration'});
       });
   };
 
@@ -215,6 +225,12 @@ class ConfigurePageComponent extends AuthComponent {
             <div className="alert alert-danger">
               <i className="glyphicon glyphicon-exclamation-sign" style={{'marginRight': '5px'}}/>
               Failed importing configuration. Invalid config file.
+            </div>
+            : ''}
+          { this.state.lastAction === 'invalid_configuration' ?
+            <div className="alert alert-danger">
+              <i className="glyphicon glyphicon-exclamation-sign" style={{'marginRight': '5px'}}/>
+              An invalid configuration file was imported and submitted, probably outdated.
             </div>
             : ''}
           { this.state.lastAction === 'import_success' ?


### PR DESCRIPTION
# Fixes

While testing the develop code for version 1.6, two bugs came up:
* Log file wasn't being written on disc
* When trying to submit an outdated configuration file in the monkey island the server would return error 500 and the page would crash.

##  Changes
  - Updated the path to the logging json configuration file to be generic relative using os.path
  - Added a small and specific error handling for the specific configuration submission endpoint for now.
