### PR TITLE
Bugfix/fix server timeout

### DIFF
--- a/monkey/infection_monkey/control.py
+++ b/monkey/infection_monkey/control.py
@@ -21,7 +21,7 @@ LOG = logging.getLogger(__name__)
 DOWNLOAD_CHUNK = 1024
 # random number greater than 5,
 # to prevent the monkey from just waiting forever to try and connect to an island before going elsewhere.
-TIMEOUT = 9
+TIMEOUT = 15
 
 
 class ControlClient(object):

--- a/monkey/infection_monkey/control.py
+++ b/monkey/infection_monkey/control.py
@@ -19,6 +19,9 @@ requests.packages.urllib3.disable_warnings()
 
 LOG = logging.getLogger(__name__)
 DOWNLOAD_CHUNK = 1024
+# random number greater than 5,
+# to prevent the monkey from just waiting forever to try and connect to an island before going elsewhere.
+TIMEOUT = 9
 
 
 class ControlClient(object):
@@ -72,7 +75,8 @@ class ControlClient(object):
                 LOG.debug(debug_message)
                 requests.get("https://%s/api?action=is-up" % (server,),
                              verify=False,
-                             proxies=ControlClient.proxies)
+                             proxies=ControlClient.proxies,
+                             timeout=TIMEOUT)
                 WormConfiguration.current_server = current_server
                 break
 


### PR DESCRIPTION
# Feature / Fixes
Fixes a situation where we could hang waiting to communicate with the Island rather than falling back to finding a proxy.

References [Requests documentation](http://docs.python-requests.org/en/master/user/advanced/#timeouts) on timeout.

> By default, requests do not time out unless a timeout value is set explicitly. Without a timeout, your code may hang for minutes or more.


* [X] Have you added an explanation of what your changes do and why you'd like to include them?
* [X] Have you successfully tested your changes locally?

##  Changes
  - Adds timeout to the initial find_server request in control.py