### PR TITLE
Fixes the problem of rdp grinder not being able to handle utf encoded credentials.

### DIFF
--- a/monkey/infection_monkey/exploit/rdpgrinder.py
+++ b/monkey/infection_monkey/exploit/rdpgrinder.py
@@ -15,6 +15,7 @@ from infection_monkey.exploit.tools import get_target_monkey
 from infection_monkey.model import RDP_CMDLINE_HTTP_BITS, RDP_CMDLINE_HTTP_VBS
 from infection_monkey.network.tools import check_tcp_port
 from infection_monkey.exploit.tools import build_monkey_commandline
+from infection_monkey.utils import utf_to_ascii
 
 __author__ = 'hoffer'
 
@@ -297,6 +298,10 @@ class RdpExploiter(HostExploiter):
                          self.host, user, password)
 
                 LOG.info("RDP connected to %r", self.host)
+
+                user = utf_to_ascii(user)
+                password = utf_to_ascii(password)
+                command = utf_to_ascii(command)
 
                 client_factory = CMDClientFactory(user, password, "", command)
 

--- a/monkey/infection_monkey/utils.py
+++ b/monkey/infection_monkey/utils.py
@@ -30,3 +30,7 @@ def is_64bit_python():
 def is_windows_os():
     return sys.platform.startswith("win")
 
+
+def utf_to_ascii(string):
+    udata = string.decode("utf-8")
+    return udata.encode("ascii", "ignore")

--- a/monkey/infection_monkey/utils.py
+++ b/monkey/infection_monkey/utils.py
@@ -32,5 +32,6 @@ def is_windows_os():
 
 
 def utf_to_ascii(string):
+    # Converts utf string to ascii. Safe to use even if string is already ascii.
     udata = string.decode("utf-8")
     return udata.encode("ascii", "ignore")


### PR DESCRIPTION
# Feature / Fixes
Bugfix for https://github.com/guardicore/monkey/issues/206

Tested on GCP, with utf -> ascii and ascii -> ascii