### PR TITLE
updated readme.txt and _MONGO_URL to support connecting to external …

### DIFF
--- a/monkey/monkey_island/cc/environment/__init__.py
+++ b/monkey/monkey_island/cc/environment/__init__.py
@@ -1,5 +1,6 @@
 import abc
 from datetime import timedelta
+import os
 
 __author__ = 'itay.mizeretz'
 
@@ -8,7 +9,7 @@ class Environment(object):
     __metaclass__ = abc.ABCMeta
 
     _ISLAND_PORT = 5000
-    _MONGO_URL = "mongodb://localhost:27017/monkeyisland"
+    _MONGO_URL = os.environ.get("MONKEY_MONGO_URL", "mongodb://localhost:27017/monkeyisland")
     _DEBUG_SERVER = False
     _AUTH_EXPIRATION_TIME = timedelta(hours=1)
 

--- a/monkey/monkey_island/readme.txt
+++ b/monkey/monkey_island/readme.txt
@@ -9,10 +9,20 @@ How to set up the Monkey Island server:
 	2.3. Copy contents from installation path (Usually C:\Python27) to monkey_island\bin\Python27
 	2.4. Copy Python27.dll from System32 folder (Usually C:\Windows\System32 or C:\Python27) to monkey_island\bin\Python27
 	2.5. (Optional) You may uninstall Python27 if you like.
-3. Place portable version of mongodb
-	3.1. Download from: https://downloads.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-latest.zip
-	3.2. Extract contents from bin folder to monkey_island\bin\mongodb.
-	3.3. Create monkey_island\db folder.
+3. Setup mongodb (Use one of the following two options):
+    3.1 Place portable version of mongodb
+	   3.1.1 Download from: https://downloads.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-latest.zip
+ 	   3.2.1 Extract contents from bin folder to monkey_island\bin\mongodb.
+	   3.3.1 Create monkey_island\db folder.
+	
+	OR
+
+    3.1 If you have an instance of mongodb running on a different host, set the MONKEY_MONGO_URL environment variable:
+
+        example for mongodb running on host with IP address 192.168.10.10:
+
+        set MONKEY_MONGO_URL="mongodb://192.168.10.10:27107/monkeyisland"
+
 4. Place portable version of OpenSSL
 	4.1. Download from: https://indy.fulgan.com/SSL/Archive/openssl-1.0.2l-i386-win32.zip
 	4.2. Extract content from bin folder to monkey_island\bin\openssl
@@ -53,13 +63,24 @@ How to run:
 	monkey-windows-32.exe - monkey binary for windows 32bit
 	monkey-windows-64.exe - monkey binary for windows 64bi
 
-4. Download MongoDB and extract it to /var/monkey_island/bin/mongodb
-    for debian64 - https://downloads.mongodb.org/linux/mongodb-linux-x86_64-debian81-latest.tgz
-    for ubuntu64 16.10 - https://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-latest.tgz
-    find more at - https://www.mongodb.org/downloads#production
-	untar.gz with: tar -zxvf filename.tar.gz -C /var/monkey_island/bin/mongodb
-	(make sure the content of the mongo folder is in this directory, meaning this path exists:
-		/var/monkey_island/bin/mongodb/bin)
+4. Setup MongoDB (Use one of the two following options):
+
+        4.1 Download MongoDB and extract it to /var/monkey_island/bin/mongodb
+                for debian64 - https://downloads.mongodb.org/linux/mongodb-linux-x86_64-debian81-latest.tgz
+                for ubuntu64 16.10 - https://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-latest.tgz
+                find more at - https://www.mongodb.org/downloads#production
+                untar.gz with: tar -zxvf filename.tar.gz -C /var/monkey_island/bin/mongodb
+                (make sure the content of the mongo folder is in this directory, meaning this path exists:
+                        /var/monkey_island/bin/mongodb/bin)
+        
+        OR
+
+        4.1 If you have an instance of mongodb running on a different host, set the MONKEY_MONGO_URL environment variable:
+
+            example for mongodb running on host with IP address 192.168.10.10:
+
+                set MONKEY_MONGO_URL="mongodb://192.168.10.10:27107/monkeyisland"
+
 
 5. install OpenSSL
     sudo apt-get install openssl


### PR DESCRIPTION
…MongoDB instance by setting MONKEY_MONGO_URL env variable

# Feature / Fixes
A simple change to get MONGO_URL from ENV variable if set, otherwise use the default for local MongoDB installation.

This is the first step in attempting to separate the UI, API, and DB functionality to enable running the components on different servers or from within individual Docker containers, with the ultimate goal of being able to run Monkey Island with docker compose.

Tested with MongoDB running in a Docker container on a separate VM with MONGO_URL environment variable set and with MongoDB running per current install instructions without MONGO_URL environment variable set.

Also made modifications to monkey_island/readme.txt to cover both options for running MongoDB.

