### PR TITLE
Makes all tabs of equal height

### DIFF
--- a/monkey/monkey_island/cc/ui/src/styles/App.css
+++ b/monkey/monkey_island/cc/ui/src/styles/App.css
@@ -138,11 +138,10 @@ body {
     padding-left: 40px;
   }
 }
+
 .main .page-header {
   margin-top: 0;
 }
-
-
 
 .index img {
   margin: 40px auto;
@@ -172,6 +171,9 @@ body {
   display: none;
 }
 
+.nav-tabs > li > a {
+  height: 63px
+}
 /*
  * Run Monkey Page
  */
@@ -491,4 +493,5 @@ body {
   .label-danger {
     background-color: #d9534f !important;
   }
+
 }


### PR DESCRIPTION
# Feature / Fixes
Before:
![image](https://user-images.githubusercontent.com/36815064/48711322-aa454400-ec13-11e8-82ea-e8e634c83c44.png)

After:
![image](https://user-images.githubusercontent.com/36815064/48711363-c648e580-ec13-11e8-9db6-a9ab7c13ef85.png)

Tests:
Quickly went trough all the pages, but these changes shouldn't target other elements if nav-tabs is aunique class.
