### PR TITLE
Small bugfix for web_rce get_open_service_ports function

### DIFF
--- a/monkey/infection_monkey/exploit/web_rce.py
+++ b/monkey/infection_monkey/exploit/web_rce.py
@@ -126,7 +126,9 @@ class WebRCE(HostExploiter):
         candidate_services = {}
         candidate_services.update({
             service: self.host.services[service] for service in self.host.services if
-            (self.host.services[service] and self.host.services[service]['name'] in names)
+            (self.host.services[service] and
+             'name' in self.host.services[service] and
+             self.host.services[service]['name'] in names)
         })
 
         valid_ports = [(port, candidate_services['tcp-' + str(port)]['data'][1]) for port in port_list if


### PR DESCRIPTION
# Feature / Fixes
> Some services are added to the host.services array without 'name' property. Thus we need to make sure it exists
![image](https://user-images.githubusercontent.com/36815064/49012440-1975e780-f182-11e8-899e-33667bc0453f.png)

