### PR TITLE
Shellshock timeout exception handling

### DIFF
--- a/monkey/infection_monkey/exploit/shellshock.py
+++ b/monkey/infection_monkey/exploit/shellshock.py
@@ -210,7 +210,7 @@ class ShellShockExploiter(HostExploiter):
                 reqs.append(requests.head(u, verify=False, timeout=TIMEOUT))
             except requests.Timeout:
                 timeout = True
-                continue
+                break
         if timeout:
             LOG.debug("Some connections timed out while sending request to potentially vulnerable urls.")
         valid_resps = [req for req in reqs if req and req.status_code == requests.codes.ok]

--- a/monkey/infection_monkey/exploit/shellshock.py
+++ b/monkey/infection_monkey/exploit/shellshock.py
@@ -202,8 +202,17 @@ class ShellShockExploiter(HostExploiter):
         if is_https:
             attack_path = 'https://'
         attack_path = attack_path + str(host) + ":" + str(port)
+        reqs = []
+        timeout = False
         attack_urls = [attack_path + url for url in url_list]
-        reqs = [requests.head(u, verify=False, timeout=TIMEOUT) for u in attack_urls]
+        for u in attack_urls:
+            try:
+                reqs.append(requests.head(u, verify=False, timeout=TIMEOUT))
+            except requests.Timeout:
+                timeout = True
+                continue
+        if timeout:
+            LOG.debug("Some connections timed out while sending request to potentially vulnerable urls.")
         valid_resps = [req for req in reqs if req and req.status_code == requests.codes.ok]
         urls = [resp.url for resp in valid_resps]
 


### PR DESCRIPTION
# Feature / Fixes
> Sending requests in shellshock module had no timeout handling.
![shellshockbug](https://user-images.githubusercontent.com/36815064/49589622-86ebfa00-f972-11e8-818d-06108c10209b.PNG)

If timeout happens for any request, we just continue sending other requests. At the end we inform that timeout happened (we don't inform about particular urls because that would trash the log)