### PR TITLE
Bugfix - report map colored again

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/pages/ReportPage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ReportPage.js
@@ -104,7 +104,7 @@ class ReportPageComponent extends AuthComponent {
       .then(res => res.json())
       .then(res => {
         res.edges.forEach(edge => {
-          edge.color = edgeGroupToColor(edge.group);
+          edge.color = {'color': edgeGroupToColor(edge.group)};
         });
         this.setState({graph: res});
         this.props.onStatusChange();


### PR DESCRIPTION
# Feature / Fixes
When we updated our mocha dependency we fixed the color in the map pane and not in the report. 

* [X] Have you added an explanation of what your changes do and why you'd like to include them?
* [X] Have you successfully tested your changes locally?

![image](https://user-images.githubusercontent.com/15857396/50165938-a24df200-02ee-11e9-83b8-7dd0cc14e7bb.png)
