### PR TITLE
Changing curl usage to wget on monkey island gui

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage.js
@@ -52,7 +52,7 @@ class RunMonkeyPageComponent extends AuthComponent {
 
   generateLinuxCmd(ip, is32Bit) {
     let bitText = is32Bit ? '32' : '64';
-    return `curl -O -k https://${ip}:5000/api/monkey/download/monkey-linux-${bitText}; chmod +x monkey-linux-${bitText}; ./monkey-linux-${bitText} m0nk3y -s ${ip}:5000`
+    return `wget --no-check-certificate https://${ip}:5000/api/monkey/download/monkey-linux-${bitText}; chmod +x monkey-linux-${bitText}; ./monkey-linux-${bitText} m0nk3y -s ${ip}:5000`
   }
 
   generateWindowsCmd(ip, is32Bit) {


### PR DESCRIPTION
# Feature / Fixes
After testing the monkey run-line that is generated in the monkey island gui on servral OSs, we saw that curl wasn't installed out of the box while wget was present on all of them already. So we decided to change download methods.

##  Changes
 - Changed curl to wget, its available out of the box on more OSs.