### PR TITLE
Post breach actions

### DIFF
--- a/monkey/infection_monkey/config.py
+++ b/monkey/infection_monkey/config.py
@@ -20,6 +20,7 @@ class Configuration(object):
         # now we won't work at <2.7 for sure
         network_import = importlib.import_module('infection_monkey.network')
         exploit_import = importlib.import_module('infection_monkey.exploit')
+        post_breach_import = importlib.import_module('infection_monkey.post_breach')
 
         unknown_items = []
         for key, value in formatted_data.items():
@@ -38,6 +39,9 @@ class Configuration(object):
                 setattr(self, key, scanner_object)
             elif key == 'exploiter_classes':
                 class_objects = [getattr(exploit_import, val) for val in value]
+                setattr(self, key, class_objects)
+            elif key == 'post_breach_actions':
+                class_objects = [getattr(post_breach_import, val) for val in value]
                 setattr(self, key, class_objects)
             else:
                 if hasattr(self, key):
@@ -265,6 +269,8 @@ class Configuration(object):
     ###########################
 
     extract_azure_creds = True
+
+    post_breach_actions = []
 
 
 WormConfiguration = Configuration()

--- a/monkey/infection_monkey/config.py
+++ b/monkey/infection_monkey/config.py
@@ -7,8 +7,6 @@ from abc import ABCMeta
 from itertools import product
 import importlib
 
-importlib.import_module('infection_monkey', 'network')
-
 __author__ = 'itamar'
 
 GUID = str(uuid.getnode())

--- a/monkey/infection_monkey/example.conf
+++ b/monkey/infection_monkey/example.conf
@@ -97,5 +97,6 @@
     "timeout_between_iterations": 10,
     "use_file_logging": true,
     "victims_max_exploit": 7,
-    "victims_max_find": 30
+    "victims_max_find": 30,
+    "post_breach_actions" : []
 }

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -109,6 +109,10 @@ class InfectionMonkey(object):
             system_info = system_info_collector.get_info()
             ControlClient.send_telemetry("system_info_collection", system_info)
 
+        for action_class in WormConfiguration.post_breach_actions:
+            action = action_class()
+            action.act()
+
         if 0 == WormConfiguration.depth:
             LOG.debug("Reached max depth, shutting down")
             ControlClient.send_telemetry("trace", "Reached max depth, shutting down")

--- a/monkey/infection_monkey/post_breach/__init__.py
+++ b/monkey/infection_monkey/post_breach/__init__.py
@@ -1,0 +1,4 @@
+__author__ = 'danielg'
+
+
+from add_user import BackdoorUser

--- a/monkey/infection_monkey/post_breach/add_user.py
+++ b/monkey/infection_monkey/post_breach/add_user.py
@@ -1,0 +1,49 @@
+import datetime
+import logging
+import subprocess
+import sys
+from infection_monkey.config import WormConfiguration
+
+LOG = logging.getLogger(__name__)
+
+# Linux doesn't have WindowsError
+try:
+    WindowsError
+except NameError:
+    WindowsError = None
+
+__author__ = 'danielg'
+
+
+class BackdoorUser(object):
+    """
+    This module adds a disabled user to the system.
+    This tests part of the ATT&CK matrix
+    """
+
+    def act(self):
+        LOG.info("Adding a user")
+        if sys.platform.startswith("win"):
+            retval = self.add_user_windows()
+        else:
+            retval = self.add_user_linux()
+        if retval != 0:
+            LOG.warn("Failed to add a user")
+        else:
+            LOG.info("Done adding user")
+
+    @staticmethod
+    def add_user_linux():
+        cmd_line = ['useradd', '-M', '--expiredate',
+                    datetime.datetime.today().strftime('%Y-%m-%d'), '--inactive', '0', '-c', 'MONKEY_USER',
+                    WormConfiguration.ms08_067_remote_user_add]
+        retval = subprocess.call(cmd_line)
+        return retval
+
+    @staticmethod
+    def add_user_windows():
+        cmd_line = ['net', 'user', WormConfiguration.ms08_067_remote_user_add,
+                    WormConfiguration.ms08_067_remote_user_pass,
+                    '/add', '/ACTIVE:NO']
+        retval = subprocess.call(cmd_line)
+        return retval

--- a/monkey/infection_monkey/requirements.txt
+++ b/monkey/infection_monkey/requirements.txt
@@ -15,3 +15,4 @@ ecdsa
 netifaces
 ipaddress
 wmi
+pywin32

--- a/monkey/monkey_island/cc/services/config_schema.py
+++ b/monkey/monkey_island/cc/services/config_schema.py
@@ -88,6 +88,19 @@ SCHEMA = {
                 }
             ]
         },
+        "post_breach_acts": {
+            "title": "Post breach actions",
+            "type": "string",
+            "anyOf": [
+                {
+                    "type": "string",
+                    "enum": [
+                        "BackdoorUser"
+                    ],
+                    "title": "Back door user",
+                },
+            ],
+        },
         "finger_classes": {
             "title": "Fingerprint class",
             "type": "string",
@@ -276,7 +289,19 @@ SCHEMA = {
                             "type": "boolean",
                             "default": True,
                             "description": "Is the monkey alive"
-                        }
+                        },
+                        "post_breach_actions": {
+                            "title": "Post breach actions",
+                            "type": "array",
+                            "uniqueItems": True,
+                            "items": {
+                                "$ref": "#/definitions/post_breach_acts"
+                            },
+                            "default": [
+                                "BackdoorUser",
+                            ],
+                            "description": "List of actions the Monkey will run post breach"
+                        },
                     }
                 },
                 "behaviour": {


### PR DESCRIPTION
# Feature
Adds two features.
1 - Ability to run post breach action. These run after collecting system information happens.
2 - Adds a specific post breach action, adding a backdoor user that is disabled.

We do this similar to finger/exploit classes, sending module names. 

* [X] Have you added an explanation of what your changes do and why you'd like to include them?
* [X] Have you successfully tested your changes locally?


Example, failure run on Windows
`2019-01-02 19:23:31,809 [3320:INFO] add_user.act.25: Adding a user`
`System error 5 has occurred.`
`Access is denied.`
`2019-01-02 19:23:31,865 [3320:WARNING] add_user.act.31: Failed to add a user`

Example, success in Linux
`2019-01-02 19:45:46,206 [2136:INFO] add_user.act.25: Adding a user
2019-01-02 19:45:46,337 [2136:INFO] add_user.act.34: Done adding user`