### PR TITLE
Search for new machines using ICMP and not just port scan

### DIFF
--- a/monkey/infection_monkey/config.py
+++ b/monkey/infection_monkey/config.py
@@ -133,7 +133,6 @@ class Configuration(object):
     # how many scan iterations to perform on each run
     max_iterations = 1
 
-    scanner_class = None
     finger_classes = []
     exploiter_classes = []
 

--- a/monkey/infection_monkey/example.conf
+++ b/monkey/infection_monkey/example.conf
@@ -64,7 +64,6 @@
     "smb_download_timeout": 300,
     "smb_service_name": "InfectionMonkey",
     "retry_failed_explotation": true,
-    "scanner_class": "TcpScanner",
     "self_delete_in_cleanup": true,
     "serialize_config": false,
     "singleton_mutex_name": "{2384ec59-0df8-4ab9-918c-843740924a28}",

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -129,8 +129,7 @@ class InfectionMonkey(object):
             if not self._keep_running or not WormConfiguration.alive:
                 break
 
-            machines = self._network.get_victim_machines(WormConfiguration.scanner_class,
-                                                         max_find=WormConfiguration.victims_max_find,
+            machines = self._network.get_victim_machines(max_find=WormConfiguration.victims_max_find,
                                                          stop_callback=ControlClient.check_for_stop)
             is_empty = True
             for machine in machines:

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -143,7 +143,7 @@ class InfectionMonkey(object):
                     finger.get_host_fingerprint(machine)
 
                 ControlClient.send_telemetry('scan', {'machine': machine.as_dict(),
-                                                      'scanner': WormConfiguration.scanner_class.__name__})
+                                                      })
 
                 # skip machines that we've already exploited
                 if machine in self._exploited_machines:

--- a/monkey/infection_monkey/network/ping_scanner.py
+++ b/monkey/infection_monkey/network/ping_scanner.py
@@ -59,10 +59,10 @@ class PingScanner(HostScanner, HostFinger):
         if regex_result:
             try:
                 ttl = int(regex_result.group(0))
-                if LINUX_TTL == ttl:
-                    host.os['type'] = 'linux'
-                elif WINDOWS_TTL == ttl:
+                if (ttl > LINUX_TTL) and (ttl <= WINDOWS_TTL):
                     host.os['type'] = 'windows'
+                if ttl <= LINUX_TTL:
+                    host.os['type'] = 'linux'
                 return True
             except Exception as exc:
                 LOG.debug("Error parsing ping fingerprint: %s", exc)

--- a/monkey/infection_monkey/network/ping_scanner.py
+++ b/monkey/infection_monkey/network/ping_scanner.py
@@ -59,10 +59,10 @@ class PingScanner(HostScanner, HostFinger):
         if regex_result:
             try:
                 ttl = int(regex_result.group(0))
-                if (ttl > LINUX_TTL) and (ttl <= WINDOWS_TTL):
-                    host.os['type'] = 'windows'
                 if ttl <= LINUX_TTL:
                     host.os['type'] = 'linux'
+                else:  # as far we we know, could also be OSX/BSD but lets handle that when it comes up.
+                    host.os['type'] = 'windows'
                 return True
             except Exception as exc:
                 LOG.debug("Error parsing ping fingerprint: %s", exc)

--- a/monkey/monkey_island/cc/services/config.py
+++ b/monkey/monkey_island/cc/services/config.py
@@ -27,7 +27,7 @@ ENCRYPTED_CONFIG_ARRAYS = \
 # This should be used for config values of string type
 ENCRYPTED_CONFIG_STRINGS = \
     [
-        
+
     ]
 
 

--- a/monkey/monkey_island/cc/services/config_schema.py
+++ b/monkey/monkey_island/cc/services/config_schema.py
@@ -400,18 +400,6 @@ SCHEMA = {
                     "title": "Classes",
                     "type": "object",
                     "properties": {
-                        "scanner_class": {
-                            "title": "Scanner class",
-                            "type": "string",
-                            "default": "TcpScanner",
-                            "enum": [
-                                "TcpScanner"
-                            ],
-                            "enumNames": [
-                                "TcpScanner"
-                            ],
-                            "description": "Determines class to scan for machines. (Shouldn't be changed)"
-                        },
                         "finger_classes": {
                             "title": "Fingerprint classes",
                             "type": "array",


### PR DESCRIPTION
# Feature
Lets use our `PingScanner` to scan machines using ICMP and not just port scan.

This is useful for the cross segment analysis, letting us find machines open to ICMP and not just specific ports.

In addition, remove option to pick specific scanner, since now we constantly want to use both.

Still to be done, add it to fingerprinting.

* [X] Have you added an explanation of what your changes do and why you'd like to include them?
* [X] Have you successfully tested your changes locally?

