### PR TITLE
wmi info handler does not crash if no wmi info is collected

### DIFF
--- a/monkey/monkey_island/cc/services/wmi_handler.py
+++ b/monkey/monkey_island/cc/services/wmi_handler.py
@@ -13,11 +13,18 @@ class WMIHandler(object):
         self.monkey_id = monkey_id
         self.info_for_mongo = {}
         self.users_secrets = user_secrets
-        self.users_info = wmi_info['Win32_UserAccount']
-        self.groups_info = wmi_info['Win32_Group']
-        self.groups_and_users = wmi_info['Win32_GroupUser']
-        self.services = wmi_info['Win32_Service']
-        self.products = wmi_info['Win32_Product']
+        if not wmi_info:
+            self.users_info = ""
+            self.groups_info = ""
+            self.groups_and_users = ""
+            self.services = ""
+            self.products = ""
+        else:
+            self.users_info = wmi_info['Win32_UserAccount']
+            self.groups_info = wmi_info['Win32_Group']
+            self.groups_and_users = wmi_info['Win32_GroupUser']
+            self.services = wmi_info['Win32_Service']
+            self.products = wmi_info['Win32_Product']
 
     def process_and_handle_wmi_info(self):
 
@@ -25,7 +32,8 @@ class WMIHandler(object):
         self.add_users_to_collection()
         self.create_group_user_connection()
         self.insert_info_to_mongo()
-        self.add_admin(self.info_for_mongo[self.ADMINISTRATORS_GROUP_KNOWN_SID], self.monkey_id)
+        if self.info_for_mongo:
+            self.add_admin(self.info_for_mongo[self.ADMINISTRATORS_GROUP_KNOWN_SID], self.monkey_id)
         self.update_admins_retrospective()
         self.update_critical_services()
 


### PR DESCRIPTION
# Fixes
Attempts to fix https://github.com/guardicore/monkey/issues/250
