### PR TITLE
Fixes the config import on MSSQL exploiter

### DIFF
--- a/monkey/infection_monkey/exploit/mssqlexec.py
+++ b/monkey/infection_monkey/exploit/mssqlexec.py
@@ -21,7 +21,6 @@ class MSSQLExploiter(HostExploiter):
 
     def __init__(self, host):
         super(MSSQLExploiter, self).__init__(host)
-        self._config = __import__('config').WormConfiguration
         self.attacks_list = [mssqlexec_utils.CmdShellAttack]
 
     def create_payload_file(self, payload_path=DEFAULT_PAYLOAD_PATH):


### PR DESCRIPTION
# Fixes
> _config import is handled by parent class constructor (HostExploiter) so we don't need it
![image](https://user-images.githubusercontent.com/36815064/51894045-627b2f80-23af-11e9-836a-f53b4232b3f2.png)
