### PR TITLE
Fixed a bug where telemetry expects a 'scanner' field

### DIFF
--- a/monkey/monkey_island/cc/resources/telemetry.py
+++ b/monkey/monkey_island/cc/resources/telemetry.py
@@ -149,8 +149,7 @@ class Telemetry(flask_restful.Resource):
         new_scan = \
             {
                 "timestamp": telemetry_json["timestamp"],
-                "data": data,
-                "scanner": telemetry_json['data']['scanner']
+                "data": data
             }
         mongo.db.edge.update(
             {"_id": edge["_id"]},
@@ -160,16 +159,15 @@ class Telemetry(flask_restful.Resource):
 
         node = mongo.db.node.find_one({"_id": edge["to"]})
         if node is not None:
-            if new_scan["scanner"] == "TcpScanner":
-                scan_os = new_scan["data"]["os"]
-                if "type" in scan_os:
-                    mongo.db.node.update({"_id": node["_id"]},
-                                         {"$set": {"os.type": scan_os["type"]}},
-                                         upsert=False)
-                if "version" in scan_os:
-                    mongo.db.node.update({"_id": node["_id"]},
-                                         {"$set": {"os.version": scan_os["version"]}},
-                                         upsert=False)
+            scan_os = new_scan["data"]["os"]
+            if "type" in scan_os:
+                mongo.db.node.update({"_id": node["_id"]},
+                                     {"$set": {"os.type": scan_os["type"]}},
+                                     upsert=False)
+            if "version" in scan_os:
+                mongo.db.node.update({"_id": node["_id"]},
+                                     {"$set": {"os.version": scan_os["version"]}},
+                                     upsert=False)
 
     @staticmethod
     def process_system_info_telemetry(telemetry_json):


### PR DESCRIPTION
# Fixes
Scanner field was removed (when implementing ICMP scanner) from machines on monkey, but Island still expects to get 'scanner' field on it's telemetry. 
![where_is_scanner](https://user-images.githubusercontent.com/36815064/51900061-028b8580-23bd-11e9-94d0-3318ebed9dd2.JPG)
![image](https://user-images.githubusercontent.com/36815064/51900487-1aafd480-23be-11e9-86bd-e3864ed283bf.png)

### This PR attempts to fix that