### PR TITLE
Fixed bug (from node['domain_name'] to monkey['domain_name']

### DIFF
--- a/monkey/monkey_island/cc/services/report.py
+++ b/monkey/monkey_island/cc/services/report.py
@@ -152,7 +152,7 @@ class ReportService:
             {
                 'label': monkey['label'],
                 'ip_addresses': monkey['ip_addresses'],
-                'domain_name': node['domain_name'],
+                'domain_name': monkey['domain_name'],
                 'exploits': list(set(
                     [ReportService.EXPLOIT_DISPLAY_DICT[exploit['exploiter']] for exploit in monkey['exploits'] if
                      exploit['result']]))


### PR DESCRIPTION
# Fixes
> Fixes typo, where instead of node dict we should reference monkey dict
