### PR TITLE
Exploitation order + tiny monkey.py refactor

### DIFF
--- a/monkey/common/utils/exploit_enum.py
+++ b/monkey/common/utils/exploit_enum.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class ExploitType(Enum):
+    VULNERABILITY = 1
+    OTHER = 8
+    BRUTE_FORCE = 9

--- a/monkey/infection_monkey/exploit/__init__.py
+++ b/monkey/infection_monkey/exploit/__init__.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta, abstractmethod
 import infection_monkey.config
+from common.utils.exploit_enum import ExploitType
 
 __author__ = 'itamar'
 
@@ -8,6 +9,9 @@ class HostExploiter(object):
     __metaclass__ = ABCMeta
 
     _TARGET_OS_TYPE = []
+
+    # Usual values are 'vulnerability' or 'brute_force'
+    EXPLOIT_TYPE = ExploitType.VULNERABILITY
 
     def __init__(self, host):
         self._config = infection_monkey.config.WormConfiguration

--- a/monkey/infection_monkey/exploit/mssqlexec.py
+++ b/monkey/infection_monkey/exploit/mssqlexec.py
@@ -6,6 +6,7 @@ import logging
 import pymssql
 
 from infection_monkey.exploit import HostExploiter, mssqlexec_utils
+from common.utils.exploit_enum import ExploitType
 
 __author__ = 'Maor Rayzin'
 
@@ -15,6 +16,7 @@ LOG = logging.getLogger(__name__)
 class MSSQLExploiter(HostExploiter):
 
     _TARGET_OS_TYPE = ['windows']
+    EXPLOIT_TYPE = ExploitType.BRUTE_FORCE
     LOGIN_TIMEOUT = 15
     SQL_DEFAULT_TCP_PORT = '1433'
     DEFAULT_PAYLOAD_PATH = os.path.expandvars(r'%TEMP%\~PLD123.bat') if platform.system() else '/tmp/~PLD123.bat'

--- a/monkey/infection_monkey/exploit/rdpgrinder.py
+++ b/monkey/infection_monkey/exploit/rdpgrinder.py
@@ -16,6 +16,7 @@ from infection_monkey.model import RDP_CMDLINE_HTTP_BITS, RDP_CMDLINE_HTTP_VBS
 from infection_monkey.network.tools import check_tcp_port
 from infection_monkey.exploit.tools import build_monkey_commandline
 from infection_monkey.utils import utf_to_ascii
+from common.utils.exploit_enum import ExploitType
 
 __author__ = 'hoffer'
 
@@ -235,6 +236,7 @@ class CMDClientFactory(rdp.ClientFactory):
 class RdpExploiter(HostExploiter):
 
     _TARGET_OS_TYPE = ['windows']
+    EXPLOIT_TYPE = ExploitType.BRUTE_FORCE
 
     def __init__(self, host):
         super(RdpExploiter, self).__init__(host)

--- a/monkey/infection_monkey/exploit/smbexec.py
+++ b/monkey/infection_monkey/exploit/smbexec.py
@@ -9,12 +9,14 @@ from infection_monkey.model import MONKEY_CMDLINE_DETACHED_WINDOWS, DROPPER_CMDL
 from infection_monkey.network import SMBFinger
 from infection_monkey.network.tools import check_tcp_port
 from infection_monkey.exploit.tools import build_monkey_commandline
+from common.utils.exploit_enum import ExploitType
 
 LOG = getLogger(__name__)
 
 
 class SmbExploiter(HostExploiter):
     _TARGET_OS_TYPE = ['windows']
+    EXPLOIT_TYPE = ExploitType.BRUTE_FORCE
     KNOWN_PROTOCOLS = {
         '139/SMB': (r'ncacn_np:%s[\pipe\svcctl]', 139),
         '445/SMB': (r'ncacn_np:%s[\pipe\svcctl]', 445),

--- a/monkey/infection_monkey/exploit/sshexec.py
+++ b/monkey/infection_monkey/exploit/sshexec.py
@@ -10,6 +10,7 @@ from infection_monkey.exploit.tools import get_target_monkey, get_monkey_depth
 from infection_monkey.model import MONKEY_ARG
 from infection_monkey.network.tools import check_tcp_port
 from infection_monkey.exploit.tools import build_monkey_commandline
+from common.utils.exploit_enum import ExploitType
 
 __author__ = 'hoffer'
 
@@ -20,6 +21,7 @@ TRANSFER_UPDATE_RATE = 15
 
 class SSHExploiter(HostExploiter):
     _TARGET_OS_TYPE = ['linux', None]
+    EXPLOIT_TYPE = ExploitType.BRUTE_FORCE
 
     def __init__(self, host):
         super(SSHExploiter, self).__init__(host)

--- a/monkey/infection_monkey/exploit/wmiexec.py
+++ b/monkey/infection_monkey/exploit/wmiexec.py
@@ -9,12 +9,14 @@ from infection_monkey.exploit import HostExploiter
 from infection_monkey.exploit.tools import SmbTools, WmiTools, AccessDeniedException, get_target_monkey, \
     get_monkey_depth, build_monkey_commandline
 from infection_monkey.model import DROPPER_CMDLINE_WINDOWS, MONKEY_CMDLINE_WINDOWS
+from common.utils.exploit_enum import ExploitType
 
 LOG = logging.getLogger(__name__)
 
 
 class WmiExploiter(HostExploiter):
     _TARGET_OS_TYPE = ['windows']
+    EXPLOIT_TYPE = ExploitType.BRUTE_FORCE
 
     def __init__(self, host):
         super(WmiExploiter, self).__init__(host)

--- a/monkey/infection_monkey/requirements_linux.txt
+++ b/monkey/infection_monkey/requirements_linux.txt
@@ -17,3 +17,4 @@ ipaddress
 wmi
 pymssql
 pyftpdlib
+enum34

--- a/monkey/infection_monkey/requirements_windows.txt
+++ b/monkey/infection_monkey/requirements_windows.txt
@@ -18,3 +18,4 @@ wmi
 pywin32
 pymssql
 pyftpdlib
+enum34


### PR DESCRIPTION
# Feature
> Implemented the ability to add a type to an exploiter (vulnerability/brute-force)
> Exploitation sequence are now determined by type (default is vulnerabilities -> other -> brute-forcers)
> In case of a vulnerable server that has brute-force prevention (like sshguard on ubuntu servers) it now get exploited instead of just blocking communications with island
> Refactored monkey.py host exploitation workflow into functions
##  Tests
Sanity test on local machine