### PR TITLE
Hotfix/various fixes

### DIFF
--- a/monkey/monkey_island/cc/resources/telemetry_feed.py
+++ b/monkey/monkey_island/cc/resources/telemetry_feed.py
@@ -31,11 +31,13 @@ class TelemetryFeed(flask_restful.Resource):
 
     @staticmethod
     def get_displayed_telemetry(telem):
+        monkey = NodeService.get_monkey_by_guid(telem['monkey_guid'])
+        default_hostname = "GUID-" + telem['monkey_guid']
         return \
             {
                 'id': telem['_id'],
                 'timestamp': telem['timestamp'].strftime('%d/%m/%Y %H:%M:%S'),
-                'hostname': NodeService.get_monkey_by_guid(telem['monkey_guid']).get('hostname','missing'),
+                'hostname': monkey.get('hostname', default_hostname) if monkey else default_hostname,
                 'brief': TELEM_PROCESS_DICT[telem['telem_type']](telem)
             }
 

--- a/monkey/monkey_island/cc/services/config_schema.py
+++ b/monkey/monkey_island/cc/services/config_schema.py
@@ -304,7 +304,6 @@ SCHEMA = {
                                 "$ref": "#/definitions/post_breach_acts"
                             },
                             "default": [
-                                "BackdoorUser",
                             ],
                             "description": "List of actions the Monkey will run post breach"
                         },

--- a/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage.js
@@ -327,17 +327,19 @@ class RunMonkeyPageComponent extends AuthComponent {
               </div>
             </div>
           </div>
+            <div className="col-sm-8 col-sm-offset-2" style={{'fontSize': '1.2em'}}>
+              <p className="alert alert-info">
+                <i className="glyphicon glyphicon-info-sign" style={{'marginRight': '5px'}}/>
+                In order to remotely run commands on AWS EC2 instances, please make sure you have
+                the <a href="https://docs.aws.amazon.com/console/ec2/run-command/prereqs" target="_blank">prerequisites</a> and if the
+                instances don't show up, check the
+                AWS <a href="https://docs.aws.amazon.com/console/ec2/run-command/troubleshooting" target="_blank">troubleshooting guide</a>.
+              </p>
+            </div>
             {
               this.state.awsUpdateFailed ?
                 <div className="col-sm-8 col-sm-offset-2" style={{'fontSize': '1.2em'}}>
                   <p className="alert alert-danger" role="alert">Authentication failed.</p>
-                  <p className="alert alert-info">
-                    <i className="glyphicon glyphicon-info-sign" style={{'marginRight': '5px'}}/>
-                    In order to remotely run commands on AWS EC2 instances, please make sure you have
-                    the <a href="https://docs.aws.amazon.com/console/ec2/run-command/prereqs" target="_blank">prerequisites</a> and if the
-                    instances don't show up, check the
-                    AWS <a href="https://docs.aws.amazon.com/console/ec2/run-command/troubleshooting" target="_blank">troubleshooting guide</a>.
-                  </p>
                 </div>
                 :
                 null


### PR DESCRIPTION
# Feature / Fixes
> AWS connection guidelines now appear regardless of auth failing
> postbreach actions disabled by default
> Hotfix telemetry feed accessing non-existent monkey_guid

* [X] Have you added an explanation of what your changes do and why you'd like to include them?
* [X] Have you successfully tested your changes locally?