### PR TITLE
Sambacry now catches NetBIOSError on attempting credentials

### DIFF
--- a/monkey/infection_monkey/exploit/sambacry.py
+++ b/monkey/infection_monkey/exploit/sambacry.py
@@ -7,6 +7,7 @@ from io import BytesIO
 from os import path
 
 import impacket.smbconnection
+from impacket.nmb import NetBIOSError
 from impacket.nt_errors import STATUS_SUCCESS
 from impacket.smb import FILE_OPEN, SMB_DIALECT, SMB, SMBCommand, SMBNtCreateAndX_Parameters, SMBNtCreateAndX_Data, \
     FILE_READ_DATA, FILE_SHARE_READ, FILE_NON_DIRECTORY_FILE, FILE_WRITE_DATA, FILE_DIRECTORY_FILE
@@ -172,7 +173,7 @@ class SambaCryExploiter(HostExploiter):
                     if self.is_share_writable(smb_client, share):
                         writable_shares_creds_dict[share] = credentials
 
-            except (impacket.smbconnection.SessionError, SessionError):
+            except (impacket.smbconnection.SessionError, SessionError, NetBIOSError):
                 # If failed using some credentials, try others.
                 pass
 


### PR DESCRIPTION
# Feature / Fixes
> Fixes bug where failed credentials would throw uncaught exception

* [X] Have you added an explanation of what your changes do and why you'd like to include them?
* [X] Have you successfully tested your changes locally?
