### PR TITLE
Updated Create_certificate to key of length 2048

### DIFF
--- a/monkey/monkey_island/linux/create_certificate.sh
+++ b/monkey/monkey_island/linux/create_certificate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 cd /var/monkey/monkey_island
-openssl genrsa -out cc/server.key 1024
+openssl genrsa -out cc/server.key 2048  
 openssl req -new -key cc/server.key -out cc/server.csr -subj "/C=GB/ST=London/L=London/O=Global Security/OU=Monkey Department/CN=monkey.com"
 openssl x509 -req -days 366 -in cc/server.csr -signkey cc/server.key -out cc/server.crt


### PR DESCRIPTION
# Issue
deb package creates a key of length 1024 by default and and since the release of openssl 1.1.1 the default openssl.conf file at /etc/ssl/openssl.conf  has CipherString = DEFAULT@SECLEVEL=2 , resulting in the key length to be small.  In order to adhere to SECLEVEL=2 the key length was increased from 1024 to 2048.

