### PR TITLE
Updated ReportPage.js

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/pages/ReportPage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ReportPage.js
@@ -403,9 +403,8 @@ class ReportPageComponent extends AuthComponent {
   generateReportRecommendationsSection() {
     return (
       <div id="recommendations">
-        <h3>
-          Domain related recommendations
-        </h3>
+        {Object.keys(this.state.report.recommendations.domain_issues).length !=0 ?
+                     <h3>Domain related recommendations</h3> : null }
         <div>
           {this.generateIssues(this.state.report.recommendations.domain_issues)}
         </div>


### PR DESCRIPTION
Fix for issue #213

# Feature / Fixes
> Fix for Domain related recommendations showing up even if it is empty



##  Changes
Insted of just doing 
`<h3>
          Domain related recommendations
        </h3>`

we check if the object is not empty before printing the heading.
`{Object.keys(this.state.report.recommendations.domain_issues).length !=0 ? <h3>Domain related recommendations</h3> : null }`