### PR TITLE
Struts2 ignores certificate errors, updated schema

### DIFF
--- a/monkey/infection_monkey/exploit/struts2.py
+++ b/monkey/infection_monkey/exploit/struts2.py
@@ -7,6 +7,7 @@ import urllib2
 import httplib
 import unicodedata
 import re
+import ssl
 
 import logging
 from infection_monkey.exploit.web_rce import WebRCE
@@ -47,7 +48,7 @@ class Struts2Exploiter(WebRCE):
         headers = {'User-Agent': 'Mozilla/5.0'}
         request = urllib2.Request(url, headers=headers)
         try:
-            return urllib2.urlopen(request).geturl()
+            return urllib2.urlopen(request, context=ssl._create_unverified_context()).geturl()
         except urllib2.URLError:
             LOG.error("Can't reach struts2 server")
             return False

--- a/monkey/monkey_island/cc/services/config_schema.py
+++ b/monkey/monkey_island/cc/services/config_schema.py
@@ -250,8 +250,9 @@ SCHEMA = {
                             "default": [
                             ],
                             "description":
-                                "List of IPs/subnets the monkey should scan."
-                                " Examples: \"192.168.0.1\", \"192.168.0.5-192.168.0.20\", \"192.168.0.5/24\""
+                                "List of IPs/subnets/hosts the monkey should scan."
+                                " Examples: \"192.168.0.1\", \"192.168.0.5-192.168.0.20\", \"192.168.0.5/24\","
+                                " \"printer.example\""
                         }
                     }
                 },


### PR DESCRIPTION
# Fixes
> Fixes this issue: https://github.com/guardicore/monkey/issues/306
> Struts2 ignores invalid certificates
> Improved configuration description, stating that user can input host names.

* [x] Have you successfully tested your changes locally?

