### PR TITLE
Import made compatible with attack config

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
@@ -299,9 +299,8 @@ class ConfigurePageComponent extends AuthComponent {
     try {
       this.setState({
         configuration: JSON.parse(event.target.result),
-        selectedSection: 'basic',
         lastAction: 'import_success'
-      }, () => {this.sendConfig()});
+      }, () => {this.sendConfig(); this.setInitialConfig(JSON.parse(event.target.result))});
       this.currentSection = 'basic';
       this.currentFormData = {};
     } catch(SyntaxError) {


### PR DESCRIPTION
# Fixes
> After import you can change to attack config without warnings.
> After import you are not thrown into a different configuration tab.
