### PR TITLE
[DONE] Added assertion of mongo db version.

### DIFF
--- a/monkey/monkey_island/cc/database.py
+++ b/monkey/monkey_island/cc/database.py
@@ -25,3 +25,14 @@ def is_db_server_up(mongo_url):
         return True
     except ServerSelectionTimeoutError:
         return False
+
+
+def get_db_version(mongo_url):
+    """
+    Return the mongo db version
+    :param mongo_url: Which mongo to check.
+    :return: version as a tuple (e.g. `(u'4', u'0', u'8')`)
+    """
+    client = MongoClient(mongo_url, serverSelectionTimeoutMS=100)
+    server_version = tuple(client.server_info()['version'].split('.'))
+    return server_version

--- a/monkey/monkey_island/cc/main.py
+++ b/monkey/monkey_island/cc/main.py
@@ -6,7 +6,7 @@ import sys
 import time
 import logging
 
-MINIMUM_MONGO_DB_VERSION_REQUIRED = "4.0.0"
+MINIMUM_MONGO_DB_VERSION_REQUIRED = "3.6.0"
 
 BASE_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/monkey/monkey_island/cc/main.py
+++ b/monkey/monkey_island/cc/main.py
@@ -6,6 +6,8 @@ import sys
 import time
 import logging
 
+MINIMUM_MONGO_DB_VERSION_REQUIRED = "4.0.0"
+
 BASE_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 if BASE_PATH not in sys.path:
@@ -22,7 +24,7 @@ from monkey_island.cc.app import init_app
 from monkey_island.cc.exporter_init import populate_exporter_list
 from monkey_island.cc.utils import local_ip_addresses
 from monkey_island.cc.environment.environment import env
-from monkey_island.cc.database import is_db_server_up
+from monkey_island.cc.database import is_db_server_up, get_db_version
 
 
 def main():
@@ -31,10 +33,8 @@ def main():
     from tornado.ioloop import IOLoop
 
     mongo_url = os.environ.get('MONGO_URL', env.get_mongo_url())
-
-    while not is_db_server_up(mongo_url):
-        logger.info('Waiting for MongoDB server')
-        time.sleep(1)
+    wait_for_mongo_db_server(mongo_url)
+    assert_mongo_db_version(mongo_url)
 
     populate_exporter_list()
     app = init_app(mongo_url)
@@ -53,6 +53,28 @@ def main():
             'Monkey Island Server is running on https://{}:{}'.format(local_ip_addresses()[0], env.get_island_port()))
 
         IOLoop.instance().start()
+
+
+def wait_for_mongo_db_server(mongo_url):
+    while not is_db_server_up(mongo_url):
+        logger.info('Waiting for MongoDB server on {0}'.format(mongo_url))
+        time.sleep(1)
+
+
+def assert_mongo_db_version(mongo_url):
+    """
+    Checks if the mongodb version is new enough for running the app.
+    If the DB is too old, quits.
+    :param mongo_url: URL to the mongo the Island will use
+    """
+    required_version = tuple(MINIMUM_MONGO_DB_VERSION_REQUIRED.split("."))
+    server_version = get_db_version(mongo_url)
+    if server_version < required_version:
+        logger.error(
+            'Mongo DB version too old. {0} is required, but got {1}'.format(str(required_version), str(server_version)))
+        sys.exit(-1)
+    else:
+        logger.info('Mongo DB version OK. Got {0}'.format(str(server_version)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Also refactored a bit to make the main shorter.

# Feature / Fixes
> Changes/Fixes the following feature

Fixes #337 

* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Have you successfully tested your changes locally?

* Example screenshot/log transcript of the feature working
#### Version is good

> `sudo+ssh://shay@10.15.1.115:22/usr/bin/python -u /home/shay/monkey/monkey/monkey_island.py
2019-06-05 19:24:37,119 - environment.py:46 -   <module>() - INFO - Monkey's env is: StandardEnvironment
2019-06-05 19:24:38,104 - main.py:60 - wait_for_mongo_db_server() - INFO - Waiting for MongoDB server on mongodb://localhost:27017/monkeyisland
2019-06-05 19:24:39,608 - main.py:60 - wait_for_mongo_db_server() - INFO - Waiting for MongoDB server on mongodb://localhost:27017/monkeyisland
2019-06-05 19:24:41,113 - main.py:60 - wait_for_mongo_db_server() - INFO - Waiting for MongoDB server on mongodb://localhost:27017/monkeyisland
2019-06-05 19:24:42,618 - main.py:60 - wait_for_mongo_db_server() - INFO - Waiting for MongoDB server on mongodb://localhost:27017/monkeyisland
2019-06-05 19:24:43,629 - main.py:77 - assert_mongo_db_version() - INFO - Mongo DB version OK. Got (u'4', u'0', u'8')`

#### Version is bad (I upped the required version to 6.0.0)

> `sudo+ssh://shay@10.15.1.115:22/usr/bin/python -u /home/shay/monkey/monkey/monkey_island.py
2019-06-05 19:27:31,436 - environment.py:46 -   <module>() - INFO - Monkey's env is: StandardEnvironment
2019-06-05 19:27:31,917 - main.py:74 - assert_mongo_db_version() - ERROR - Mongo DB version too old. ('6', '0', '0') is required, but got (u'4', u'0', u'8')
Process finished with exit code 255`
