### PR TITLE
[CR] Use tempfile to create monkey directory

### DIFF
--- a/monkey/infection_monkey/config.py
+++ b/monkey/infection_monkey/config.py
@@ -157,9 +157,8 @@ class Configuration(object):
 
     keep_tunnel_open_time = 60
 
-    # Monkey files directories
-    monkey_dir_linux = '/tmp/monkey_dir'
-    monkey_dir_windows = r'C:\Windows\Temp\monkey_dir'
+    # Monkey files directory name
+    monkey_dir_name = 'monkey_dir'
 
     ###########################
     # scanners config

--- a/monkey/infection_monkey/example.conf
+++ b/monkey/infection_monkey/example.conf
@@ -29,9 +29,7 @@
     "dropper_target_path_win_64": "C:\\Windows\\temp\\monkey64.exe",
     "dropper_target_path_linux": "/tmp/monkey",
 
-    monkey_dir_linux = '/tmp/monkey_dir',
-    monkey_dir_windows = r'C:\Windows\Temp\monkey_dir',
-
+    "monkey_dir_name": "monkey_dir",
 
     "kill_file_path_linux": "/var/run/monkey.not",
     "kill_file_path_windows": "%windir%\\monkey.not",

--- a/monkey/infection_monkey/exploit/mssqlexec.py
+++ b/monkey/infection_monkey/exploit/mssqlexec.py
@@ -1,15 +1,16 @@
-import os
 import logging
-from time import sleep
-import pymssql
+import os
 import textwrap
+from time import sleep
 
-from infection_monkey.exploit import HostExploiter, tools
+import pymssql
+
 from common.utils.exploit_enum import ExploitType
+from infection_monkey.exploit import HostExploiter, tools
 from infection_monkey.exploit.tools import HTTPTools
-from infection_monkey.config import WormConfiguration
-from infection_monkey.model import DROPPER_ARG
 from infection_monkey.exploit.tools import get_monkey_dest_path
+from infection_monkey.model import DROPPER_ARG
+from infection_monkey.utils import get_monkey_dir_path
 
 LOG = logging.getLogger(__name__)
 
@@ -52,10 +53,10 @@ class MSSQLExploiter(HostExploiter):
         LOG.info("Started http server on %s", http_path)
 
         dst_path = get_monkey_dest_path(http_path)
-        tmp_file_path = os.path.join(WormConfiguration.monkey_dir_windows, MSSQLExploiter.TMP_FILE_NAME)
+        tmp_file_path = os.path.join(get_monkey_dir_path(), MSSQLExploiter.TMP_FILE_NAME)
 
         # Create monkey dir.
-        commands = ["xp_cmdshell \"mkdir %s\"" % WormConfiguration.monkey_dir_windows]
+        commands = ["xp_cmdshell \"mkdir %s\"" % get_monkey_dir_path()]
         MSSQLExploiter.execute_command(cursor, commands)
 
         # Form download command in a file

--- a/monkey/infection_monkey/utils.py
+++ b/monkey/infection_monkey/utils.py
@@ -1,8 +1,9 @@
 import os
-import sys
 import shutil
 import struct
-import datetime
+import sys
+import tempfile
+
 from infection_monkey.config import WormConfiguration
 
 
@@ -17,10 +18,9 @@ def get_dropper_log_path():
 
 
 def is_64bit_windows_os():
-    '''
+    """
     Checks for 64 bit Windows OS using environment variables.
-    :return:
-    '''
+    """
     return 'PROGRAMFILES(X86)' in os.environ
 
 
@@ -54,7 +54,4 @@ def remove_monkey_dir():
 
 
 def get_monkey_dir_path():
-    if is_windows_os():
-        return WormConfiguration.monkey_dir_windows
-    else:
-        return WormConfiguration.monkey_dir_linux
+    return os.path.join(tempfile.gettempdir(), WormConfiguration.monkey_dir_name)

--- a/monkey/monkey_island/cc/services/config_schema.py
+++ b/monkey/monkey_island/cc/services/config_schema.py
@@ -499,17 +499,11 @@ SCHEMA = {
                             "default": 60,
                             "description": "Time to keep tunnel open before going down after last exploit (in seconds)"
                         },
-                        "monkey_dir_windows": {
-                            "title": "Monkey's windows directory",
+                        "monkey_dir_name": {
+                            "title": "Monkey's directory name",
                             "type": "string",
-                            "default": r"C:\Windows\temp\monkey_dir",
-                            "description": "Directory containing all monkey files on windows"
-                        },
-                        "monkey_dir_linux": {
-                            "title": "Monkey's linux directory",
-                            "type": "string",
-                            "default": "/tmp/monkey_dir",
-                            "description": "Directory containing all monkey files on linux"
+                            "default": r"monkey_dir",
+                            "description": "Directory name for the directory which will contain all of the monkey files"
                         },
                     }
                 },


### PR DESCRIPTION
Instead of predetermined tmp paths.

# Feature / Fixes
Fixes #348 .

* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Have you successfully tested your changes locally?

* Example screenshot/log transcript of the feature working
After running the monkey locally...
```
C:\users\shay~1.neh\appdata\local\temp>dir | findstr monkey_dir
12/06/2019  17:51    <DIR>          monkey_dir
```

##  Changes
  - Now using tempfile to create monkey directory