### PR TITLE
HTTP servers' bugfix

### DIFF
--- a/monkey/infection_monkey/transport/http.py
+++ b/monkey/infection_monkey/transport/http.py
@@ -49,7 +49,8 @@ class FileServHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                 start_range += chunk
 
             if f.tell() == monkeyfs.getsize(self.filename):
-                self.report_download(self.client_address)
+                if self.report_download(self.client_address):
+                    self.close_connection = 1
 
             f.close()
 
@@ -171,7 +172,8 @@ class HTTPServer(threading.Thread):
                 LOG.info('File downloaded from (%s,%s)' % (dest[0], dest[1]))
                 self.downloads += 1
                 if not self.downloads < self.max_downloads:
-                    self.close_connection = 1
+                    return True
+                return False
 
         httpd = BaseHTTPServer.HTTPServer((self._local_ip, self._local_port), TempHandler)
         httpd.timeout = 0.5  # this is irrelevant?
@@ -217,7 +219,8 @@ class LockedHTTPServer(threading.Thread):
                 LOG.info('File downloaded from (%s,%s)' % (dest[0], dest[1]))
                 self.downloads += 1
                 if not self.downloads < self.max_downloads:
-                    self.close_connection = 1
+                    return True
+                return False
 
         httpd = BaseHTTPServer.HTTPServer((self._local_ip, self._local_port), TempHandler)
         self.lock.release()


### PR DESCRIPTION
# Fixes
> Changes/Fixes the following feature
![image](https://user-images.githubusercontent.com/36815064/59741786-ac888300-9274-11e9-9f56-4c7cf07d8cc9.png)

* [X] Successfully tested changes locally.

For some reason the previous bugfix stopped working (it was setting `closed_connection = 1` on http server object, not on request handler). 

