### PR TITLE
Create island_password_hasher.py

### DIFF
--- a/monkey/monkey_island/scripts/island_password_hasher.py
+++ b/monkey/monkey_island/scripts/island_password_hasher.py
@@ -1,0 +1,23 @@
+"""
+Utility script for running a string through SHA3_512 hash.
+Used for Monkey Island password hash, see
+https://github.com/guardicore/monkey/wiki/Enabling-Monkey-Island-Password-Protection
+for more details.
+"""
+
+import argparse
+from Crypto.Hash import SHA3_512
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("string_to_sha", help="The string to do sha for")
+    args = parser.parse_args()
+
+    h = SHA3_512.new()
+    h.update(args.string_to_sha)
+    print(h.hexdigest())
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Used for Monkey Island password hash. See
https://github.com/guardicore/monkey/wiki/Enabling-Monkey-Island-Password-Protection

# Feature / Fixes
Added the script for ease of use

* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Have you successfully tested your changes locally?

* Example screenshot/log transcript of the feature working
```
C:\Python27\python.exe C:/Users/shay.nehmad/PycharmProjects/sha3-512-er/shascript.py Password1
61a73c554fd0a2024eb3bffb06a597ef5095764ab049d8440c683f0ccd4e77d5a737fa90358664006cfa13c3b839028e63fc82f77e652730524c111efac95073
```
