### PR TITLE
self_delete_in_cleanup default is now True

### DIFF
--- a/monkey/monkey_island/cc/services/config_schema.py
+++ b/monkey/monkey_island/cc/services/config_schema.py
@@ -389,7 +389,7 @@ SCHEMA = {
                         "self_delete_in_cleanup": {
                             "title": "Self delete on cleanup",
                             "type": "boolean",
-                            "default": False,
+                            "default": True,
                             "description": "Should the monkey delete its executable when going down"
                         },
                         "use_file_logging": {


### PR DESCRIPTION
# Feature / Fixes
The monkey will delete itself after going down by default. 

* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Have you successfully tested your changes locally?

* Example screenshot/log transcript of the feature working
![image](https://user-images.githubusercontent.com/48879847/62003086-d78ab000-b119-11e9-956f-928a33bd71da.png)
