### PR TITLE
Add missing requirement

### DIFF
--- a/monkey/monkey_island/requirements.txt
+++ b/monkey/monkey_island/requirements.txt
@@ -25,3 +25,4 @@ wheel
 mongoengine
 mongomock
 requests
+dpath


### PR DESCRIPTION
Fix missing requirement dpath in Island

@ShayNehmad what ideas did you have about making sure this never happens?