### PR TITLE
Attack: private key query fix, mimikatz: log message.

### DIFF
--- a/monkey/infection_monkey/system_info/windows_info_collector.py
+++ b/monkey/infection_monkey/system_info/windows_info_collector.py
@@ -63,5 +63,6 @@ class WindowsInfoCollector(InfoCollector):
             if "credentials" in self.info:
                 self.info["credentials"].update(mimikatz_info)
             self.info["mimikatz"] = mimikatz_collector.get_mimikatz_text()
+            LOG.info('Mimikatz info gathered successfully')
         else:
             LOG.info('No mimikatz info was gathered')

--- a/monkey/monkey_island/cc/services/attack/technique_reports/T1145.py
+++ b/monkey/monkey_island/cc/services/attack/technique_reports/T1145.py
@@ -12,7 +12,7 @@ class T1145(AttackTechnique):
     used_msg = "Monkey found ssh keys on machines in the network."
 
     # Gets data about ssh keys found
-    query = [{'$match': {'telem_category': 'system_info_collection',
+    query = [{'$match': {'telem_category': 'system_info',
                          'data.ssh_info': {'$elemMatch': {'private_key': {'$exists': True}}}}},
              {'$project': {'_id': 0,
                            'machine': {'hostname': '$data.hostname', 'ips': '$data.network_info.networks'},


### PR DESCRIPTION
# Small fixes
> Mimikatz logs successful credential gathering
> Private key attack technique query fixed according to changed telemetry type
