### PR TITLE
Bugfix: can't submit on import

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
@@ -295,13 +295,12 @@ class ConfigurePageComponent extends AuthComponent {
     this.setState({PBAlinuxFile: [], PBAwinFile: []});
   }
 
-  onReadFile = (event) => {
+  setConfigOnImport = (event) => {
     try {
       this.setState({
         configuration: JSON.parse(event.target.result),
         lastAction: 'import_success'
       }, () => {this.sendConfig(); this.setInitialConfig(JSON.parse(event.target.result))});
-      this.currentSection = 'basic';
       this.currentFormData = {};
     } catch(SyntaxError) {
       this.setState({lastAction: 'import_failure'});
@@ -335,7 +334,7 @@ class ConfigurePageComponent extends AuthComponent {
 
   importConfig = (event) => {
     let reader = new FileReader();
-    reader.onload = this.onReadFile;
+    reader.onload = this.setConfigOnImport;
     reader.readAsText(event.target.files[0]);
     event.target.value = null;
   };
@@ -494,7 +493,6 @@ class ConfigurePageComponent extends AuthComponent {
     } else if(this.state.selectedSection !== 'attack') {
       content = this.renderConfigContent(displayedSchema)
     }
-
     return (
       <Col xs={12} lg={10}>
         {this.renderAttackAlertModal()}


### PR DESCRIPTION
# Fixes
> Fixes a bug where you can't submit changed config after import.

* [x] Have you successfully tested your changes locally?

* Example screenshot/log transcript of the feature working

##  Changes
Refactored config import not to change current section on import.
Refactored 'onReadFile' to 'setConfigOnImport'
