### PR TITLE
Bugfix for monkey not reporting being dead

### DIFF
--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -225,7 +225,7 @@ class InfectionMonkey(object):
             InfectionMonkey.close_tunnel()
             firewall.close()
         else:
-            StateTelem(False).send()  # Signal the server (before closing the tunnel)
+            StateTelem(True).send()  # Signal the server (before closing the tunnel)
             InfectionMonkey.close_tunnel()
             firewall.close()
             if WormConfiguration.send_log_to_server:


### PR DESCRIPTION
# Fixes
> Fixes monkey sending wrong telemetry on cleanup which results in monkey not reporting it's death
