### PR TITLE
442/bugfix/api status queries trigger multiple report generations

### DIFF
--- a/monkey/infection_monkey/network/network_scanner.py
+++ b/monkey/infection_monkey/network/network_scanner.py
@@ -6,7 +6,7 @@ from infection_monkey.config import WormConfiguration
 from infection_monkey.model.victim_host_generator import VictimHostGenerator
 from infection_monkey.network.info import local_ips, get_interfaces_ranges
 from infection_monkey.network import TcpScanner, PingScanner
-from infection_monkey.utils.environment import is_windows_os
+from infection_monkey.utils import is_windows_os
 
 if is_windows_os():
     from multiprocessing.dummy import Pool

--- a/monkey/infection_monkey/network/network_scanner.py
+++ b/monkey/infection_monkey/network/network_scanner.py
@@ -6,7 +6,7 @@ from infection_monkey.config import WormConfiguration
 from infection_monkey.model.victim_host_generator import VictimHostGenerator
 from infection_monkey.network.info import local_ips, get_interfaces_ranges
 from infection_monkey.network import TcpScanner, PingScanner
-from infection_monkey.utils import is_windows_os
+from infection_monkey.utils.environment import is_windows_os
 
 if is_windows_os():
     from multiprocessing.dummy import Pool

--- a/monkey/monkey_island/cc/services/attack/attack_report.py
+++ b/monkey/monkey_island/cc/services/attack/attack_report.py
@@ -6,6 +6,7 @@ from monkey_island.cc.services.attack.technique_reports import T1145, T1105, T10
 from monkey_island.cc.services.attack.technique_reports import T1090, T1041, T1222, T1005, T1018, T1016, T1021, T1064
 from monkey_island.cc.services.attack.attack_config import AttackConfig
 from monkey_island.cc.database import mongo
+from monkey_island.cc.services.reporting.report_generation_synchronisation import safe_generate_attack_report
 
 __author__ = "VakarisZ"
 
@@ -88,7 +89,8 @@ class AttackReportService:
             report_modifytime = latest_report['meta']['latest_monkey_modifytime']
             if monkey_modifytime and report_modifytime and monkey_modifytime == report_modifytime:
                 return latest_report
-        return AttackReportService.generate_new_report()
+
+        return safe_generate_attack_report()
 
     @staticmethod
     def is_report_generated():

--- a/monkey/monkey_island/cc/services/reporting/report.py
+++ b/monkey/monkey_island/cc/services/reporting/report.py
@@ -1,25 +1,25 @@
-import itertools
 import functools
+import itertools
+import logging
+import time
 
 import ipaddress
-import logging
-
 from bson import json_util
 from enum import Enum
-
 from six import text_type
 
+from common.network.network_range import NetworkRange
 from common.network.segmentation_utils import get_ip_in_src_and_not_in_dst
 from monkey_island.cc.database import mongo
 from monkey_island.cc.models import Monkey
-from monkey_island.cc.services.reporting.report_exporter_manager import ReportExporterManager
 from monkey_island.cc.services.config import ConfigService
 from monkey_island.cc.services.configuration.utils import get_config_network_segments_as_subnet_groups
 from monkey_island.cc.services.edge import EdgeService
 from monkey_island.cc.services.node import NodeService
-from monkey_island.cc.utils import local_ip_addresses, get_subnets
 from monkey_island.cc.services.reporting.pth_report import PTHReportService
-from common.network.network_range import NetworkRange
+from monkey_island.cc.services.reporting.report_exporter_manager import ReportExporterManager
+from monkey_island.cc.services.reporting.report_generation_synchronisation import safe_generate_regular_report
+from monkey_island.cc.utils import local_ip_addresses, get_subnets
 
 __author__ = "itay.mizeretz"
 
@@ -692,6 +692,7 @@ class ReportService:
 
     @staticmethod
     def generate_report():
+        time.sleep(40)
         domain_issues = ReportService.get_domain_issues()
         issues = ReportService.get_issues()
         config_users = ReportService.get_config_users()
@@ -780,7 +781,7 @@ class ReportService:
     def get_report():
         if ReportService.is_latest_report_exists():
             return ReportService.decode_dot_char_before_mongo_insert(mongo.db.report.find_one())
-        return ReportService.generate_report()
+        return safe_generate_regular_report()
 
     @staticmethod
     def did_exploit_type_succeed(exploit_type):

--- a/monkey/monkey_island/cc/services/reporting/report.py
+++ b/monkey/monkey_island/cc/services/reporting/report.py
@@ -1,7 +1,6 @@
 import functools
 import itertools
 import logging
-import time
 
 import ipaddress
 from bson import json_util
@@ -692,7 +691,6 @@ class ReportService:
 
     @staticmethod
     def generate_report():
-        time.sleep(40)
         domain_issues = ReportService.get_domain_issues()
         issues = ReportService.get_issues()
         config_users = ReportService.get_config_users()

--- a/monkey/monkey_island/cc/services/reporting/report_generation_synchronisation.py
+++ b/monkey/monkey_island/cc/services/reporting/report_generation_synchronisation.py
@@ -1,0 +1,63 @@
+import logging
+import threading
+
+logger = logging.getLogger(__name__)
+
+# These are pseudo-singletons - global Locks. These locks will allow only one thread to generate a report at a time.
+# Report generation can be quite slow if there is a lot of data, and the UI queries the Root service often; without
+# the locks, these requests would accumulate, overload the server, eventually causing it to crash.
+logger.debug("Initializing report generation lock.")
+report_generating_lock = threading.Semaphore()
+__attack_report_generating_lock = threading.Semaphore()
+__regular_report_generating_lock = threading.Semaphore()
+
+
+def safe_generate_reports():
+    # Wait until report generation is available.
+    logger.debug("Waiting for report generation...")
+    # Entering the critical section.
+    report_generating_lock.acquire()
+    logger.debug("Report generation locked.")
+    report = safe_generate_regular_report()
+    attack_report = safe_generate_attack_report()
+    # Leaving the critical section.
+    report_generating_lock.release()
+    logger.debug("Report generation released.")
+    return report, attack_report
+
+
+def safe_generate_regular_report():
+    # Local import to avoid circular imports
+    from monkey_island.cc.services.reporting.report import ReportService
+    logger.debug("Waiting for regular report generation...")
+    __regular_report_generating_lock.acquire()
+    logger.debug("Regular report generation locked.")
+    report = ReportService.generate_report()
+    __regular_report_generating_lock.release()
+    logger.debug("Regular report generation released.")
+    return report
+
+
+def safe_generate_attack_report():
+    # Local import to avoid circular imports
+    from monkey_island.cc.services.attack.attack_report import AttackReportService
+    logger.debug("Waiting for attack report generation...")
+    __attack_report_generating_lock.acquire()
+    logger.debug("Attack report generation locked.")
+    attack_report = AttackReportService.generate_new_report()
+    __attack_report_generating_lock.release()
+    logger.debug("Attack report generation released.")
+    return attack_report
+
+
+def is_report_being_generated():
+    # From https://docs.python.org/2/library/threading.html#threading.Semaphore.acquire:
+    # When invoked with blocking set to false, do not block.
+    #   If a call without an argument would block, return false immediately;
+    #   otherwise, do the same thing as when called without arguments, and return true.
+    is_report_being_generated_right_now = not report_generating_lock.acquire(blocking=False)
+    logger.debug("is_report_being_generated_right_now == " + str(is_report_being_generated_right_now))
+    if not is_report_being_generated_right_now:
+        # We're not using the critical resource; we just checked its state.
+        report_generating_lock.release()
+    return is_report_being_generated_right_now

--- a/monkey/monkey_island/cc/services/reporting/report_generation_synchronisation.py
+++ b/monkey/monkey_island/cc/services/reporting/report_generation_synchronisation.py
@@ -6,47 +6,37 @@ logger = logging.getLogger(__name__)
 # These are pseudo-singletons - global Locks. These locks will allow only one thread to generate a report at a time.
 # Report generation can be quite slow if there is a lot of data, and the UI queries the Root service often; without
 # the locks, these requests would accumulate, overload the server, eventually causing it to crash.
-logger.debug("Initializing report generation lock.")
-report_generating_lock = threading.Semaphore()
+logger.debug("Initializing report generation locks.")
+__report_generating_lock = threading.Semaphore()
 __attack_report_generating_lock = threading.Semaphore()
 __regular_report_generating_lock = threading.Semaphore()
 
 
 def safe_generate_reports():
-    # Wait until report generation is available.
-    logger.debug("Waiting for report generation...")
-    # Entering the critical section.
-    report_generating_lock.acquire()
-    logger.debug("Report generation locked.")
+    # Entering the critical section; Wait until report generation is available.
+    __report_generating_lock.acquire()
     report = safe_generate_regular_report()
     attack_report = safe_generate_attack_report()
     # Leaving the critical section.
-    report_generating_lock.release()
-    logger.debug("Report generation released.")
+    __report_generating_lock.release()
     return report, attack_report
 
 
 def safe_generate_regular_report():
     # Local import to avoid circular imports
     from monkey_island.cc.services.reporting.report import ReportService
-    logger.debug("Waiting for regular report generation...")
     __regular_report_generating_lock.acquire()
-    logger.debug("Regular report generation locked.")
     report = ReportService.generate_report()
     __regular_report_generating_lock.release()
-    logger.debug("Regular report generation released.")
     return report
 
 
 def safe_generate_attack_report():
     # Local import to avoid circular imports
     from monkey_island.cc.services.attack.attack_report import AttackReportService
-    logger.debug("Waiting for attack report generation...")
     __attack_report_generating_lock.acquire()
-    logger.debug("Attack report generation locked.")
     attack_report = AttackReportService.generate_new_report()
     __attack_report_generating_lock.release()
-    logger.debug("Attack report generation released.")
     return attack_report
 
 
@@ -55,9 +45,8 @@ def is_report_being_generated():
     # When invoked with blocking set to false, do not block.
     #   If a call without an argument would block, return false immediately;
     #   otherwise, do the same thing as when called without arguments, and return true.
-    is_report_being_generated_right_now = not report_generating_lock.acquire(blocking=False)
-    logger.debug("is_report_being_generated_right_now == " + str(is_report_being_generated_right_now))
+    is_report_being_generated_right_now = not __report_generating_lock.acquire(blocking=False)
     if not is_report_being_generated_right_now:
         # We're not using the critical resource; we just checked its state.
-        report_generating_lock.release()
+        __report_generating_lock.release()
     return is_report_being_generated_right_now


### PR DESCRIPTION
# Feature / Fixes
Fixes #442 .

* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Have you successfully tested your changes locally?

## Log transcript of the feature working
With five seconds of sleep in report generation. *Logs have been deleted from the code*. 
```
2019-10-02 13:20:20,802 - root.py:65 - get_completed_steps() - DEBUG - Infection is done; checking if should generate report...
2019-10-02 13:20:20,803 - root.py:81 - generate_report() - DEBUG - Generating report from Root service.
SLEEP
DONE SLEEP
2019-10-02 13:20:25,805 - report.py:558 - get_domain_issues() - INFO - Domain issues generated for reporting
2019-10-02 13:20:25,894 - report.py:237 - get_azure_creds() - INFO - Azure machines creds generated for reporting
2019-10-02 13:20:25,894 - report.py:111 - get_azure_issues() - INFO - Azure issues generated for reporting
2019-10-02 13:20:25,895 - report.py:593 - get_issues() - INFO - Issues generated for reporting
2019-10-02 13:20:25,901 - config.py:164 - get_default_config() - INFO - Default config was called
2019-10-02 13:20:25,999 - report.py:144 - get_scanned() - INFO - Scanned nodes generated for reporting
2019-10-02 13:20:26,000 - report.py:168 - get_exploited() - INFO - Exploited nodes generated for reporting
2019-10-02 13:20:26,000 - report.py:194 - get_stolen_creds() - INFO - Stolen creds generated for reporting
2019-10-02 13:20:26,002 - report.py:237 - get_azure_creds() - INFO - Azure machines creds generated for reporting
2019-10-02 13:20:26,055 - attack_report.py:67 - generate_new_report() - ERROR - Attack technique does not have it's report component added to attack report service. u'T1078'
2019-10-02 13:20:26,101 - root.py:87 - generate_report() - DEBUG - Finished generating report from Root service.
2019-10-02 13:20:26,102 - wsgi.py:374 -       _log() - INFO - 200 GET /api (127.0.0.1) 5406.00ms
2019-10-02 13:20:26,457 - wsgi.py:374 -       _log() - INFO - 200 GET /api/netmap (127.0.0.1) 345.00ms
2019-10-02 13:20:26,467 - wsgi.py:374 -       _log() - INFO - 200 GET /api/telemetry-feed?timestamp=null (127.0.0.1) 9.00ms
2019-10-02 13:20:26,566 - root.py:65 - get_completed_steps() - DEBUG - Infection is done; checking if should generate report...
2019-10-02 13:20:26,571 - wsgi.py:374 -       _log() - INFO - 200 GET /api (127.0.0.1) 98.00ms
2019-10-02 13:20:27,174 - wsgi.py:374 -       _log() - INFO - 200 GET /api/netmap (127.0.0.1) 356.00ms
2019-10-02 13:20:27,272 - root.py:65 - get_completed_steps() - DEBUG - Infection is done; checking if should generate report...
2019-10-02 13:20:27,275 - wsgi.py:374 -       _log() - INFO - 200 GET /api (127.0.0.1) 96.00ms
2019-10-02 13:20:27,721 - root.py:65 - get_completed_steps() - DEBUG - Infection is done; checking if should generate report...
2019-10-02 13:20:27,724 - wsgi.py:374 -       _log() - INFO - 200 GET /api (127.0.0.1) 91.00ms
2019-10-02 13:20:28,174 - root.py:65 - get_completed_steps() - DEBUG - Infection is done; checking if should generate report...
2019-10-02 13:20:28,177 - wsgi.py:374 -       _log() - INFO - 200 GET /api (127.0.0.1) 95.00ms
2019-10-02 13:20:30,795 - root.py:65 - get_completed_steps() - DEBUG - Infection is done; checking if should generate report...
```

##  Changes
  - Added event to Root service to make sure report isn't generated unnecessarily, and to support future multithreaded server. 
  - Improved the logic of the Root Service `get_server_info()` function. 