### PR TITLE
463/hotfix/exception on aws network error

### DIFF
--- a/monkey/common/cloud/aws_instance.py
+++ b/monkey/common/cloud/aws_instance.py
@@ -29,14 +29,14 @@ class AwsInstance(object):
                 AWS_LATEST_METADATA_URI_PREFIX + 'meta-data/instance-id', timeout=2).read()
             self.region = self._parse_region(
                 urllib2.urlopen(AWS_LATEST_METADATA_URI_PREFIX + 'meta-data/placement/availability-zone').read())
-        except urllib2.URLError as e:
-            logger.debug("Failed init of AwsInstance while getting metadata: {}".format(e.message))
+        except (urllib2.URLError, IOError) as e:
+            logger.debug("Failed init of AwsInstance while getting metadata: {}".format(e.message), exc_info=True)
 
         try:
             self.account_id = self._extract_account_id(
                 urllib2.urlopen(
                     AWS_LATEST_METADATA_URI_PREFIX + 'dynamic/instance-identity/document', timeout=2).read())
-        except urllib2.URLError as e:
+        except (urllib2.URLError, IOError) as e:
             logger.debug("Failed init of AwsInstance while getting dynamic instance data: {}".format(e.message))
 
     @staticmethod

--- a/monkey/infection_monkey/system_info/__init__.py
+++ b/monkey/infection_monkey/system_info/__init__.py
@@ -113,7 +113,7 @@ class InfoCollector(object):
         :return: None. Updates class information
         """
         LOG.debug("Reading subnets")
-        self.info['network_info'] =\
+        self.info['network_info'] = \
             {
                 'networks': get_host_subnets(),
                 'netstat': NetstatCollector.get_netstat_info()
@@ -122,28 +122,38 @@ class InfoCollector(object):
     def get_azure_info(self):
         """
         Adds credentials possibly stolen from an Azure VM instance (if we're on one)
-        Updates the credentials structure, creating it if neccesary (compat with mimikatz)
+        Updates the credentials structure, creating it if necessary (compat with mimikatz)
         :return: None. Updates class information
         """
-        from infection_monkey.config import WormConfiguration
-        if not WormConfiguration.extract_azure_creds:
-            return
-        LOG.debug("Harvesting creds if on an Azure machine")
-        azure_collector = AzureCollector()
-        if 'credentials' not in self.info:
-            self.info["credentials"] = {}
-        azure_creds = azure_collector.extract_stored_credentials()
-        for cred in azure_creds:
-            username = cred[0]
-            password = cred[1]
-            if username not in self.info["credentials"]:
-                self.info["credentials"][username] = {}
-            # we might be losing passwords in case of multiple reset attempts on same username
-            # or in case another collector already filled in a password for this user
-            self.info["credentials"][username]['password'] = password
-        if len(azure_creds) != 0:
-            self.info["Azure"] = {}
-            self.info["Azure"]['usernames'] = [cred[0] for cred in azure_creds]
+        # noinspection PyBroadException
+        try:
+            from infection_monkey.config import WormConfiguration
+            if not WormConfiguration.extract_azure_creds:
+                return
+            LOG.debug("Harvesting creds if on an Azure machine")
+            azure_collector = AzureCollector()
+            if 'credentials' not in self.info:
+                self.info["credentials"] = {}
+            azure_creds = azure_collector.extract_stored_credentials()
+            for cred in azure_creds:
+                username = cred[0]
+                password = cred[1]
+                if username not in self.info["credentials"]:
+                    self.info["credentials"][username] = {}
+                # we might be losing passwords in case of multiple reset attempts on same username
+                # or in case another collector already filled in a password for this user
+                self.info["credentials"][username]['password'] = password
+            if len(azure_creds) != 0:
+                self.info["Azure"] = {}
+                self.info["Azure"]['usernames'] = [cred[0] for cred in azure_creds]
+        except Exception:
+            # If we failed to collect azure info, no reason to fail all the collection. Log and continue.
+            LOG.error("Failed collecting Azure info.", exc_info=True)
 
     def get_aws_info(self):
-        self.info['aws'] = AwsCollector().get_aws_info()
+        # noinspection PyBroadException
+        try:
+            self.info['aws'] = AwsCollector().get_aws_info()
+        except Exception:
+            # If we failed to collect aws info, no reason to fail all the collection. Log and continue.
+            LOG.error("Failed collecting AWS info.", exc_info=True)

--- a/monkey/monkey_island/cc/environment/aws.py
+++ b/monkey/monkey_island/cc/environment/aws.py
@@ -9,6 +9,7 @@ __author__ = 'itay.mizeretz'
 class AwsEnvironment(Environment):
     def __init__(self):
         super(AwsEnvironment, self).__init__()
+        # Not suppressing error here on purpose. This is critical if we're on AWS env.
         self.aws_info = AwsInstance()
         self._instance_id = self._get_instance_id()
         self.region = self._get_region()

--- a/monkey/monkey_island/cc/services/remote_run_aws.py
+++ b/monkey/monkey_island/cc/services/remote_run_aws.py
@@ -1,3 +1,5 @@
+import logging
+
 from monkey_island.cc.services.config import ConfigService
 from common.cloud.aws_instance import AwsInstance
 from common.cloud.aws_service import AwsService
@@ -6,6 +8,8 @@ from common.cmd.cmd import Cmd
 from common.cmd.cmd_runner import CmdRunner
 
 __author__ = "itay.mizeretz"
+
+logger = logging.getLogger(__name__)
 
 
 class RemoteRunAwsService:
@@ -23,7 +27,15 @@ class RemoteRunAwsService:
         :return: None
         """
         if RemoteRunAwsService.aws_instance is None:
+            RemoteRunAwsService.try_init_aws_instance()
+
+    @staticmethod
+    def try_init_aws_instance():
+        # noinspection PyBroadException
+        try:
             RemoteRunAwsService.aws_instance = AwsInstance()
+        except Exception:
+            logger.error("Failed init aws instance. Exception info: ", exc_info=True)
 
     @staticmethod
     def run_aws_monkeys(instances, island_ip):
@@ -119,7 +131,7 @@ class RemoteRunAwsService:
         return r"[System.Net.ServicePointManager]::ServerCertificateValidationCallback = {" \
                r"$true}; (New-Object System.Net.WebClient).DownloadFile('https://" + island_ip + \
                r":5000/api/monkey/download/monkey-windows-" + bit_text + r".exe','.\\monkey.exe'); " \
-               r";Start-Process -FilePath '.\\monkey.exe' -ArgumentList 'm0nk3y -s " + island_ip + r":5000'; "
+                                                                         r";Start-Process -FilePath '.\\monkey.exe' -ArgumentList 'm0nk3y -s " + island_ip + r":5000'; "
 
     @staticmethod
     def _get_run_monkey_cmd_line(is_linux, is_64bit, island_ip):

--- a/monkey/monkey_island/cc/services/reporting/aws_exporter.py
+++ b/monkey/monkey_island/cc/services/reporting/aws_exporter.py
@@ -24,6 +24,7 @@ class AWSExporter(Exporter):
             logger.info('No issues were found by the monkey, no need to send anything')
             return True
 
+        # Not suppressing error here on purpose.
         current_aws_region = AwsInstance().get_region()
 
         for machine in issues_list:
@@ -70,6 +71,7 @@ class AWSExporter(Exporter):
         configured_product_arn = load_server_configuration_from_file()['aws'].get('sec_hub_product_arn', '')
         product_arn = 'arn:aws:securityhub:{region}:{arn}'.format(region=region, arn=configured_product_arn)
         instance_arn = 'arn:aws:ec2:' + str(region) + ':instance:{instance_id}'
+        # Not suppressing error here on purpose.
         account_id = AwsInstance().get_account_id()
         logger.debug("aws account id acquired: {}".format(account_id))
 

--- a/monkey/monkey_island/cc/services/reporting/exporter_init.py
+++ b/monkey/monkey_island/cc/services/reporting/exporter_init.py
@@ -22,5 +22,5 @@ def try_add_aws_exporter_to_manager(manager):
         RemoteRunAwsService.init()
         if RemoteRunAwsService.is_running_on_aws() and ('aws' == env.get_deployment()):
             manager.add_exporter_to_list(AWSExporter)
-    except Exception as err:
-        logger.error("Failed adding aws exporter to manager.", exc_info=True)
+    except Exception:
+        logger.error("Failed adding aws exporter to manager. Exception info:", exc_info=True)

--- a/monkey/monkey_island/cc/services/reporting/exporter_init.py
+++ b/monkey/monkey_island/cc/services/reporting/exporter_init.py
@@ -9,11 +9,18 @@ logger = logging.getLogger(__name__)
 
 def populate_exporter_list():
     manager = ReportExporterManager()
-    RemoteRunAwsService.init()
-    if RemoteRunAwsService.is_running_on_aws() and ('aws' == env.get_deployment()):
-        manager.add_exporter_to_list(AWSExporter)
+    try_add_aws_exporter_to_manager(manager)
 
     if len(manager.get_exporters_list()) != 0:
         logger.debug(
             "Populated exporters list with the following exporters: {0}".format(str(manager.get_exporters_list())))
 
+
+def try_add_aws_exporter_to_manager(manager):
+    # noinspection PyBroadException
+    try:
+        RemoteRunAwsService.init()
+        if RemoteRunAwsService.is_running_on_aws() and ('aws' == env.get_deployment()):
+            manager.add_exporter_to_list(AWSExporter)
+    except Exception as err:
+        logger.error("Failed adding aws exporter to manager.", exc_info=True)


### PR DESCRIPTION
# Feature / Fixes
Fixes #463 .

* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Have you successfully tested your changes locally?

* Example screenshot/log transcript of the feature working
I've added the line `raise Exception('F')` to the AwsInstance class to simulate an unknown error. 
```
2019-10-13 11:05:14,516 - environment.py:46 -   <module>() - INFO - Monkey's env is: StandardEnvironment
2019-10-13 11:05:15,276 - report_generation_synchronisation.py:9 -   <module>() - DEBUG - Initializing report generation locks.
2019-10-13 11:05:16,380 - main.py:85 - assert_mongo_db_version() - INFO - Mongo DB version OK. Got (u'4', u'1', u'0-158-g3d62f3cd37')
2019-10-13 11:05:23,743 - remote_run_aws.py:38 - try_init_aws_instance() - ERROR - Failed init aws instance. Exception info: 
Traceback (most recent call last):
  File "C:\Users\shay.nehmad\PycharmProjects\monkey\monkey\monkey_island\cc\services\remote_run_aws.py", line 36, in try_init_aws_instance
    RemoteRunAwsService.aws_instance = AwsInstance()
  File "C:\Users\shay.nehmad\PycharmProjects\monkey\monkey\common\cloud\aws_instance.py", line 23, in __init__
    raise Exception("F")
Exception: F
2019-10-13 11:05:36,701 - exporter_init.py:26 - try_add_aws_exporter_to_manager() - ERROR - Failed adding aws exporter to manager. Exception info:
Traceback (most recent call last):
  File "C:\Users\shay.nehmad\PycharmProjects\monkey\monkey\monkey_island\cc\services\reporting\exporter_init.py", line 23, in try_add_aws_exporter_to_manager
    if RemoteRunAwsService.is_running_on_aws() and ('aws' == env.get_deployment()):
  File "C:\Users\shay.nehmad\PycharmProjects\monkey\monkey\monkey_island\cc\services\remote_run_aws.py", line 58, in is_running_on_aws
    return RemoteRunAwsService.aws_instance.is_aws_instance()
AttributeError: 'NoneType' object has no attribute 'is_aws_instance'
2019-10-13 11:06:02,450 - remote_run_aws.py:38 - try_init_aws_instance() - ERROR - Failed init aws instance. Exception info: 
Traceback (most recent call last):
  File "C:\Users\shay.nehmad\PycharmProjects\monkey\monkey\monkey_island\cc\services\remote_run_aws.py", line 36, in try_init_aws_instance
    RemoteRunAwsService.aws_instance = AwsInstance()
  File "C:\Users\shay.nehmad\PycharmProjects\monkey\monkey\common\cloud\aws_instance.py", line 23, in __init__
    raise Exception("F")
Exception: F
2019-10-13 11:06:08,950 - main.py:60 - log_init_info() - INFO - Monkey Island Server is running. Listening on the following URLs: https://10.28.0.111:5000, https://10.0.0.212:5000, https://172.17.218.17:5000
[...]
```

##  Changes
  - Added exception suppression to all usages of AwsInstance except places where specifically not required (which were documented).