### PR TITLE
Added config won't change warning

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
@@ -30,7 +30,7 @@ class ConfigurePageComponent extends AuthComponent {
       lastAction: 'none',
       sections: [],
       selectedSection: 'attack',
-      allMonkeysAreDead: true,
+      monkeysRan: false,
       PBAwinFile: [],
       PBAlinuxFile: [],
       showAttackAlert: false
@@ -363,13 +363,7 @@ class ConfigurePageComponent extends AuthComponent {
     this.authFetch('/api')
       .then(res => res.json())
       .then(res => {
-        // This check is used to prevent unnecessary re-rendering
-        let allMonkeysAreDead = (!res['completed_steps']['run_monkey']) || (res['completed_steps']['infection_done']);
-        if (allMonkeysAreDead !== this.state.allMonkeysAreDead) {
-          this.setState({
-            allMonkeysAreDead: allMonkeysAreDead
-          });
-        }
+        this.setState({monkeysRan: res['completed_steps']['run_monkey']});
       });
   };
 
@@ -470,15 +464,15 @@ class ConfigurePageComponent extends AuthComponent {
     </div>)
   };
 
-  renderRunningMonkeysWarning = () => {
+  renderConfigWontChangeWarning = () => {
     return (<div>
-      {this.state.allMonkeysAreDead ?
-        '' :
+      {this.state.monkeysRan ?
         <div className="alert alert-warning">
           <i className="glyphicon glyphicon-warning-sign" style={{'marginRight': '5px'}}/>
-          Some monkeys are currently running. Note that changing the configuration will only apply to new
-          infections.
+          Changed configuration will only apply to new infections.
+          "Start over" to run again with different configuration.
         </div>
+        : ''
       }
     </div>)
   };
@@ -520,7 +514,7 @@ class ConfigurePageComponent extends AuthComponent {
         {this.renderAttackAlertModal()}
         <h1 className="page-title">Monkey Configuration</h1>
         {this.renderNav()}
-        {this.renderRunningMonkeysWarning()}
+        {this.renderConfigWontChangeWarning()}
         {content}
         <div className="text-center">
           <button type="submit" onClick={this.onSubmit} className="btn btn-success btn-lg" style={{margin: '5px'}}>


### PR DESCRIPTION
# What is this? 
Fixes #355 
Altered the warning to be displayed even after monkeys stop running. 

It's a possible scenario, that user will want to run again with more aggressive configuration after first run went fine. Now he will be noted that to change configuration he needs to "start over"

## Proof that it works
![image](https://user-images.githubusercontent.com/36815064/71248141-d8b7b600-2322-11ea-9a11-919fcb325461.png)

