### PR TITLE
Add pyinstaller hook for systeminfo plugins

### DIFF
--- a/monkey/infection_monkey/pyinstaller_hooks/hook-infection_monkey.system_info.collectors.py
+++ b/monkey/infection_monkey/pyinstaller_hooks/hook-infection_monkey.system_info.collectors.py
@@ -1,0 +1,6 @@
+from PyInstaller.utils.hooks import collect_submodules, collect_data_files
+
+# Import all actions as modules
+hiddenimports = collect_submodules('infection_monkey.system_info.collectors')
+# Add action files that we enumerate
+datas = (collect_data_files('infection_monkey.system_info.collectors', include_py_files=True))

--- a/monkey/infection_monkey/system_info/__init__.py
+++ b/monkey/infection_monkey/system_info/__init__.py
@@ -8,7 +8,7 @@ from enum import IntEnum
 from infection_monkey.network.info import get_host_subnets
 from infection_monkey.system_info.azure_cred_collector import AzureCollector
 from infection_monkey.system_info.netstat_collector import NetstatCollector
-from system_info.system_info_collectors_handler import SystemInfoCollectorsHandler
+from infection_monkey.system_info.system_info_collectors_handler import SystemInfoCollectorsHandler
 
 LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
# What is this? 
Fixes the lack of pyinstaller hooks for the new systeminfo collector plugin system.

## Checklist
* [X] Have you added an explanation of what your changes do and why you'd like to include them?
* [X] Have you successfully tested your changes locally? WIP
* [ ] Is the TravisCI build passing? 
