### PR TITLE
Fix names to match island naming conventions

### DIFF
--- a/monkey/infection_monkey/monkey.spec
+++ b/monkey/infection_monkey/monkey.spec
@@ -94,7 +94,11 @@ def get_traceroute_binaries():
 
 
 def get_monkey_filename():
-    name = 'monkey'
+    name = 'monkey-'
+    if is_windows():
+        name = name+"windows-"
+    else:
+        name = name+"linux-"
     if is_32_bit():
         name = name+"32"
     else:


### PR DESCRIPTION
Simplifying any build process out there so the binary names generated match what the Island expects.