### PR TITLE
Hotfix pyinstaller spec file - datas paths

### DIFF
--- a/monkey/infection_monkey/monkey.spec
+++ b/monkey/infection_monkey/monkey.spec
@@ -20,7 +20,7 @@ def main():
                  runtime_hooks=None,
                  binaries=None,
                  datas=[
-                    ("../common/BUILD", "../common/BUILD")
+                    ("../common/BUILD", "/common")
                  ],
                  excludes=None,
                  win_no_prefer_redirects=None,


### PR DESCRIPTION
The tuple is from source file to dst folder. https://stackoverflow.com/a/59710336/4119906

# What is this? 
Hotfix for the #543 pr.

## Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Have you successfully tested your changes locally?
* [x] Is the TravisCI build passing? 

## Proof that it works
![image](https://user-images.githubusercontent.com/48879847/75629051-6fd4a000-5be7-11ea-838b-9e9b5348847d.png)
