### PR TITLE
dev-setup: Fix minor issues in dev-setup readme

### DIFF
--- a/monkey/infection_monkey/readme.md
+++ b/monkey/infection_monkey/readme.md
@@ -55,11 +55,11 @@ Tested on Ubuntu 16.04.
 
 3. Build Sambacry binaries
     - Build/Download according to sections at the end of this readme.
-    - Place the binaries under [code location]\infection_monkey\bin, under the names 'sc_monkey_runner32.so', 'sc_monkey_runner64.so'
+    - Place the binaries under [code location]/infection_monkey/bin, under the names 'sc_monkey_runner32.so', 'sc_monkey_runner64.so'
 
 4. Build Traceroute binaries
     - Build/Download according to sections at the end of this readme.
-    - Place the binaries under [code location]\infection_monkey\bin, under the names 'traceroute32', 'traceroute64'
+    - Place the binaries under [code location]/infection_monkey/bin, under the names 'traceroute32', 'traceroute64'
 
 5. To build, run in terminal:
     - `cd [code location]/infection_monkey`

--- a/monkey/monkey_island/readme.md
+++ b/monkey/monkey_island/readme.md
@@ -103,4 +103,4 @@
 
 #### How to run
 
-1. When your current working directory is monkey, run ./monkey_island/linux/run.sh (located under /linux)
+1. When your current working directory is monkey, run `chmod 755 ./monkey_island/linux/run.sh` followed by `./monkey_island/linux/run.sh` (located under /linux)


### PR DESCRIPTION
This PR sets replaces windows style path separator with linux style path separator for linux dev setup guide. It also adds chmod command for ./monkey_island/linux/run.sh in  monkey_island/readme.md

Closes https://github.com/guardicore/monkey/issues/561

# What is this? 
Fixes https://github.com/guardicore/monkey/issues/561

Add any further explanations here. 

## Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Have you successfully tested your changes locally?
* [ ] Is the TravisCI build passing? 

## Proof that it works
If applicable, add screenshots or log transcripts of the feature working

## Changes
Are the commit messages enough? If not, elaborate. 
