### PR TITLE
install_mongo.sh: Add entry for ubuntu 19.10

### DIFF
--- a/monkey/monkey_island/linux/install_mongo.sh
+++ b/monkey/monkey_island/linux/install_mongo.sh
@@ -14,6 +14,9 @@ if [[ ${os_version_monkey} == "Ubuntu 16.04"* ]]; then
 elif [[ ${os_version_monkey} == "Ubuntu 18.04"* ]]; then
   echo Detected Ubuntu 18.04
   export tgz_url="https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.2.3.tgz"
+elif [[ ${os_version_monkey} == "Ubuntu 19.10"* ]]; then
+  echo Detected Ubuntu 19.10
+  export tgz_url="https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.2.3.tgz"
 elif [[ ${os_version_monkey} == "Debian GNU/Linux 8"* ]]; then
   echo Detected Debian 8
   export tgz_url="https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian81-4.0.16.tgz"


### PR DESCRIPTION
This PR adds entry for ubuntu 19.10. mongodb does not provide the download for 19.10 version yet. But the 18.04 version download works fine. The entry will have to be replaced if and when the mongodb download for 19.10 becomes available

Closes https://github.com/guardicore/monkey/issues/563

# What is this? 
Fixes https://github.com/guardicore/monkey/issues/563

Add any further explanations here. 

## Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Have you successfully tested your changes locally?
* [ ] Is the TravisCI build passing? 

## Proof that it works
If applicable, add screenshots or log transcripts of the feature working

## Changes
Are the commit messages enough? If not, elaborate. 
