### PR TITLE
Autoscroll to last line in telemetry console

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/pages/MapPage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/MapPage.js
@@ -20,6 +20,7 @@ class MapPageComponent extends AuthComponent {
       telemetry: [],
       telemetryLastTimestamp: null
     };
+    this.telemConsole = React.createRef();
   }
 
   events = {
@@ -66,8 +67,8 @@ class MapPageComponent extends AuthComponent {
               telemetry: newTelem,
               telemetryLastTimestamp: res['timestamp']
             });
-            var telemConsole = document.querySelector('div.telemetry-console');
-            telemConsole.scrollTop = telemConsole.scrollHeight - telemConsole.clientHeight
+          var telemConsoleRef = this.telemConsole.current;
+          telemConsoleRef.scrollTop = telemConsoleRef.scrollHeight - telemConsoleRef.clientHeight
           this.props.onStatusChange();
         }
       });
@@ -142,7 +143,7 @@ class MapPageComponent extends AuthComponent {
 
   renderTelemetryConsole() {
     return (
-      <div className="telemetry-console">
+      <div className="telemetry-console" ref={this.telemConsole}>
         {
           this.state.telemetry.map(this.renderTelemetryEntry)
         }

--- a/monkey/monkey_island/cc/ui/src/components/pages/MapPage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/MapPage.js
@@ -66,6 +66,8 @@ class MapPageComponent extends AuthComponent {
               telemetry: newTelem,
               telemetryLastTimestamp: res['timestamp']
             });
+            var telemConsole = document.querySelector('div.telemetry-console');
+            telemConsole.scrollTop = telemConsole.scrollHeight - telemConsole.clientHeight
           this.props.onStatusChange();
         }
       });

--- a/monkey/monkey_island/cc/ui/src/components/pages/MapPage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/MapPage.js
@@ -18,9 +18,12 @@ class MapPageComponent extends AuthComponent {
       killPressed: false,
       showKillDialog: false,
       telemetry: [],
-      telemetryLastTimestamp: null
+      telemetryLastTimestamp: null,
+      movedTop: false,
     };
     this.telemConsole = React.createRef();
+    this.handleScroll = this.handleScroll.bind(this);
+    this.scrollTop = 0;
   }
 
   events = {
@@ -67,9 +70,13 @@ class MapPageComponent extends AuthComponent {
               telemetry: newTelem,
               telemetryLastTimestamp: res['timestamp']
             });
-          var telemConsoleRef = this.telemConsole.current;
-          telemConsoleRef.scrollTop = telemConsoleRef.scrollHeight - telemConsoleRef.clientHeight
           this.props.onStatusChange();
+
+          let telemConsoleRef = this.telemConsole.current;
+          if(!this.state.movedTop){
+            telemConsoleRef.scrollTop = telemConsoleRef.scrollHeight - telemConsoleRef.clientHeight;
+            this.scrollTop = telemConsoleRef.scrollTop;
+          }
         }
       });
   };
@@ -141,9 +148,20 @@ class MapPageComponent extends AuthComponent {
     );
   }
 
+  handleScroll(e){
+
+    let element = e.target;
+    if(element.scrollTop < this.scrollTop){
+      this.setState({movedTop: true});
+    }else{
+      this.setState({movedTop: false});
+    }
+
+  }
+
   renderTelemetryConsole() {
     return (
-      <div className="telemetry-console" ref={this.telemConsole}>
+      <div className="telemetry-console" onScroll={this.handleScroll} ref={this.telemConsole}>
         {
           this.state.telemetry.map(this.renderTelemetryEntry)
         }

--- a/monkey/monkey_island/cc/ui/src/components/pages/MapPage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/MapPage.js
@@ -19,7 +19,7 @@ class MapPageComponent extends AuthComponent {
       showKillDialog: false,
       telemetry: [],
       telemetryLastTimestamp: null,
-      movedTop: false,
+      isScrolledUp: false,
     };
     this.telemConsole = React.createRef();
     this.handleScroll = this.handleScroll.bind(this);
@@ -73,7 +73,7 @@ class MapPageComponent extends AuthComponent {
           this.props.onStatusChange();
 
           let telemConsoleRef = this.telemConsole.current;
-          if(!this.state.movedTop){
+          if (!this.state.isScrolledUp) {
             telemConsoleRef.scrollTop = telemConsoleRef.scrollHeight - telemConsoleRef.clientHeight;
             this.scrollTop = telemConsoleRef.scrollTop;
           }
@@ -148,15 +148,13 @@ class MapPageComponent extends AuthComponent {
     );
   }
 
-  handleScroll(e){
-
+  handleScroll(e) {
     let element = e.target;
-    if(element.scrollTop < this.scrollTop){
-      this.setState({movedTop: true});
-    }else{
-      this.setState({movedTop: false});
+    if (element.scrollTop < this.scrollTop) {
+      this.setState({isScrolledUp: true});
+    } else {
+      this.setState({isScrolledUp: false});
     }
-
   }
 
   renderTelemetryConsole() {

--- a/monkey/monkey_island/cc/ui/src/components/pages/MapPage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/MapPage.js
@@ -20,6 +20,8 @@ class MapPageComponent extends AuthComponent {
       telemetry: [],
       telemetryLastTimestamp: null,
       isScrolledUp: false,
+      telemetryLines: 0,
+      telemetryCurrentLine: 0,
     };
     this.telemConsole = React.createRef();
     this.handleScroll = this.handleScroll.bind(this);
@@ -64,15 +66,16 @@ class MapPageComponent extends AuthComponent {
       .then(res => {
         if ('telemetries' in res) {
           let newTelem = this.state.telemetry.concat(res['telemetries']);
+          let telemConsoleRef = this.telemConsole.current;
 
           this.setState(
             {
               telemetry: newTelem,
-              telemetryLastTimestamp: res['timestamp']
+              telemetryLastTimestamp: res['timestamp'],
+              telemetryLines: telemConsoleRef.scrollHeight,
             });
           this.props.onStatusChange();
 
-          let telemConsoleRef = this.telemConsole.current;
           if (!this.state.isScrolledUp) {
             telemConsoleRef.scrollTop = telemConsoleRef.scrollHeight - telemConsoleRef.clientHeight;
             this.scrollTop = telemConsoleRef.scrollTop;
@@ -151,9 +154,9 @@ class MapPageComponent extends AuthComponent {
   handleScroll(e) {
     let element = e.target;
     if (element.scrollTop < this.scrollTop) {
-      this.setState({isScrolledUp: true});
+      this.setState({isScrolledUp: true, telemetryCurrentLine: element.scrollTop});
     } else {
-      this.setState({isScrolledUp: false});
+      this.setState({isScrolledUp: false, telemetryCurrentLine: element.scrollTop});
     }
   }
 
@@ -163,6 +166,14 @@ class MapPageComponent extends AuthComponent {
         {
           this.state.telemetry.map(this.renderTelemetryEntry)
         }
+      </div>
+    );
+  }
+
+  renderTelemetryLineCount() {
+    return (
+      <div className="telemetry-lines">
+        <b>[{this.state.telemetryCurrentLine}/{this.state.telemetryLines}]</b>
       </div>
     );
   }
@@ -189,6 +200,7 @@ class MapPageComponent extends AuthComponent {
           <div style={{height: '80vh'}}>
             <ReactiveGraph graph={this.state.graph} options={options} events={this.events}/>
           </div>
+          {this.renderTelemetryLineCount()}
         </Col>
         <Col xs={4}>
           <input className="form-control input-block"

--- a/monkey/monkey_island/cc/ui/src/components/pages/MapPage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/MapPage.js
@@ -156,17 +156,18 @@ class MapPageComponent extends AuthComponent {
     let telemetryStyle = window.getComputedStyle(element)
     let telemetryLineHeight = parseInt((telemetryStyle.lineHeight).replace('px', ''))
 
+    this.setState({
+      telemetryCurrentLine: parseInt(element.scrollTop/telemetryLineHeight)+1,
+      telemetryLines: parseInt(element.scrollHeight/telemetryLineHeight),
+    });
+
     if (element.scrollTop < this.scrollTop) {
       this.setState({
         isScrolledUp: true,
-        telemetryCurrentLine: parseInt(element.scrollTop/telemetryLineHeight)+1,
-        telemetryLines: parseInt(element.scrollHeight/telemetryLineHeight),
       });
     } else {
       this.setState({
         isScrolledUp: false,
-        telemetryCurrentLine: parseInt(element.scrollTop/telemetryLineHeight)+1,
-        telemetryLines: parseInt(element.scrollHeight/telemetryLineHeight),
       });
     }
   }

--- a/monkey/monkey_island/cc/ui/src/components/pages/MapPage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/MapPage.js
@@ -21,7 +21,7 @@ class MapPageComponent extends AuthComponent {
       telemetryLastTimestamp: null,
       isScrolledUp: false,
       telemetryLines: 0,
-      telemetryCurrentLine: 0,
+      telemetryCurrentLine: 0
     };
     this.telemConsole = React.createRef();
     this.handleScroll = this.handleScroll.bind(this);
@@ -158,16 +158,16 @@ class MapPageComponent extends AuthComponent {
 
     this.setState({
       telemetryCurrentLine: parseInt(element.scrollTop/telemetryLineHeight)+1,
-      telemetryLines: parseInt(element.scrollHeight/telemetryLineHeight),
+      telemetryLines: parseInt(element.scrollHeight/telemetryLineHeight)
     });
 
     if (element.scrollTop < this.scrollTop) {
       this.setState({
-        isScrolledUp: true,
+        isScrolledUp: true
       });
     } else {
       this.setState({
-        isScrolledUp: false,
+        isScrolledUp: false
       });
     }
   }

--- a/monkey/monkey_island/cc/ui/src/components/pages/MapPage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/MapPage.js
@@ -66,16 +66,15 @@ class MapPageComponent extends AuthComponent {
       .then(res => {
         if ('telemetries' in res) {
           let newTelem = this.state.telemetry.concat(res['telemetries']);
-          let telemConsoleRef = this.telemConsole.current;
 
           this.setState(
             {
               telemetry: newTelem,
-              telemetryLastTimestamp: res['timestamp'],
-              telemetryLines: telemConsoleRef.scrollHeight,
+              telemetryLastTimestamp: res['timestamp']
             });
           this.props.onStatusChange();
 
+          let telemConsoleRef = this.telemConsole.current;
           if (!this.state.isScrolledUp) {
             telemConsoleRef.scrollTop = telemConsoleRef.scrollHeight - telemConsoleRef.clientHeight;
             this.scrollTop = telemConsoleRef.scrollTop;
@@ -153,10 +152,22 @@ class MapPageComponent extends AuthComponent {
 
   handleScroll(e) {
     let element = e.target;
+
+    let telemetryStyle = window.getComputedStyle(element)
+    let telemetryLineHeight = parseInt((telemetryStyle.lineHeight).replace('px', ''))
+
     if (element.scrollTop < this.scrollTop) {
-      this.setState({isScrolledUp: true, telemetryCurrentLine: element.scrollTop});
+      this.setState({
+        isScrolledUp: true,
+        telemetryCurrentLine: parseInt(element.scrollTop/telemetryLineHeight)+1,
+        telemetryLines: parseInt(element.scrollHeight/telemetryLineHeight),
+      });
     } else {
-      this.setState({isScrolledUp: false, telemetryCurrentLine: element.scrollTop});
+      this.setState({
+        isScrolledUp: false,
+        telemetryCurrentLine: parseInt(element.scrollTop/telemetryLineHeight)+1,
+        telemetryLines: parseInt(element.scrollHeight/telemetryLineHeight),
+      });
     }
   }
 

--- a/monkey/monkey_island/cc/ui/src/components/pages/MapPage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/MapPage.js
@@ -157,19 +157,10 @@ class MapPageComponent extends AuthComponent {
     let telemetryLineHeight = parseInt((telemetryStyle.lineHeight).replace('px', ''))
 
     this.setState({
+      isScrolledUp: !!(element.scrollTop < this.scrollTop),
       telemetryCurrentLine: parseInt(element.scrollTop/telemetryLineHeight)+1,
       telemetryLines: parseInt(element.scrollHeight/telemetryLineHeight)
     });
-
-    if (element.scrollTop < this.scrollTop) {
-      this.setState({
-        isScrolledUp: true
-      });
-    } else {
-      this.setState({
-        isScrolledUp: false
-      });
-    }
   }
 
   renderTelemetryConsole() {

--- a/monkey/monkey_island/cc/ui/src/components/pages/MapPage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/MapPage.js
@@ -153,13 +153,13 @@ class MapPageComponent extends AuthComponent {
   handleScroll(e) {
     let element = e.target;
 
-    let telemetryStyle = window.getComputedStyle(element)
-    let telemetryLineHeight = parseInt((telemetryStyle.lineHeight).replace('px', ''))
+    let telemetryStyle = window.getComputedStyle(element);
+    let telemetryLineHeight = parseInt((telemetryStyle.lineHeight).replace('px', ''));
 
     this.setState({
-      isScrolledUp: !!(element.scrollTop < this.scrollTop),
-      telemetryCurrentLine: parseInt(element.scrollTop/telemetryLineHeight)+1,
-      telemetryLines: parseInt(element.scrollHeight/telemetryLineHeight)
+      isScrolledUp: (element.scrollTop < this.scrollTop),
+      telemetryCurrentLine: Math.trunc(element.scrollTop/telemetryLineHeight)+1,
+      telemetryLines: Math.trunc(element.scrollHeight/telemetryLineHeight)
     });
   }
 

--- a/monkey/monkey_island/cc/ui/src/styles/App.css
+++ b/monkey/monkey_island/cc/ui/src/styles/App.css
@@ -325,8 +325,14 @@ body {
 }
 
 .telemetry-lines {
+  z-index: 3;
   position: absolute;
-  right: 0;
+  bottom: 103px;
+  right: 20px;
+  background: black;
+  border-radius: 2px;
+  padding: 1px;
+  color: white;
 }
 
 .map-legend {

--- a/monkey/monkey_island/cc/ui/src/styles/App.css
+++ b/monkey/monkey_island/cc/ui/src/styles/App.css
@@ -324,6 +324,11 @@ body {
   font-weight: bold;
 }
 
+.telemetry-lines {
+  position: absolute;
+  right: 0;
+}
+
 .map-legend {
   font-size: 18px;
 }

--- a/monkey/monkey_island/cc/ui/src/styles/App.css
+++ b/monkey/monkey_island/cc/ui/src/styles/App.css
@@ -329,8 +329,8 @@ body {
   position: absolute;
   bottom: 103px;
   right: 20px;
-  background: black;
-  border-radius: 2px;
+  background: #000000cc;
+  border-radius: 5px;
   padding: 1px;
   color: white;
 }
@@ -593,4 +593,3 @@ body {
   margin-left: auto;
   margin-right: auto;
 }
-


### PR DESCRIPTION
Fixes #538 

Currently, the telemetry console stays at the top even when there are updates. Seeing the new content requires user action.

This makes sure that it scrolls to the last line when there are new updates.

TODO:
1. don't scroll if the user has scrolled up
2. show line number
