### PR TITLE
Map create user PBA to ATT&CK matrix

### DIFF
--- a/monkey/monkey_island/cc/services/attack/attack_report.py
+++ b/monkey/monkey_island/cc/services/attack/attack_report.py
@@ -3,7 +3,7 @@ import logging
 from monkey_island.cc.models import Monkey
 from monkey_island.cc.services.attack.technique_reports import T1210, T1197, T1110, T1075, T1003, T1059, T1086, T1082
 from monkey_island.cc.services.attack.technique_reports import T1145, T1105, T1065, T1035, T1129, T1106, T1107, T1188
-from monkey_island.cc.services.attack.technique_reports import T1090, T1041, T1222, T1005, T1018, T1016, T1021, T1064
+from monkey_island.cc.services.attack.technique_reports import T1090, T1041, T1222, T1005, T1018, T1016, T1021, T1064, T1136
 from monkey_island.cc.services.attack.attack_config import AttackConfig
 from monkey_island.cc.database import mongo
 from monkey_island.cc.services.reporting.report_generation_synchronisation import safe_generate_attack_report
@@ -35,7 +35,8 @@ TECHNIQUES = {'T1210': T1210.T1210,
               'T1018': T1018.T1018,
               'T1016': T1016.T1016,
               'T1021': T1021.T1021,
-              'T1064': T1064.T1064
+              'T1064': T1064.T1064,
+              'T1136': T1136.T1136
               }
 
 REPORT_NAME = 'new_report'

--- a/monkey/monkey_island/cc/services/attack/attack_report.py
+++ b/monkey/monkey_island/cc/services/attack/attack_report.py
@@ -3,7 +3,8 @@ import logging
 from monkey_island.cc.models import Monkey
 from monkey_island.cc.services.attack.technique_reports import T1210, T1197, T1110, T1075, T1003, T1059, T1086, T1082
 from monkey_island.cc.services.attack.technique_reports import T1145, T1105, T1065, T1035, T1129, T1106, T1107, T1188
-from monkey_island.cc.services.attack.technique_reports import T1090, T1041, T1222, T1005, T1018, T1016, T1021, T1064, T1136
+from monkey_island.cc.services.attack.technique_reports import T1090, T1041, T1222, T1005, T1018, T1016, T1021, T1064
+from monkey_island.cc.services.attack.technique_reports import T1136
 from monkey_island.cc.services.attack.attack_config import AttackConfig
 from monkey_island.cc.database import mongo
 from monkey_island.cc.services.reporting.report_generation_synchronisation import safe_generate_attack_report

--- a/monkey/monkey_island/cc/services/attack/attack_schema.py
+++ b/monkey/monkey_island/cc/services/attack/attack_schema.py
@@ -289,6 +289,22 @@ SCHEMA = {
                     "description": "Data exfiltration is performed over the Command and Control channel."
                 }
             }
+        },
+        "persistence": {
+            "title": "Persistence",
+            "type": "object",
+            "link": "https://attack.mitre.org/tactics/TA0003/",
+            "properties": {
+                "T1136": {
+                    "title": "Create account",
+                    "type": "bool",
+                    "value": True,
+                    "necessary": False,
+                    "link": "https://attack.mitre.org/techniques/T1136",
+                    "description": "Adversaries with a sufficient level of access "
+                                    "may create a local system, domain, or cloud tenant account."
+                }
+            }
         }
     }
 }

--- a/monkey/monkey_island/cc/services/attack/technique_reports/T1136.py
+++ b/monkey/monkey_island/cc/services/attack/technique_reports/T1136.py
@@ -3,14 +3,14 @@ from monkey_island.cc.services.reporting.report import ReportService
 from common.utils.attack_utils import ScanStatus
 from monkey_island.cc.models import Monkey
 
-__author__ = "VakarisZ"
+__author__ = "shreyamalviya"
 
 
 class T1136(AttackTechnique):
     tech_id = "T1136"
-    unscanned_msg = "Monkey didn't try creating a new user."
+    unscanned_msg = "Monkey didn't try creating a new user on the network's systems."
     scanned_msg = ""
-    used_msg = "Monkey created a new user."
+    used_msg = "Monkey created a new user on the network's systems."
 
     @staticmethod
     def get_report_data():

--- a/monkey/monkey_island/cc/services/attack/technique_reports/T1136.py
+++ b/monkey/monkey_island/cc/services/attack/technique_reports/T1136.py
@@ -1,0 +1,36 @@
+from monkey_island.cc.services.attack.technique_reports import AttackTechnique
+from monkey_island.cc.services.reporting.report import ReportService
+from common.utils.attack_utils import ScanStatus
+from monkey_island.cc.models import Monkey
+
+__author__ = "VakarisZ"
+
+
+class T1136(AttackTechnique):
+    tech_id = "T1136"
+    unscanned_msg = "Monkey didn't try creating a new user."
+    scanned_msg = ""
+    used_msg = "Monkey created a new user."
+
+    @staticmethod
+    def get_report_data():
+        data = {'title': T1136.technique_title()}
+
+        scanned_nodes = ReportService.get_scanned()
+        status = ScanStatus.UNSCANNED.value
+        for node in scanned_nodes:
+            if node['pba_results'] != 'None':
+                for pba in node['pba_results']:
+                    if pba['name'] == 'Backdoor user':
+                        status = ScanStatus.USED.value
+                        data.update({
+                            'info': [{
+                                'machine': {
+                                    'hostname': pba['hostname'],
+                                    'ips': node['ip_addresses'],
+                                },
+                                'result': pba['result'][0]
+                            }]
+                        })
+            data.update(T1136.get_message_and_status(status))
+        return data

--- a/monkey/monkey_island/cc/services/config_schema.py
+++ b/monkey/monkey_island/cc/services/config_schema.py
@@ -158,7 +158,7 @@ SCHEMA = {
                         "CommunicateAsNewUser"
                     ],
                     "title": "Communicate as new user",
-                    "attack_techniques": []
+                    "attack_techniques": ["T1136"]
                 },
             ],
         },

--- a/monkey/monkey_island/cc/services/config_schema.py
+++ b/monkey/monkey_island/cc/services/config_schema.py
@@ -150,7 +150,7 @@ SCHEMA = {
                         "BackdoorUser"
                     ],
                     "title": "Back door user",
-                    "attack_techniques": []
+                    "attack_techniques": ["T1136"]
                 },
                 {
                     "type": "string",
@@ -378,6 +378,7 @@ SCHEMA = {
                                 "$ref": "#/definitions/post_breach_acts"
                             },
                             "default": [
+                                "BackdoorUser",
                                 "CommunicateAsNewUser"
                             ],
                             "description": "List of actions the Monkey will run post breach"

--- a/monkey/monkey_island/cc/services/config_schema.py
+++ b/monkey/monkey_island/cc/services/config_schema.py
@@ -140,7 +140,7 @@ SCHEMA = {
                 },
             ],
         },
-        "post_breach_acts": {
+        "post_breach_actions": {
             "title": "Post breach actions",
             "type": "string",
             "anyOf": [
@@ -375,7 +375,7 @@ SCHEMA = {
                             "type": "array",
                             "uniqueItems": True,
                             "items": {
-                                "$ref": "#/definitions/post_breach_acts"
+                                "$ref": "#/definitions/post_breach_actions"
                             },
                             "default": [
                                 "BackdoorUser",

--- a/monkey/monkey_island/cc/ui/src/components/attack/techniques/T1136.js
+++ b/monkey/monkey_island/cc/ui/src/components/attack/techniques/T1136.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import ReactTable from 'react-table';
+import {renderMachineFromSystemData, ScanStatus} from './Helpers'
+
+class T1136 extends React.Component {
+
+  constructor(props) {
+    super(props);
+  }
+
+  static getColumns() {
+      return ([{
+        columns: [
+            { Header: 'Machine',
+              id: 'machine',
+              accessor: x => renderMachineFromSystemData(x.machine),
+              style: {'whiteSpace': 'unset'}},
+            { Header: 'Result',
+              id: 'result',
+              accessor: x => x.result,
+              style: {'whiteSpace': 'unset'}}
+          ]
+      }])
+  }
+
+  render() {
+    return (
+      <div>
+        <div>{this.props.data.message}</div>
+        <br/>
+        {this.props.data.status === ScanStatus.USED ?
+          <ReactTable
+            columns={T1136.getColumns()}
+            data={this.props.data.info}
+            showPagination={false}
+            defaultPageSize={this.props.data.info.length}
+          /> : ''}
+      </div>
+    );
+  }
+}
+
+export default T1136;

--- a/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
@@ -217,19 +217,6 @@ class ConfigurePageComponent extends AuthComponent {
   updateConfigSection = () => {
     let newConfig = this.state.configuration;
     if (Object.keys(this.currentFormData).length > 0) {
-
-      if (this.currentSection == 'monkey') {
-        let tempMatrix = this.state.attackConfig;
-        if (this.currentFormData['general']['post_breach_actions'].includes('BackdoorUser')) {
-          tempMatrix['persistence'].properties['T1136'].value = true;
-        }
-        else {
-          tempMatrix['persistence'].properties['T1136'].value = false;
-        }
-        this.setState({attackConfig: tempMatrix});
-        this.matrixSubmit();
-      }
-
       newConfig[this.currentSection] = this.currentFormData;
       this.currentFormData = {};
     }

--- a/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
@@ -180,6 +180,7 @@ class ConfigurePageComponent extends AuthComponent {
       if (techType[1].properties.hasOwnProperty(technique)) {
         let tempMatrix = this.state.attackConfig;
         tempMatrix[techType[0]].properties[technique].value = value;
+        this.setState({attackConfig: tempMatrix});
 
         // Toggle all mapped techniques
         if (!mapped) {

--- a/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
@@ -181,19 +181,6 @@ class ConfigurePageComponent extends AuthComponent {
         let tempMatrix = this.state.attackConfig;
         tempMatrix[techType[0]].properties[technique].value = value;
 
-        if (technique == 'T1136') {
-          let newConfig = this.state.configuration;
-          if (value && !newConfig['monkey']['general']['post_breach_actions'].includes('BackdoorUser')) {
-              newConfig['monkey']['general']['post_breach_actions'].push('BackdoorUser');
-            }
-          else if (!value && newConfig['monkey']['general']['post_breach_actions'].includes('BackdoorUser')) {
-              let toRemoveIndex = newConfig['monkey']['general']['post_breach_actions'].indexOf('BackdoorUser');
-              newConfig['monkey']['general']['post_breach_actions'].splice(toRemoveIndex, 1);
-            }
-          this.setState({attackConfig: tempMatrix, configuration: newConfig});
-          this.configSubmit();
-      }
-
         // Toggle all mapped techniques
         if (!mapped) {
           // Loop trough each column and each row

--- a/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
@@ -180,7 +180,19 @@ class ConfigurePageComponent extends AuthComponent {
       if (techType[1].properties.hasOwnProperty(technique)) {
         let tempMatrix = this.state.attackConfig;
         tempMatrix[techType[0]].properties[technique].value = value;
-        this.setState({attackConfig: tempMatrix});
+
+        if (technique == 'T1136') {
+          let newConfig = this.state.configuration;
+          if (value && !newConfig['monkey']['general']['post_breach_actions'].includes('BackdoorUser')) {
+              newConfig['monkey']['general']['post_breach_actions'].push('BackdoorUser');
+            }
+          else if (!value && newConfig['monkey']['general']['post_breach_actions'].includes('BackdoorUser')) {
+              let toRemoveIndex = newConfig['monkey']['general']['post_breach_actions'].indexOf('BackdoorUser');
+              newConfig['monkey']['general']['post_breach_actions'].splice(toRemoveIndex, 1);
+            }
+          this.setState({attackConfig: tempMatrix, configuration: newConfig});
+          this.configSubmit();
+      }
 
         // Toggle all mapped techniques
         if (!mapped) {
@@ -205,6 +217,19 @@ class ConfigurePageComponent extends AuthComponent {
   updateConfigSection = () => {
     let newConfig = this.state.configuration;
     if (Object.keys(this.currentFormData).length > 0) {
+
+      if (this.currentSection == 'monkey') {
+        let tempMatrix = this.state.attackConfig;
+        if (this.currentFormData['general']['post_breach_actions'].includes('BackdoorUser')) {
+          tempMatrix['persistence'].properties['T1136'].value = true;
+        }
+        else {
+          tempMatrix['persistence'].properties['T1136'].value = false;
+        }
+        this.setState({attackConfig: tempMatrix});
+        this.matrixSubmit();
+      }
+
       newConfig[this.currentSection] = this.currentFormData;
       this.currentFormData = {};
     }


### PR DESCRIPTION
Fixes #579 

~Implemented changes 1, 2, 4 from the following (mentioned in the issue):~
Implemented all changes mentioned in the issue:
> Let's add this PBA to the matrix as Create Account attack technique.
>1. The "Create Account" technique should be present in attack matrix and user should be able to toggle it.
>2. On hover a brief with information about this particular attack technique should appear.
>3. This technique should be mapped with "Back door user" post breach action. This means that when "Create Account" is turned off, "Back door user" should turn off and vice versa.
>4. After exploitation, "Create Account" technique should be present on the ATT&CK report page.

~TODO: 3~