### PR TITLE
Bootlaoder reliability

### DIFF
--- a/monkey/monkey_island/cc/services/bootloader.py
+++ b/monkey/monkey_island/cc/services/bootloader.py
@@ -17,7 +17,7 @@ class BootloaderService:
             telem['os_version'] = "Unknown OS"
 
         telem_id = BootloaderService.get_mongo_id_for_bootloader_telem(telem)
-        mongo.db.bootloader_telems.update({'_id': telem_id}, telem, upsert=True)
+        mongo.db.bootloader_telems.update({'_id': telem_id}, {'$setOnInsert': telem}, upsert=True)
 
         will_monkey_run = BootloaderService.is_os_compatible(telem)
         try:


### PR DESCRIPTION
Pyinstaller seems to launch bootloader two times. The second launch seems to error on command launching function/functions and thus gives less information about the machine.
Changes code to only store the first bootloader telem instead of overriding it with the incomplete second one.
