### PR TITLE
Python 3 hashing requires bytes, not string

### DIFF
--- a/monkey/common/version.py
+++ b/monkey/common/version.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 MAJOR = "1"
 MINOR = "8"
-PATCH = "0"
+PATCH = "1"
 build_file_path = Path(__file__).parent.joinpath("BUILD")
 with open(build_file_path, "r") as build_file:
     BUILD = build_file.read()

--- a/monkey/monkey_island/cc/environment/__init__.py
+++ b/monkey/monkey_island/cc/environment/__init__.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta, abstractmethod
 from datetime import timedelta
 import os
-from Crypto.Hash import SHA3_512
+import hashlib
 
 __author__ = 'itay.mizeretz'
 
@@ -45,10 +45,11 @@ class Environment(object, metaclass=ABCMeta):
     def get_auth_expiration_time(self):
         return self._AUTH_EXPIRATION_TIME
 
-    def hash_secret(self, secret):
-        h = SHA3_512.new()
-        h.update(secret)
-        return h.hexdigest()
+    @staticmethod
+    def hash_secret(secret):
+        hash_obj = hashlib.sha3_512()
+        hash_obj.update(secret.encode('utf-8'))
+        return hash_obj.hexdigest()
 
     def get_deployment(self):
         return self._get_from_config('deployment', 'unknown')

--- a/monkey/monkey_island/cc/environment/test_aws.py
+++ b/monkey/monkey_island/cc/environment/test_aws.py
@@ -1,0 +1,26 @@
+from monkey_island.cc.auth import User
+from monkey_island.cc.testing.IslandTestCase import IslandTestCase
+from monkey_island.cc.environment.aws import AwsEnvironment
+
+import hashlib
+
+
+class TestAwsEnvironment(IslandTestCase):
+    def test_get_auth_users(self):
+        env = AwsEnvironment()
+        # This is "injecting" the instance id to the env. This is the UTs aren't always executed on the same AWS machine
+        # (might not be an AWS machine at all). Perhaps it would have been more elegant to create a Mock, but not worth it for
+        # this small test.
+        env._instance_id = "i-666"
+        hash_obj = hashlib.sha3_512()
+        hash_obj.update(b"i-666")
+        auth_users = env.get_auth_users()
+        assert isinstance(auth_users, list)
+        assert len(auth_users) == 1
+        auth_user = auth_users[0]
+        assert isinstance(auth_user, User)
+        assert auth_user.id == 1
+        assert auth_user.username == "monkey"
+        assert auth_user.secret == hash_obj.hexdigest()
+
+


### PR DESCRIPTION
# What is this? 
Fix encoding bug in AWS env secret hashing

## Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Have you successfully tested your changes locally?
* [x] Is the TravisCI build passing? 

## Proof that it works
![image](https://user-images.githubusercontent.com/48879847/80494643-9016a600-896f-11ea-94d0-b1985b9e6f04.png)

## Changes
Commit messages.