### PR TITLE
SMB vulnerable port fix

### DIFF
--- a/envs/monkey_zoo/blackbox/README.md
+++ b/envs/monkey_zoo/blackbox/README.md
@@ -25,6 +25,9 @@ Configure a PyTest configuration with the additional arguments `-s --island=35.2
 `monkey\envs\monkey_zoo\blackbox`.
 
 ### Running telemetry performance test
+
+**Before running performance test make sure browser is not sending requests to island!** 
+
 To run telemetry performance test follow these steps:
 1. Gather monkey telemetries.
     1. Enable "Export monkey telemetries" in Configuration -> Internal -> Tests if you don't have 

--- a/envs/monkey_zoo/blackbox/tests/performance/endpoint_performance_test.py
+++ b/envs/monkey_zoo/blackbox/tests/performance/endpoint_performance_test.py
@@ -18,9 +18,9 @@ class EndpointPerformanceTest(BasicTest):
 
     def run(self) -> bool:
         # Collect timings for all pages
-        self.island_client.clear_caches()
         endpoint_timings = {}
         for endpoint in self.test_config.endpoints_to_test:
+            self.island_client.clear_caches()
             endpoint_timings[endpoint] = self.island_client.requests.get_request_time(endpoint,
                                                                                       SupportedRequestMethod.GET)
         analyzer = PerformanceAnalyzer(self.test_config, endpoint_timings)

--- a/envs/monkey_zoo/blackbox/tests/performance/telemetry_performance_test_workflow.py
+++ b/envs/monkey_zoo/blackbox/tests/performance/telemetry_performance_test_workflow.py
@@ -15,7 +15,9 @@ class TelemetryPerformanceTestWorkflow(BasicTest):
     def run(self):
         try:
             if not self.quick_performance_test:
-                TelemetryPerformanceTest(island_client=self.island_client).test_telemetry_performance()
+                telem_sending_test = TelemetryPerformanceTest(island_client=self.island_client,
+                                                              quick_performance_test=self.quick_performance_test)
+                telem_sending_test.test_telemetry_performance()
             performance_test = EndpointPerformanceTest(self.name, self.performance_config, self.island_client)
             assert performance_test.run()
         finally:

--- a/monkey/infection_monkey/exploit/smbexec.py
+++ b/monkey/infection_monkey/exploit/smbexec.py
@@ -169,3 +169,5 @@ class SmbExploiter(HostExploiter):
             self.vulnerable_port = "445"
         elif 'tcp-139' in self.host.services:
             self.vulnerable_port = "139"
+        else:
+            self.vulnerable_port = None

--- a/monkey/infection_monkey/exploit/smbexec.py
+++ b/monkey/infection_monkey/exploit/smbexec.py
@@ -6,7 +6,7 @@ from impacket.smbconnection import SMB_DIALECT
 from infection_monkey.exploit.HostExploiter import HostExploiter
 from infection_monkey.exploit.tools.helpers import get_target_monkey, get_monkey_depth, build_monkey_commandline
 from infection_monkey.exploit.tools.smb_tools import SmbTools
-from infection_monkey.model import MONKEY_CMDLINE_DETACHED_WINDOWS, DROPPER_CMDLINE_DETACHED_WINDOWS
+from infection_monkey.model import MONKEY_CMDLINE_DETACHED_WINDOWS, DROPPER_CMDLINE_DETACHED_WINDOWS, VictimHost
 from infection_monkey.network.smbfinger import SMBFinger
 from infection_monkey.network.tools import check_tcp_port
 from common.utils.exploit_enum import ExploitType
@@ -37,13 +37,11 @@ class SmbExploiter(HostExploiter):
         if not self.host.os.get('type'):
             is_smb_open, _ = check_tcp_port(self.host.ip_addr, 445)
             if is_smb_open:
-                self.vulnerable_port = 445
                 smb_finger = SMBFinger()
                 smb_finger.get_host_fingerprint(self.host)
             else:
                 is_nb_open, _ = check_tcp_port(self.host.ip_addr, 139)
                 if is_nb_open:
-                    self.vulnerable_port = 139
                     self.host.os['type'] = 'windows'
             return self.host.os.get('type') in self._TARGET_OS_TYPE
         return False
@@ -102,6 +100,7 @@ class SmbExploiter(HostExploiter):
             LOG.debug("Exploiter SmbExec is giving up...")
             return False
 
+        self.set_vulnerable_port(self.host)
         # execute the remote dropper in case the path isn't final
         if remote_full_path.lower() != self._config.dropper_target_path_win_32.lower():
             cmdline = DROPPER_CMDLINE_DETACHED_WINDOWS % {'dropper_path': remote_full_path} + \
@@ -164,3 +163,9 @@ class SmbExploiter(HostExploiter):
         self.add_vuln_port("%s or %s" % (SmbExploiter.KNOWN_PROTOCOLS['139/SMB'][1],
                                          SmbExploiter.KNOWN_PROTOCOLS['445/SMB'][1]))
         return True
+
+    def set_vulnerable_port(self, host: VictimHost):
+        if 'tcp-445' in self.host.services:
+            self.vulnerable_port = "445"
+        elif 'tcp-139' in self.host.services:
+            self.vulnerable_port = "139"

--- a/monkey/monkey_island/cc/services/telemetry/processing/scan.py
+++ b/monkey/monkey_island/cc/services/telemetry/processing/scan.py
@@ -2,6 +2,7 @@ import copy
 
 from monkey_island.cc.database import mongo
 from monkey_island.cc.models import Monkey
+from monkey_island.cc.services.edge import EdgeService
 from monkey_island.cc.services.telemetry.processing.utils import get_edge_by_scan_or_exploit_telemetry
 from monkey_island.cc.services.telemetry.zero_trust_tests.data_endpoints import test_open_data_endpoints
 from monkey_island.cc.services.telemetry.zero_trust_tests.segmentation import test_segmentation_violation
@@ -42,3 +43,4 @@ def update_edges_and_nodes_based_on_scan_telemetry(telemetry_json):
             mongo.db.node.update({"_id": node["_id"]},
                                  {"$set": {"os.version": scan_os["version"]}},
                                  upsert=False)
+        EdgeService.update_label_by_endpoint(edge, node["_id"])


### PR DESCRIPTION
# What is this? 
Fixes SMB exploiter not passing vulnerable port (thus causing redundant exploitations)

## Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Have you successfully tested your changes locally?
* [ ] Is the TravisCI build passing? 

## Proof that it works
```
2020-05-26 11:41:07,787 [1160:10408:INFO] smbexec._exploit_host.163: Executed monkey 'C:\Windows\temp\monkey32.exe' on remote victim VictimHost('3.1.1.1') (cmdline='cmd.exe /c start cmd /c C:\\Windows\\temp\\monkey32.exe m0nk3y -p 268308375968634 -t 1.1.1.1:42614 -s 1.1.1.1:5000 -d 1 -vp 445')
