### PR TITLE
Changed minimum mongodb version required

### DIFF
--- a/monkey/monkey_island/cc/main.py
+++ b/monkey/monkey_island/cc/main.py
@@ -5,7 +5,7 @@ import time
 import logging
 from threading import Thread
 
-MINIMUM_MONGO_DB_VERSION_REQUIRED = "3.6.0"
+MINIMUM_MONGO_DB_VERSION_REQUIRED = "4.2.0"
 
 BASE_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 


### PR DESCRIPTION
# What is this? 
Changed minimum mongodb version required to 4.2.0
