### PR TITLE
pywin32 is missing from the Monkey

### DIFF
--- a/monkey/common/utils/wmi_utils.py
+++ b/monkey/common/utils/wmi_utils.py
@@ -1,4 +1,7 @@
-import wmi
+import sys
+
+if sys.platform.startswith("win"):
+    import wmi
 
 from .mongo_utils import MongoUtils
 

--- a/monkey/infection_monkey/requirements.txt
+++ b/monkey/infection_monkey/requirements.txt
@@ -13,8 +13,4 @@ pyftpdlib==1.5.6
 pymssql<3.0
 pypykatz==0.3.12
 requests>=2.24
-# Locking WMI since version 1.5 introduced breaking change on Linux agent compilation.
-# See breaking change here: https://github.com/tjguk/wmi/commit/dcf8e3eca79bb8c0101ffb83e25c066b0ba9e16d
-# Causes pip to error with:
-# Could not find a version that satisfies the requirement pywin32 (from wmi->-r /src/infection_monkey/requirements.txt (line 12)) (from versions: none)
-wmi==1.4.9 ; sys_platform == 'win32'
+wmi==1.5.1 ; sys_platform == 'win32'


### PR DESCRIPTION
# What is this? 
WMI package upgraded and required pywin32.
because we have this package imported but not used in linux machines
we downgraded

## Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Have you successfully tested your changes locally?
* [x] Is the TravisCI build passing? 

## Proof that it works
After `pip install -r monkey\infection_monkey\requirements.txt`:
```
Collecting pywin32 (from wmi==1.5.1->-r monkey\infection_monkey\requirements.txt (line 16))
  Downloading https://files.pythonhosted.org/packages/96/51/d46eb277182e0989a81cdc0933e97924b68b12519dfe62ae0ea5dec198dd/pywin32-228-cp37-cp37m-win_amd64.whl (9.1MB)
    100% |████████████████████████████████| 9.1MB 2.9MB/s
```