### PR TITLE
Preserves ATT&CK config order on clicking 'Reset to defaults'

### DIFF
--- a/monkey/monkey_island/cc/app.py
+++ b/monkey/monkey_island/cc/app.py
@@ -143,6 +143,7 @@ def init_api_resources(api):
 
 def init_app(mongo_url):
     app = Flask(__name__)
+    app.config['JSON_SORT_KEYS'] = False
 
     api = flask_restful.Api(app)
     api.representations = {'application/json': output_json}

--- a/monkey/monkey_island/cc/app.py
+++ b/monkey/monkey_island/cc/app.py
@@ -78,6 +78,10 @@ def init_app_config(app, mongo_url):
     # deciding to reset credentials and then still logging in with the old JWT.
     app.config['JWT_SECRET_KEY'] = str(uuid.uuid4())
 
+    # By default, Flask sorts keys of JSON objects alphabetically, which messes with the ATT&CK matrix in the
+    # configuration. See https://flask.palletsprojects.com/en/1.1.x/config/#JSON_SORT_KEYS.
+    app.config['JSON_SORT_KEYS'] = False
+
 
 def init_app_services(app):
     init_jwt(app)
@@ -143,7 +147,6 @@ def init_api_resources(api):
 
 def init_app(mongo_url):
     app = Flask(__name__)
-    app.config['JSON_SORT_KEYS'] = False
 
     api = flask_restful.Api(app)
     api.representations = {'application/json': output_json}


### PR DESCRIPTION
Fixes #752 

Preserves the ATT&CK schema configuration order by setting Flask config variable `JSON_SORT_KEYS` to false.
By default, this variable is set to true and Flask sorts keys of JSON objects alphabetically (see [this](https://flask.palletsprojects.com/en/1.1.x/config/#JSON_SORT_KEYS)).

Proof it works:
![bugfix_reset-attack-config](https://user-images.githubusercontent.com/44770317/89058762-88efa180-d37d-11ea-92ea-1c4064ee2f9e.gif)
