### PR TITLE
Windows' "modify shell startup files" PBA fix

### DIFF
--- a/monkey/infection_monkey/post_breach/actions/modify_shell_startup_files.py
+++ b/monkey/infection_monkey/post_breach/actions/modify_shell_startup_files.py
@@ -35,7 +35,7 @@ class ModifyShellStartupFiles(PBA):
 
             for startup_file_per_user in shell_startup_files_per_user_for_windows:
                 windows_cmds = ' '.join(cmds_for_windows).format(startup_file_per_user)
-                pbas.append(self.ModifyShellStartupFile(linux_cmds='', windows_cmds=['powershell.exe', windows_cmds]))
+                pbas.append(self.ModifyShellStartupFile(linux_cmds='', windows_cmds=windows_cmds))
 
             for username in usernames_for_linux:
                 for shell_startup_file in shell_startup_files_for_linux:

--- a/monkey/infection_monkey/post_breach/shell_startup_files/windows/modify_powershell_startup_file.ps1
+++ b/monkey/infection_monkey/post_breach/shell_startup_files/windows/modify_powershell_startup_file.ps1
@@ -2,10 +2,25 @@ param (
     [string]$startup_file_path = $profile
 )
 
-If (!(Test-Path $startup_file_path)) {  # create profile.ps1 file if it doesn't exist already
-    New-Item -Path $startup_file_path -ItemType "file" -Force
+
+# check if paths exist already
+$startup_file_prev_exists = Test-Path $startup_file_path
+$startup_file_folder_path = ($startup_file_path -split '\\')[0..(($startup_file_path -split '\\').count -2)] -join '\'
+$startup_file_folder_prev_exists = Test-Path $startup_file_folder_path
+
+# carry out pba
+If (!($startup_file_prev_exists)) {  # create profile.ps1 file if it doesn't exist already
+    [Void](New-Item -Path $startup_file_path -ItemType "file" -Force)
 }
 Add-Content $startup_file_path "# Successfully modified $startup_file_path" ;  # add line to $Profile
 cat $startup_file_path | Select -last 1 ;  # print last line of $Profile
-$OldProfile = cat $startup_file_path | Select -skiplast 1 ;
-Set-Content $startup_file_path -Value $OldProfile ;
+$OldProfile = cat $startup_file_path | Select -skiplast 1 ;  # get file's original content
+Set-Content $startup_file_path -Value $OldProfile ;  # restore file's original content
+
+# cleanup
+If (!($startup_file_prev_exists)) {  # remove file if it didn't exist previously
+    Remove-Item -Path $startup_file_path -Force ;
+}
+If (!($startup_file_folder_prev_exists)) {  # remove folder if it didn't exist previously
+    Remove-Item -Path $startup_file_folder_path -Force -Recurse ;
+}

--- a/monkey/infection_monkey/post_breach/shell_startup_files/windows/modify_powershell_startup_file.ps1
+++ b/monkey/infection_monkey/post_breach/shell_startup_files/windows/modify_powershell_startup_file.ps1
@@ -1,0 +1,11 @@
+param (
+    [string]$startup_file_path = $profile
+)
+
+If (!(Test-Path $startup_file_path)) {  # create profile.ps1 file if it doesn't exist already
+    New-Item -Path $startup_file_path -ItemType "file" -Force
+}
+Add-Content $startup_file_path "# Successfully modified $startup_file_path" ;  # add line to $Profile
+cat $startup_file_path | Select -last 1 ;  # print last line of $Profile
+$OldProfile = cat $startup_file_path | Select -skiplast 1 ;
+Set-Content $startup_file_path -Value $OldProfile ;

--- a/monkey/infection_monkey/post_breach/shell_startup_files/windows/shell_startup_files_modification.py
+++ b/monkey/infection_monkey/post_breach/shell_startup_files/windows/shell_startup_files_modification.py
@@ -21,9 +21,7 @@ def get_windows_commands_to_modify_shell_startup_files():
                               for user in USERS]
 
     return [
-        'Add-Content {0}',
-        '\"# Successfully modified {0}\" ;',  # add line to $profile
-        'cat {0} | Select -last 1 ;',  # print last line of $profile
-        '$OldProfile = cat {0} | Select -skiplast 1 ;',
-        'Set-Content {0} -Value $OldProfile ;'  # remove last line of $profile
+        'powershell.exe',
+        'infection_monkey/post_breach/shell_startup_files/windows/modify_powershell_startup_file.ps1',
+        '-startup_file_path {0}'
     ], STARTUP_FILES_PER_USER

--- a/monkey/infection_monkey/post_breach/shell_startup_files/windows/shell_startup_files_modification.py
+++ b/monkey/infection_monkey/post_breach/shell_startup_files/windows/shell_startup_files_modification.py
@@ -13,6 +13,7 @@ def get_windows_commands_to_modify_shell_startup_files():
 
     # get list of usernames
     USERS = subprocess.check_output('dir C:\\Users /b', shell=True).decode().split("\r\n")[:-1]  # noqa: DUO116
+    USERS.remove("Public")
 
     STARTUP_FILES_PER_USER = ['\\'.join(SHELL_STARTUP_FILE_PATH_COMPONENTS[:2] +
                                         [user] +


### PR DESCRIPTION
Fixes #759

(1) ~~TODO~~ Runs a powershell script that creates a new folder and file if `profile.ps1` doesn't exist already.

(2) Removes "Public" from `USERS` in windows modify shell startup PBA file so it doesn't look for a `profile.ps1` file in the Public folder too.

