### PR TITLE
Fix rendering bug in security report generation due to PBA section

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/report-components/security/PostBreachParser.js
+++ b/monkey/monkey_island/cc/ui/src/components/report-components/security/PostBreachParser.js
@@ -23,7 +23,7 @@ function aggregateShellStartupPba(results) {
       failedOutputs += results[i].result[0];
     }
   }
-  if(aggregatedPbaResult === undefined) return;
+  if(aggregatedPbaResult === undefined) return results;
 
   results = results.filter(result => result.name !== SHELL_STARTUP_NAME);
   aggregatedPbaResult.result[0] = successfulOutputs + failedOutputs;


### PR DESCRIPTION
If the post-breach results have no changes, nothing is returned from `aggregateShellStartupPba()` which causes a rendering issue (te replicate, try running only the `trap` command PBA).

This makes sure the results are returned back as it is if there are no changes.