### PR TITLE
Retargeted links in README.md to direct to documentation framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ The Infection Monkey uses the following techniques and exploits to propagate to 
   * SambaCry
   * Elastic Search (CVE-2015-1427)
   * Weblogic server
-  * and more
+  * and more, see our [Documentation hub](https://www.guardicore.com/infectionmonkey/docs/reference/exploiters/) for more information about our RCE exploiters.
 
 ## Setup
 Check out the [Setup](https://www.guardicore.com/infectionmonkey/docs/setup/) page in the Wiki or a quick getting [started guide](https://www.guardicore.com/infectionmonkey/docs/usage/getting-started/).
 
-The Infection Monkey supports a variety of platforms, documented [in the documentation framework](https://www.guardicore.com/infectionmonkey/docs/reference/operating_systems_support/).
+The Infection Monkey supports a variety of platforms, documented [in our documentation hub](https://www.guardicore.com/infectionmonkey/docs/reference/operating_systems_support/).
 
 ## Building the Monkey from source
 To deploy development version of monkey you should refer to readme in the [deployment scripts](deployment_scripts) 

--- a/README.md
+++ b/README.md
@@ -54,14 +54,13 @@ The Infection Monkey uses the following techniques and exploits to propagate to 
   * and more
 
 ## Setup
-Check out the [Setup](https://github.com/guardicore/monkey/wiki/setup) page in the Wiki or a quick getting [started guide](https://www.guardicore.com/infectionmonkey/wt/).
+Check out the [Setup](https://www.guardicore.com/infectionmonkey/docs/setup/) page in the Wiki or a quick getting [started guide](https://www.guardicore.com/infectionmonkey/docs/usage/getting-started/).
 
-The Infection Monkey supports a variety of platforms, documented [in the wiki](https://github.com/guardicore/monkey/wiki/OS-compatibility).
+The Infection Monkey supports a variety of platforms, documented [in the documentation framework](https://www.guardicore.com/infectionmonkey/docs/reference/operating_systems_support/).
 
 ## Building the Monkey from source
-To deploy development version of monkey you should refer to readme in the [deployment scripts](deployment_scripts) folder.
-If you only want to build the monkey from source, see [Setup](https://github.com/guardicore/monkey/wiki/Setup#compile-it-yourself)
-and follow the instructions at the readme files under [infection_monkey](monkey/infection_monkey) and [monkey_island](monkey/monkey_island). 
+To deploy development version of monkey you should refer to readme in the [deployment scripts](deployment_scripts) 
+folder or follow documentation in [documentation hub](https://www.guardicore.com/infectionmonkey/docs/development/setup-development-environment/).
 
 ### Build status
 | Branch | Status |


### PR DESCRIPTION
# What is this? 
Retargeted links in README.md to direct to documentation framework
