### PR TITLE
Fix mongoengine version to 0.20.0

### DIFF
--- a/monkey/monkey_island/requirements.txt
+++ b/monkey/monkey_island/requirements.txt
@@ -10,7 +10,7 @@ dpath>=2.0
 flask>=1.1
 ipaddress>=1.0.23
 jsonschema==3.2.0
-mongoengine>=0.20
+mongoengine==0.20
 mongomock==3.19.0
 netifaces>=0.10.9
 pycryptodome==3.9.8


### PR DESCRIPTION
**What this fixes**
Our Travis CI builds were failing because of [this](https://github.com/guardicore/monkey/blob/5ba1bf1db8a87fe5793b015aa4c8770d7165dafb/monkey/monkey_island/cc/models/test_monkey.py#L52) line.

**How**
The [latest mongoengine release](https://github.com/MongoEngine/mongoengine/blob/v0.21.0/docs/changelog.rst#changes-in-0210) has some changes in "Cursor.count" which throw an AttributeError on calling "QuerySet.count()", which is being used in `is_dead()` in `test_monkey.py`. The AttributeError is [caught by the except statement](https://github.com/guardicore/monkey/blob/5ba1bf1db8a87fe5793b015aa4c8770d7165dafb/monkey/monkey_island/cc/models/monkey.py#L84-L91) which marks the monkey as dead. 

There's no workaround yet either (see [this](https://github.com/MongoEngine/mongoengine/issues/2425)) &#8658; fixing the mongoengine version to 0.20.0.
