### PR TITLE
Documentation fix

### DIFF
--- a/docs/content/usage/reports/zero-trust.md
+++ b/docs/content/usage/reports/zero-trust.md
@@ -17,7 +17,7 @@ This diagram provides a quick glance at how your organization scores on each com
 - {{< label danger Failed >}} At least one of the tests related to this component failed. This means that the Infection Monkey detected an unmet Zero Trust requirement.
 - {{< label warning Verify >}} At least one of the tests’ results related to this component requires further manual verification.
 - {{< label success Passed >}} All Tests related to this pillar passed. No violation of a Zero Trust guiding principle was detected.
-- {{< label other Unexecuted >}} This status means no tests were executed for this pillar.
+- {{< label unused Unexecuted >}} This status means no tests were executed for this pillar.
 
 ![Zero Trust Report summary](/images/usage/reports/ztreport1.png "Zero Trust Report summary")
 


### PR DESCRIPTION
# What does this PR do? 
Makes "Unexecuted" visible [here](https://www.guardicore.com/infectionmonkey/docs/usage/reports/zero-trust/#summary).

Changes this  

<img src="https://user-images.githubusercontent.com/44770317/102893660-fb296580-4487-11eb-8527-56000d74d7d9.png" height=110>

to this  

<img src="https://user-images.githubusercontent.com/44770317/102893704-0b414500-4488-11eb-88b3-988f42a551eb.png" height=120>
