### PR TITLE
Import/export MITRE ATT&CK config

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
@@ -276,12 +276,21 @@ class ConfigurePageComponent extends AuthComponent {
 
   setConfigOnImport = (event) => {
     try {
+      let parsedConfig = JSON.parse(event.target.result);
+
+      let importedAttackConfig = parsedConfig.attack;
+      delete parsedConfig.attack;
+      let importedMonkeyConfig = parsedConfig;
+
       this.setState({
-        configuration: JSON.parse(event.target.result),
+        configuration: importedMonkeyConfig,
+        attackConfig: importedAttackConfig,
         lastAction: 'import_success'
       }, () => {
         this.sendConfig();
-        this.setInitialConfig(JSON.parse(event.target.result))
+        this.matrixSubmit();
+        this.setInitialConfig(importedMonkeyConfig);
+        this.setInitialAttackConfig(importedAttackConfig);
       });
       this.currentFormData = {};
     } catch (SyntaxError) {
@@ -291,10 +300,12 @@ class ConfigurePageComponent extends AuthComponent {
 
   exportConfig = () => {
     this.updateConfigSection();
-    const configAsJson = JSON.stringify(this.state.configuration, null, 2);
-    const configAsBinary = new Blob([configAsJson], {type: 'text/plain;charset=utf-8'});
+    let allConfig = this.state.configuration;
+    allConfig.attack = this.state.attackConfig;
+    let allConfigAsJson = JSON.stringify(allConfig, null, 2);
+    const allConfigAsBinary = new Blob([allConfigAsJson], {type: 'text/plain;charset=utf-8'});
 
-    FileSaver.saveAs(configAsBinary, 'monkey.conf');
+    FileSaver.saveAs(allConfigAsBinary, 'monkey.conf');
   };
 
   sendConfig() {

--- a/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
@@ -278,8 +278,8 @@ class ConfigurePageComponent extends AuthComponent {
     try {
       let parsedConfig = JSON.parse(event.target.result);
 
-      let importedAttackConfig = parsedConfig.attack;
-      delete parsedConfig.attack;
+      let importedAttackConfig = parsedConfig.attack_matrix_ui_state;
+      delete parsedConfig.attack_matrix_ui_state;
       let importedMonkeyConfig = parsedConfig;
 
       this.setState({
@@ -300,12 +300,12 @@ class ConfigurePageComponent extends AuthComponent {
 
   exportConfig = () => {
     this.updateConfigSection();
-    let allConfig = this.state.configuration;
-    allConfig.attack = this.state.attackConfig;
-    let allConfigAsJson = JSON.stringify(allConfig, null, 2);
-    const allConfigAsBinary = new Blob([allConfigAsJson], {type: 'text/plain;charset=utf-8'});
+    let config = this.state.configuration;
+    config.attack_matrix_ui_state = this.state.attackConfig;
+    let configAsJson = JSON.stringify(config, null, 2);
+    const configAsBinary = new Blob([configAsJson], {type: 'text/plain;charset=utf-8'});
 
-    FileSaver.saveAs(allConfigAsBinary, 'monkey.conf');
+    FileSaver.saveAs(configAsBinary, 'monkey.conf');
   };
 
   sendConfig() {


### PR DESCRIPTION
Importing/exporting config on the configuration page does not work for the ATT&CK configuration right now. This PR fixes that.

Demo:

https://user-images.githubusercontent.com/44770317/104189938-5fb16200-5441-11eb-9c24-5ba4cd7f0cd4.mp4

**Note:**  
For old users of Monkey, if they upgrade to a new version having this and try to import a previously exported configuration, it will throw an error. How do we handle this? Checking if the imported configuration has data for the ATT&CK configuration, or something else?