### PR TITLE
Added jwt_required decorator to the "local_run" endpoint

### DIFF
--- a/monkey/monkey_island/cc/resources/local_run.py
+++ b/monkey/monkey_island/cc/resources/local_run.py
@@ -11,6 +11,7 @@ import monkey_island.cc.environment.environment_singleton as env_singleton
 from monkey_island.cc.server_utils.consts import MONKEY_ISLAND_ABS_PATH
 from monkey_island.cc.models import Monkey
 from monkey_island.cc.services.utils.network_utils import local_ip_addresses
+from monkey_island.cc.resources.auth.auth import jwt_required
 from monkey_island.cc.resources.monkey_download import get_monkey_executable
 from monkey_island.cc.services.node import NodeService
 
@@ -55,6 +56,7 @@ def run_local_monkey():
 
 
 class LocalRun(flask_restful.Resource):
+    @jwt_required
     def get(self):
         NodeService.update_dead_monkeys()
         island_monkey = NodeService.get_monkey_island_monkey()
@@ -65,6 +67,7 @@ class LocalRun(flask_restful.Resource):
 
         return jsonify(is_running=is_monkey_running)
 
+    @jwt_required
     def post(self):
         body = json.loads(request.data)
         if body.get('action') == 'run':


### PR DESCRIPTION
# What does this PR do? 

Fixes a bug, where anyone could run the monkey on island without authorization.

