### PR TITLE
Show only configured IPs for Run Monkey -> Manual page

### DIFF
--- a/monkey/monkey_island/cc/services/tests/test_config.py
+++ b/monkey/monkey_island/cc/services/tests/test_config.py
@@ -1,0 +1,31 @@
+import pytest
+
+import monkey_island.cc.services.config
+from monkey_island.cc.environment import Environment
+from monkey_island.cc.services.config import ConfigService
+
+IPS = ["0.0.0.0", "9.9.9.9"]
+PORT = 9999
+
+
+@pytest.fixture
+def config(monkeypatch):
+    monkeypatch.setattr("monkey_island.cc.services.config.local_ip_addresses",
+                        lambda: IPS)
+    monkeypatch.setattr(Environment, "_ISLAND_PORT", PORT)
+    config = ConfigService.get_default_config(True)
+    return config
+
+
+def test_set_server_ips_in_config_command_servers(config):
+    ConfigService.set_server_ips_in_config(config)
+    expected_config_command_servers = [f"{ip}:{PORT}" for ip in IPS]
+    assert config["internal"]["island_server"]["command_servers"] ==\
+        expected_config_command_servers
+
+
+def test_set_server_ips_in_config_current_server(config):
+    ConfigService.set_server_ips_in_config(config)
+    expected_config_current_server = f"{IPS[0]}:{PORT}"
+    assert config["internal"]["island_server"]["current_server"] ==\
+        expected_config_current_server

--- a/monkey/monkey_island/cc/services/tests/test_config.py
+++ b/monkey/monkey_island/cc/services/tests/test_config.py
@@ -7,6 +7,9 @@ from monkey_island.cc.services.config import ConfigService
 IPS = ["0.0.0.0", "9.9.9.9"]
 PORT = 9999
 
+# If tests fail because config path is changed, sync with
+# monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/RunOptions.js
+
 
 @pytest.fixture
 def config(monkeypatch):

--- a/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/RunOptions.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/RunOptions.js
@@ -10,6 +10,8 @@ import RunOnIslandButton from './RunOnIslandButton';
 import AWSRunButton from './RunOnAWS/AWSRunButton';
 import CloudOptions from './scoutsuite-setup/CloudOptions';
 
+const CONFIG_URL = '/api/configuration/island';
+
 function RunOptions(props) {
 
   const [currentContent, setCurrentContent] = useState(loadingContents());
@@ -20,12 +22,16 @@ function RunOptions(props) {
 
   useEffect(() => {
     if (initialized === false) {
-      authComponent.authFetch('/api')
-        .then(res => res.json())
-        .then(res => {
-          setIps([res['ip_addresses']][0]);
-          setInitialized(true);
+      authComponent.authFetch(CONFIG_URL)
+      .then(res => res.json())
+      .then(res => {
+        let commandServers = res.configuration.internal.island_server.command_servers;
+        let ipAddresses = commandServers.map(ip => {
+          return ip.split(":", 1);
         });
+        setIps(ipAddresses);
+        setInitialized(true);
+      });
     }
   })
 


### PR DESCRIPTION
Fixes #953

Only configured Island Server's IPs appear on the Run Monkey -> Manual page.
<img src="https://user-images.githubusercontent.com/44770317/108839543-361c5680-75fb-11eb-961b-734ac54b577f.gif" height=320>

