### PR TITLE
Show "No rows found" if there are no findings in ZT report

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/report-components/common/PaginatedTable.js
+++ b/monkey/monkey_island/cc/ui/src/components/report-components/common/PaginatedTable.js
@@ -4,25 +4,19 @@ import * as PropTypes from 'prop-types';
 
 class PaginatedTable extends Component {
   render() {
-    if (this.props.data.length > 0) {
-      let defaultPageSize = this.props.data.length > this.props.pageSize ? this.props.pageSize : this.props.data.length;
-      let showPagination = this.props.data.length > this.props.pageSize;
+    let defaultPageSize = this.props.data.length > this.props.pageSize ? this.props.pageSize : this.props.data.length;
+    let showPagination = this.props.data.length > this.props.pageSize;
 
-      return (
-        <div>
-          <ReactTable
-            columns={this.props.columns}
-            data={this.props.data}
-            showPagination={showPagination}
-            defaultPageSize={defaultPageSize}
-          />
-        </div>
-      );
-    } else {
-      return (
-        <div/>
-      );
-    }
+    return (
+      <div>
+        <ReactTable
+          columns={this.props.columns}
+          data={this.props.data}
+          showPagination={showPagination}
+          defaultPageSize={defaultPageSize}
+        />
+      </div>
+    );
   }
 }
 


### PR DESCRIPTION
Fixes #947

The findings tables in ZT reports use `PaginatedTable` (from `monkey_island/cc/ui/src/components/report-components/common/PaginatedTable.js`). The if-else in `PaginatedTable` was returning an empty div in the case where no data is available. This isn't necessary since `ReactTable` takes care of that case.

<img src="https://user-images.githubusercontent.com/44770317/108843101-3ec35b80-7600-11eb-8a2a-2b8fcb3fa736.png" height=400>
