### PR TITLE
Attack config unsafe warning

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/configuration-components/UnsafeOptionsWarningModal.js
+++ b/monkey/monkey_island/cc/ui/src/components/configuration-components/UnsafeOptionsWarningModal.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import {Modal, Button} from 'react-bootstrap';
+
+function UnsafeOptionsConfirmationModal(props) {
+  return (
+    <Modal show={props.show}>
+      <Modal.Body>
+        <h2>
+          <div className='text-center'>Warning</div>
+        </h2>
+        <p className='text-center' style={{'fontSize': '1.2em', 'marginBottom': '2em'}}>
+          Some of the selected options could cause systems to become unstable or malfunction.
+        </p>
+        <div className='text-center'>
+          <Button type='button'
+                  className='btn btn-danger'
+                  size='lg'
+                  style={{margin: '5px'}}
+                  onClick={props.onContinueClick}>
+            Continue
+          </Button>
+        </div>
+      </Modal.Body>
+    </Modal>
+  )
+}
+
+export default UnsafeOptionsConfirmationModal;

--- a/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
@@ -130,8 +130,8 @@ class ConfigurePageComponent extends AuthComponent {
       .then(() => {
         this.setInitialAttackConfig(this.state.attackConfig);
       })
-      .then(this.updateConfig())
-      .then(this.setState({lastAction: 'saved'}))
+      .then(() => this.updateConfig())
+      .then(() => this.setState({lastAction: 'saved'}))
       .catch(error => {
         console.log('Bad configuration: ' + error.toString());
         this.setState({lastAction: 'invalid_configuration'});

--- a/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
@@ -12,6 +12,7 @@ import {formValidationFormats} from '../configuration-components/ValidationForma
 import transformErrors from '../configuration-components/ValidationErrorMessages';
 import InternalConfig from '../configuration-components/InternalConfig';
 import UnsafeOptionsConfirmationModal from '../configuration-components/UnsafeOptionsConfirmationModal.js';
+import UnsafeOptionsWarningModal from '../configuration-components/UnsafeOptionsWarningModal.js';
 import isUnsafeOptionSelected from '../utils/SafeOptionValidator.js';
 
 const ATTACK_URL = '/api/attack';
@@ -38,7 +39,8 @@ class ConfigurePageComponent extends AuthComponent {
       sections: [],
       selectedSection: 'attack',
       showAttackAlert: false,
-      showUnsafeOptionsConfirmation: false
+      showUnsafeOptionsConfirmation: false,
+      showUnsafeAttackOptionsWarning: false
     };
   }
 
@@ -92,12 +94,17 @@ class ConfigurePageComponent extends AuthComponent {
     }
   }
 
-  updateConfig = () => {
+  onUnsafeAttackContinueClick = () => {
+    this.setState({showUnsafeAttackOptionsWarning: false});
+  }
+
+
+  updateConfig = (callback=null) => {
     this.authFetch(CONFIG_URL)
       .then(res => res.json())
       .then(data => {
         this.setInitialConfig(data.configuration);
-        this.setState({configuration: data.configuration});
+        this.setState({configuration: data.configuration}, callback);
       })
   };
 
@@ -130,13 +137,19 @@ class ConfigurePageComponent extends AuthComponent {
       .then(() => {
         this.setInitialAttackConfig(this.state.attackConfig);
       })
-      .then(() => this.updateConfig())
+      .then(() => this.updateConfig(this.checkAndShowUnsafeAttackWarning))
       .then(() => this.setState({lastAction: 'saved'}))
       .catch(error => {
         console.log('Bad configuration: ' + error.toString());
         this.setState({lastAction: 'invalid_configuration'});
       });
   };
+
+  checkAndShowUnsafeAttackWarning = () => {
+    if (isUnsafeOptionSelected(this.state.schema, this.state.configuration)) {
+      this.setState({showUnsafeAttackOptionsWarning: true});
+    }
+  }
 
   attemptConfigSubmit() {
     this.updateConfigSection();
@@ -239,6 +252,15 @@ class ConfigurePageComponent extends AuthComponent {
         show={this.state.showUnsafeOptionsConfirmation}
         onCancelClick={this.onUnsafeConfirmationCancelClick}
         onContinueClick={this.onUnsafeConfirmationContinueClick}
+      />
+    );
+  }
+
+  renderUnsafeAttackOptionsWarningModal() {
+    return (
+      <UnsafeOptionsWarningModal
+        show={this.state.showUnsafeAttackOptionsWarning}
+        onContinueClick={this.onUnsafeAttackContinueClick}
       />
     );
   }
@@ -468,6 +490,7 @@ class ConfigurePageComponent extends AuthComponent {
            className={'main'}>
         {this.renderAttackAlertModal()}
         {this.renderUnsafeOptionsConfirmationModal()}
+        {this.renderUnsafeAttackOptionsWarningModal()}
         <h1 className='page-title'>Monkey Configuration</h1>
         {this.renderNav()}
         {content}


### PR DESCRIPTION
# What does this PR do? 

Adds a warning when a user submits an ATT&CK config that could be unsafe.

The ATT&CK configuration screen could allow users to unknowingly submit a potentially unsafe configuration.

**Example**
1. Go to `Exploits` and enable an unsafe exploiter.
2. Submit config -- you are warned that this config may be unsafe.
3. Go to the `ATT&CK` configuration screen and click submit -- You are not warned that the config may be unsafe
4. Export the configuration
5. Open the exported configuration and verify that the unsafe exploiter is present in the configuration.

**Solution**
When ATT&CK configurations are submitted, the workflow is: 

1. ATT&CK configuration is submitted to the back-end.
2. The back-end converts the ATT&CK configuration into a regular configuration
3. The front-end pulls the new, regular configuration from the back-end.

The ATT&CK configuration does not contain enough information for the front-end to simply determine whether or not it is safe. Therefore, the front-end relies on the back-end to translate the ATT&CK config into a regular config before it can evaluate safety. The front-end can then only warn the user, not prevent submission as in https://github.com/guardicore/monkey/pull/1000.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing? 
* [ ] Was the documentation framework updated to reflect the changes?

## Testing Checklist

* [ ] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested locally. See screenshot
* [x] If applicable, add screenshots or log transcripts of the feature working


![attack-warning](https://user-images.githubusercontent.com/19957806/109533007-bde4e380-7a87-11eb-80af-c3f6685c7f48.gif)

