### PR TITLE
Fixed cryptography requirement

### DIFF
--- a/monkey/infection_monkey/requirements.txt
+++ b/monkey/infection_monkey/requirements.txt
@@ -1,3 +1,4 @@
+cryptography==2.5
 WinSys-3.x>=0.5.2
 cffi>=1.14
 ecdsa==0.15


### PR DESCRIPTION
# What does this PR do? 

Fixes cryptography requirement to version 2.5, which has a built wheel available for Linux 32 bit, so we can build the agent.
