### PR TITLE
Configuration generation for BB tests bugfix

### DIFF
--- a/envs/monkey_zoo/blackbox/island_configs/ssh.py
+++ b/envs/monkey_zoo/blackbox/island_configs/ssh.py
@@ -1,8 +1,10 @@
+from copy import copy
+
 from envs.monkey_zoo.blackbox.island_configs.base_template import BaseTemplate
 
 
 class Ssh(BaseTemplate):
-    config_values = BaseTemplate.config_values
+    config_values = copy(BaseTemplate.config_values)
 
     config_values.update({
         "basic.exploiters.exploiter_classes": ["SSHExploiter"],

--- a/envs/monkey_zoo/blackbox/island_configs/struts2.py
+++ b/envs/monkey_zoo/blackbox/island_configs/struts2.py
@@ -1,9 +1,11 @@
+from copy import copy
+
 from envs.monkey_zoo.blackbox.island_configs.base_template import BaseTemplate
 
 
 class Struts2(BaseTemplate):
 
-    config_values = BaseTemplate.config_values
+    config_values = copy(BaseTemplate.config_values)
 
     config_values.update({
         "basic.exploiters.exploiter_classes": ["Struts2Exploiter"],

--- a/envs/monkey_zoo/blackbox/island_configs/tunneling.py
+++ b/envs/monkey_zoo/blackbox/island_configs/tunneling.py
@@ -1,8 +1,10 @@
+from copy import copy
+
 from envs.monkey_zoo.blackbox.island_configs.base_template import BaseTemplate
 
 
 class Tunneling(BaseTemplate):
-    config_values = BaseTemplate.config_values
+    config_values = copy(BaseTemplate.config_values)
 
     config_values.update({
         "basic.exploiters.exploiter_classes": ["SmbExploiter",

--- a/envs/monkey_zoo/blackbox/island_configs/weblogic.py
+++ b/envs/monkey_zoo/blackbox/island_configs/weblogic.py
@@ -1,9 +1,11 @@
+from copy import copy
+
 from envs.monkey_zoo.blackbox.island_configs.base_template import BaseTemplate
 
 
 class Weblogic(BaseTemplate):
 
-    config_values = BaseTemplate.config_values
+    config_values = copy(BaseTemplate.config_values)
 
     config_values.update({
         "basic.exploiters.exploiter_classes": ["WebLogicExploiter"],

--- a/envs/monkey_zoo/blackbox/island_configs/wmi_mimikatz.py
+++ b/envs/monkey_zoo/blackbox/island_configs/wmi_mimikatz.py
@@ -1,8 +1,10 @@
+from copy import copy
+
 from envs.monkey_zoo.blackbox.island_configs.base_template import BaseTemplate
 
 
 class WmiMimikatz(BaseTemplate):
-    config_values = BaseTemplate.config_values
+    config_values = copy(BaseTemplate.config_values)
 
     config_values.update({
         "basic.exploiters.exploiter_classes": ["WmiExploiter"],

--- a/envs/monkey_zoo/blackbox/island_configs/wmi_pth.py
+++ b/envs/monkey_zoo/blackbox/island_configs/wmi_pth.py
@@ -1,8 +1,10 @@
+from copy import copy
+
 from envs.monkey_zoo.blackbox.island_configs.base_template import BaseTemplate
 
 
 class WmiPth(BaseTemplate):
-    config_values = BaseTemplate.config_values
+    config_values = copy(BaseTemplate.config_values)
 
     config_values.update({
         "basic.exploiters.exploiter_classes": ["WmiExploiter"],

--- a/envs/monkey_zoo/blackbox/test_blackbox.py
+++ b/envs/monkey_zoo/blackbox/test_blackbox.py
@@ -46,6 +46,7 @@ GCP_TEST_MACHINE_LIST = ['sshkeys-11', 'sshkeys-12', 'elastic-4', 'elastic-5', '
                          'mimikatz-14', 'mimikatz-15', 'struts2-23', 'struts2-24', 'tunneling-9', 'tunneling-10',
                          'tunneling-11', 'tunneling-12', 'weblogic-18', 'weblogic-19', 'shellshock-8', 'zerologon-25']
 LOG_DIR_PATH = "./logs"
+logging.basicConfig(level=logging.INFO)
 LOGGER = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
 Fixed a bug related to incorrect references in configuration generation and changed the default logging level to `INFO`

## Testing Checklist

* [x] Ran BB tests

