### PR TITLE
Moved elastic port to HTTP ports to fix a bug of "All web-ports are c…

### DIFF
--- a/monkey/monkey_island/cc/services/config_schema/internal.py
+++ b/monkey/monkey_island/cc/services/config_schema/internal.py
@@ -159,7 +159,8 @@ INTERNAL = {
                                 8080,
                                 443,
                                 8008,
-                                7001
+                                7001,
+                                9200
                             ],
                             "description": "List of ports the monkey will check if are being used for HTTP"
                         },
@@ -181,7 +182,6 @@ INTERNAL = {
                                 443,
                                 8008,
                                 3306,
-                                9200,
                                 7001,
                                 8088
                             ],


### PR DESCRIPTION
# What does this PR do? 

Fixes:
```
2021-03-24 12:28:32,832 [5772:1840:INFO] web_rce.get_ports_w.295: All default web ports are closed on \"Victim Host 10.2.2.5: OS - [type-windows ] Services - [tcp-9200-{'display_name': 'unknown(TCP)', 'port': 9200} ] ICMP: True target monkey: None\", skipping
 2021-03-24 12:28:32,832 [5772:1840:INFO] monkey.try_exploiting.356: Failed exploiting VictimHost('10.2.2.5') with exploiter ElasticGroovyExploiter
 ```
By assigning 9200 to web ports.