### PR TITLE
Fix error when removing uploaded post breach file on config reset

### DIFF
--- a/monkey/monkey_island/cc/resources/pba_file_upload.py
+++ b/monkey/monkey_island/cc/resources/pba_file_upload.py
@@ -69,13 +69,14 @@ class FileUpload(flask_restful.Resource):
             PBA_LINUX_FILENAME_PATH if file_type == "PBAlinux" else PBA_WINDOWS_FILENAME_PATH
         )
         filename = ConfigService.get_config_value(filename_path)
-        file_path = Path(env_singleton.env.get_config().data_dir_abs_path).joinpath(filename)
-        try:
-            if os.path.exists(file_path):
-                os.remove(file_path)
-            ConfigService.set_config_value(filename_path, "")
-        except OSError as e:
-            LOG.error("Can't remove previously uploaded post breach files: %s" % e)
+        if filename:
+            file_path = Path(env_singleton.env.get_config().data_dir_abs_path).joinpath(filename)
+            try:
+                if os.path.exists(file_path):
+                    os.remove(file_path)
+                ConfigService.set_config_value(filename_path, "")
+            except OSError as e:
+                LOG.error("Can't remove previously uploaded post breach files: %s" % e)
 
         return {}
 

--- a/monkey/monkey_island/cc/resources/pba_file_upload.py
+++ b/monkey/monkey_island/cc/resources/pba_file_upload.py
@@ -58,24 +58,6 @@ class FileUpload(flask_restful.Resource):
         response = Response(response=filename, status=200, mimetype="text/plain")
         return response
 
-    @jwt_required
-    def delete(self, file_type):
-        """
-        Deletes file that has been deleted on the front end
-        :param file_type: Type indicates which file was deleted, linux of windows
-        :return: Empty response
-        """
-        filename_path = (
-            PBA_LINUX_FILENAME_PATH if file_type == "PBAlinux" else PBA_WINDOWS_FILENAME_PATH
-        )
-        filename = ConfigService.get_config_value(filename_path)
-        if filename:
-            file_path = Path(env_singleton.env.get_config().data_dir_abs_path).joinpath(filename)
-            FileUpload._delete_file(file_path)
-            ConfigService.set_config_value(filename_path, "")
-
-        return {}
-
     @staticmethod
     def upload_pba_file(request_, is_linux=True):
         """
@@ -93,6 +75,24 @@ class FileUpload(flask_restful.Resource):
             (PBA_LINUX_FILENAME_PATH if is_linux else PBA_WINDOWS_FILENAME_PATH), filename
         )
         return filename
+
+    @jwt_required
+    def delete(self, file_type):
+        """
+        Deletes file that has been deleted on the front end
+        :param file_type: Type indicates which file was deleted, linux of windows
+        :return: Empty response
+        """
+        filename_path = (
+            PBA_LINUX_FILENAME_PATH if file_type == "PBAlinux" else PBA_WINDOWS_FILENAME_PATH
+        )
+        filename = ConfigService.get_config_value(filename_path)
+        if filename:
+            file_path = Path(env_singleton.env.get_config().data_dir_abs_path).joinpath(filename)
+            FileUpload._delete_file(file_path)
+            ConfigService.set_config_value(filename_path, "")
+
+        return {}
 
     @staticmethod
     def _delete_file(file_path):

--- a/monkey/monkey_island/cc/resources/pba_file_upload.py
+++ b/monkey/monkey_island/cc/resources/pba_file_upload.py
@@ -18,7 +18,7 @@ from monkey_island.cc.services.post_breach_files import (
 __author__ = "VakarisZ"
 
 LOG = logging.getLogger(__name__)
-# Front end uses these strings to identify which files to work with (linux of windows)
+# Front end uses these strings to identify which files to work with (linux or windows)
 LINUX_PBA_TYPE = "PBAlinux"
 WINDOWS_PBA_TYPE = "PBAwindows"
 
@@ -71,12 +71,8 @@ class FileUpload(flask_restful.Resource):
         filename = ConfigService.get_config_value(filename_path)
         if filename:
             file_path = Path(env_singleton.env.get_config().data_dir_abs_path).joinpath(filename)
-            try:
-                if os.path.exists(file_path):
-                    os.remove(file_path)
-                ConfigService.set_config_value(filename_path, "")
-            except OSError as e:
-                LOG.error("Can't remove previously uploaded post breach files: %s" % e)
+            FileUpload._delete_file(file_path)
+            ConfigService.set_config_value(filename_path, "")
 
         return {}
 
@@ -97,3 +93,11 @@ class FileUpload(flask_restful.Resource):
             (PBA_LINUX_FILENAME_PATH if is_linux else PBA_WINDOWS_FILENAME_PATH), filename
         )
         return filename
+
+    @staticmethod
+    def _delete_file(file_path):
+        try:
+            if os.path.exists(file_path):
+                os.remove(file_path)
+        except OSError as e:
+            LOG.error("Couldn't remove previously uploaded post breach files: %s" % e)


### PR DESCRIPTION
Fixes:
![image](https://user-images.githubusercontent.com/44770317/112489824-d2757c80-8da4-11eb-9a68-c74357ca27d1.png)
`os.remove(file_path)` in `monkey_island/cc/resources/pba_file_upload.py` attempts to delete a directory which throws an error when the PBA_linux_filename/PBA_windows_filename field in the database is empty.
<img src="https://user-images.githubusercontent.com/44770317/112490402-5891c300-8da5-11eb-96f2-7b3b1c9aadbd.png" height=75>

To reproduce:
1. Start Monkey Island.
2. Go to the configuration page.
3. Make sure that nothing is uploaded in the custom PBA file field.
4. Reset the config.