### PR TITLE
travis: install node v12.x, instead of latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
 - node --version
 - npm --version
 - nvm --version
-- nvm install node
+- nvm install 12
 - nvm use node
 - npm i -g eslint
 - node --version


### PR DESCRIPTION
# What does this PR do? 

Fixes #1111

Install Node v12 instead of latest in travis script.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing? 
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Have you successfully tested your changes locally? Elaborate:
    > Tested by {Running the Monkey locally with relevant config/running Island/...} 
* [ ] If applicable, add screenshots or log transcripts of the feature working