### PR TITLE
BB tests: automatic registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Authentication mechanism to use bcrypt on server side. #1139
 - `server_config.json` puts environment config options in a separate section
   named "environment". #1161
+- BlackBox tests can now register if they are ran on a fresh installation. #1180
 - Improved the structure of unit tests by scoping fixtures only to relevant modules
   instead of having a one huge fixture file, improved and renamed the directory
   structure of unit tests and unit test infrastructure. #1178

--- a/envs/monkey_zoo/blackbox/test_blackbox.py
+++ b/envs/monkey_zoo/blackbox/test_blackbox.py
@@ -103,7 +103,7 @@ def island_client(island, quick_performance_tests):
         island_client_object = MonkeyIslandClient(island)
         client_established = island_client_object.get_api_status()
     except Exception:
-        logging.exception("message")
+        logging.exception("Got an exception while trying to establish connection to the Island.")
     finally:
         if not client_established:
             pytest.exit("BB tests couldn't establish communication to the island.")


### PR DESCRIPTION
# What does this PR do? 

EtE tests deploy the island, but island prompts a registration screen, which BB can't handle. 
This PR solves that problem by selecting a passwordless option.

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing? 
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?

## Testing Checklist

* [ ] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested with an unregistred island (registration successful)
    > Tested with a registered island (authentication error is thrown, tests don't run)
    > Tested with unreachable island ("can't reach island" error message is displayed, tests don't run)
