### PR TITLE
Config export modal

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/configuration-components/ExportConfigModal.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/configuration-components/ExportConfigModal.tsx
@@ -1,0 +1,53 @@
+import {Button, Modal, Form} from 'react-bootstrap';
+import React from 'react';
+
+type Props = {
+  show: boolean,
+  onClick: () => void
+}
+
+
+const PasswordInput = (props) => {
+  return (
+    <div className={'config-export-password-input'}>
+      <p>Encrypt with a password:</p>
+      <Form.Control type='password' placeholder='Password' />
+    </div>
+  )
+}
+
+
+const ConfigExportModal = (props: Props) => {
+  return (
+    <Modal show={props.show}
+           onHide={props.onClick}
+           size={'lg'}>
+      <Modal.Header closeButton>
+        <Modal.Title>Configuration export</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <div key={'config-export-option'} className='mb-3'>
+          <Form.Check
+            type={'radio'}
+            id={'password'}
+            label={<PasswordInput/>}
+          />
+
+          <Form.Check
+            type={'radio'}
+            label={'Skip encryption (export as plaintext)'}
+          />
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant='secondary' onClick={props.onClick}>
+          Close
+        </Button>
+        <Button variant='primary' onClick={props.onClick}>
+          Save Changes
+        </Button>
+      </Modal.Footer>
+    </Modal>)
+}
+
+export default ConfigExportModal;

--- a/monkey/monkey_island/cc/ui/src/components/configuration-components/ExportConfigModal.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/configuration-components/ExportConfigModal.tsx
@@ -1,53 +1,115 @@
 import {Button, Modal, Form} from 'react-bootstrap';
-import React from 'react';
+import React, {useState} from 'react';
+
+import AuthComponent from '../AuthComponent';
+import '../../styles/components/configuration-components/ExportConfigModal.scss';
+
 
 type Props = {
   show: boolean,
   onClick: () => void
 }
 
-
-const PasswordInput = (props) => {
-  return (
-    <div className={'config-export-password-input'}>
-      <p>Encrypt with a password:</p>
-      <Form.Control type='password' placeholder='Password' />
-    </div>
-  )
-}
-
-
 const ConfigExportModal = (props: Props) => {
+  // TODO implement the back end
+  const configExportEndpoint = '/api/configuration/export';
+
+  const [pass, setPass] = useState('');
+  const [radioValue, setRadioValue] = useState('password');
+  const authComponent = new AuthComponent({});
+
+  function isExportBtnDisabled() {
+    return pass === '' && radioValue === 'password';
+  }
+
+  function onSubmit() {
+    authComponent.authFetch(configExportEndpoint,
+      {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+          should_encrypt: (radioValue === 'password'),
+          password: pass
+        })
+      }
+    )
+  }
+
   return (
     <Modal show={props.show}
            onHide={props.onClick}
-           size={'lg'}>
+           size={'lg'}
+           className={'config-export-modal'}>
       <Modal.Header closeButton>
         <Modal.Title>Configuration export</Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        <div key={'config-export-option'} className='mb-3'>
-          <Form.Check
-            type={'radio'}
-            id={'password'}
-            label={<PasswordInput/>}
-          />
+        <div key={'config-export-option'}
+             className={`mb-3 export-type-radio-buttons`}>
+          <Form>
+            <Form.Check
+              type={'radio'}
+              className={'password-radio-button'}
+              label={<PasswordInput onChange={setPass}/>}
+              name={'export-choice'}
+              value={'password'}
+              onChange={evt => {
+                setRadioValue(evt.target.value)
+              }}
+              checked={radioValue === 'password'}
+            />
+            <ExportPlaintextChoiceField onChange={setRadioValue}
+                                        radioValue={radioValue}/>
+          </Form>
 
-          <Form.Check
-            type={'radio'}
-            label={'Skip encryption (export as plaintext)'}
-          />
         </div>
       </Modal.Body>
       <Modal.Footer>
-        <Button variant='secondary' onClick={props.onClick}>
-          Close
-        </Button>
-        <Button variant='primary' onClick={props.onClick}>
-          Save Changes
+        <Button variant={'info'}
+                onClick={onSubmit}
+                disabled={isExportBtnDisabled()}>
+          Export
         </Button>
       </Modal.Footer>
     </Modal>)
 }
+
+const PasswordInput = (props: {
+  onChange: (passValue) => void
+}) => {
+  return (
+    <div className={'config-export-password-input'}>
+      <p>Encrypt with a password:</p>
+      <Form.Control type='password'
+                    placeholder='Password'
+                    onChange={evt => (props.onChange(evt.target.value))}/>
+    </div>
+  )
+}
+
+const ExportPlaintextChoiceField = (props: {
+  radioValue: string,
+  onChange: (radioValue) => void
+}) => {
+  return (
+    <div className={'config-export-plaintext'}>
+      <Form.Check
+        type={'radio'}
+        label={'Skip encryption (export as plaintext)'}
+        name={'export-choice'}
+        value={'plaintext'}
+        checked={props.radioValue === 'plaintext'}
+        onChange={evt => {
+          props.onChange(evt.target.value);
+        }}
+      />
+      <p className={`export-warning text-secondary`}>
+        Configuration might contain stolen credentials or sensitive data.<br/>
+        It is advised to use password encryption option.
+      </p>
+    </div>
+  )
+}
+
 
 export default ConfigExportModal;

--- a/monkey/monkey_island/cc/ui/src/components/configuration-components/ExportConfigModal.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/configuration-components/ExportConfigModal.tsx
@@ -104,8 +104,8 @@ const ExportPlaintextChoiceField = (props: {
         }}
       />
       <p className={`export-warning text-secondary`}>
-        Configuration might contain stolen credentials or sensitive data.<br/>
-        It is advised to use password encryption option.
+        Configuration may contain stolen credentials or sensitive data.<br/>
+        It is advised to use password encryption.
       </p>
     </div>
   )

--- a/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
@@ -14,6 +14,7 @@ import InternalConfig from '../configuration-components/InternalConfig';
 import UnsafeOptionsConfirmationModal from '../configuration-components/UnsafeOptionsConfirmationModal.js';
 import UnsafeOptionsWarningModal from '../configuration-components/UnsafeOptionsWarningModal.js';
 import isUnsafeOptionSelected from '../utils/SafeOptionValidator.js';
+import ConfigExportModal from '../configuration-components/ExportConfigModal';
 
 const ATTACK_URL = '/api/attack';
 const CONFIG_URL = '/api/configuration/island';
@@ -40,7 +41,8 @@ class ConfigurePageComponent extends AuthComponent {
       selectedSection: 'attack',
       showAttackAlert: false,
       showUnsafeOptionsConfirmation: false,
-      showUnsafeAttackOptionsWarning: false
+      showUnsafeAttackOptionsWarning: false,
+      showConfigExportModal: false
     };
   }
 
@@ -219,6 +221,14 @@ class ConfigurePageComponent extends AuthComponent {
     }
     this.setState({configuration: newConfig, lastAction: 'none'});
   };
+
+  renderConfigExportModal = () => {
+    return (<ConfigExportModal show={this.state.showConfigExportModal}
+                               onClick={this.onExport} />)}
+
+  onExport = () => {
+    this.setState({showConfigExportModal: false})
+  }
 
   renderAttackAlertModal = () => {
     return (<Modal show={this.state.showAttackAlert} onHide={() => {
@@ -488,6 +498,7 @@ class ConfigurePageComponent extends AuthComponent {
       <Col sm={{offset: 3, span: 9}} md={{offset: 3, span: 9}}
            lg={{offset: 3, span: 8}} xl={{offset: 2, span: 8}}
            className={'main'}>
+        {this.renderConfigExportModal()}
         {this.renderAttackAlertModal()}
         {this.renderUnsafeOptionsConfirmationModal()}
         {this.renderUnsafeAttackOptionsWarningModal()}
@@ -509,7 +520,9 @@ class ConfigurePageComponent extends AuthComponent {
           </button>
           <input id='uploadInputInternal' type='file' accept='.conf' onChange={this.importConfig}
                  style={{display: 'none'}}/>
-          <button type='button' onClick={this.exportConfig} className='btn btn-info btn-lg' style={{margin: '5px'}}>
+          <button type='button'
+                  onClick={() => {this.setState({showConfigExportModal: true})}}
+                  className='btn btn-info btn-lg' style={{margin: '5px'}}>
             Export config
           </button>
         </div>

--- a/monkey/monkey_island/cc/ui/src/styles/components/configuration-components/ExportConfigModal.scss
+++ b/monkey/monkey_island/cc/ui/src/styles/components/configuration-components/ExportConfigModal.scss
@@ -1,0 +1,30 @@
+.config-export-modal .config-export-password-input p {
+  display: inline-block;
+  width: auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-right: 10px;
+}
+
+.config-export-modal .export-type-radio-buttons
+.password-radio-button .config-export-password-input input {
+  display: inline-block;
+  width: auto;
+  top: 0;
+  transform: none;
+}
+
+.config-export-modal .export-type-radio-buttons .password-radio-button input{
+  margin-top: 0;
+  top: 50%;
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+}
+
+.config-export-modal div.config-export-plaintext p.export-warning {
+  margin-left: 20px;
+}
+
+.config-export-modal div.config-export-plaintext {
+  margin-top: 15px;
+}


### PR DESCRIPTION
# What does this PR do? 

Creates a modal window/popup for configuration export.

Mockup:
![image](https://user-images.githubusercontent.com/36815064/119950851-01c28880-bfa4-11eb-9280-68a5835ef25a.png)

Results:
![image](https://user-images.githubusercontent.com/36815064/119950985-23237480-bfa4-11eb-8884-ab6d17bbfeb3.png)


## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing? 
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Have you successfully tested your changes locally? Elaborate:
    > Tested manually, by using all of the functionality in the popup: close modal, enter password, switch to plaintext, switch back to password, etc.
* [x] If applicable, add screenshots or log transcripts of the feature working
