### PR TITLE
Test data dir expand user env

### DIFF
--- a/monkey/monkey_island/setup/island_config_options.py
+++ b/monkey/monkey_island/setup/island_config_options.py
@@ -11,8 +11,9 @@ from monkey_island.cc.server_utils.consts import (
 
 class IslandConfigOptions:
     def __init__(self, config_contents: dict):
-        self.data_dir = os.path.expanduser(config_contents.get("data_dir", DEFAULT_DATA_DIR))
-
+        self.data_dir = os.path.expandvars(
+            os.path.expanduser(config_contents.get("data_dir", DEFAULT_DATA_DIR))
+        )
         self.log_level = config_contents.get("log_level", DEFAULT_LOG_LEVEL)
 
         self.start_mongodb = config_contents.get(

--- a/monkey/tests/unit_tests/monkey_island/setup/test_island_config_options.py
+++ b/monkey/tests/unit_tests/monkey_island/setup/test_island_config_options.py
@@ -33,7 +33,7 @@ def test_island_config_options__data_dir_expanduser(monkeypatch, tmpdir):
     DATA_DIR_NAME = "test_data_dir"
 
     assert_island_config_options_data_dir_equals(
-        {"data_dir": f"~/{DATA_DIR_NAME}"}, os.path.join(tmpdir, DATA_DIR_NAME)
+        {"data_dir": os.path.join("~", DATA_DIR_NAME)}, os.path.join(tmpdir, DATA_DIR_NAME)
     )
 
 
@@ -42,7 +42,7 @@ def test_island_config_options__data_dir_expandvars(monkeypatch, tmpdir):
     DATA_DIR_NAME = "test_data_dir"
 
     assert_island_config_options_data_dir_equals(
-        {"data_dir": f"$HOME/{DATA_DIR_NAME}"}, os.path.join(tmpdir, DATA_DIR_NAME)
+        {"data_dir": os.path.join("$HOME", DATA_DIR_NAME)}, os.path.join(tmpdir, DATA_DIR_NAME)
     )
 
 

--- a/monkey/tests/unit_tests/monkey_island/setup/test_island_config_options.py
+++ b/monkey/tests/unit_tests/monkey_island/setup/test_island_config_options.py
@@ -52,3 +52,12 @@ def test_island_config_options__data_dir_expanduser(monkeypatch, tmpdir):
     options = IslandConfigOptions({"data_dir": f"~/{DATA_DIR_NAME}"})
 
     assert options.data_dir == os.path.join(tmpdir, DATA_DIR_NAME)
+
+
+def test_island_config_options__data_dir_expandvars(monkeypatch, tmpdir):
+    set_home_env(monkeypatch, tmpdir)
+    DATA_DIR_NAME = "test_data_dir"
+
+    options = IslandConfigOptions({"data_dir": f"$HOME/{DATA_DIR_NAME}"})
+
+    assert options.data_dir == os.path.join(tmpdir, DATA_DIR_NAME)

--- a/monkey/tests/unit_tests/monkey_island/setup/test_island_config_options.py
+++ b/monkey/tests/unit_tests/monkey_island/setup/test_island_config_options.py
@@ -1,3 +1,5 @@
+import os
+
 from monkey_island.cc.server_utils.consts import (
     DEFAULT_DATA_DIR,
     DEFAULT_LOG_LEVEL,
@@ -37,3 +39,16 @@ def test_island_config_options__mongodb():
     assert options.start_mongodb == DEFAULT_START_MONGO_DB
     options = IslandConfigOptions(TEST_CONFIG_FILE_CONTENTS_NO_STARTMONGO)
     assert options.start_mongodb == DEFAULT_START_MONGO_DB
+
+
+def set_home_env(monkeypatch, tmpdir):
+    monkeypatch.setenv("HOME", str(tmpdir))
+
+
+def test_island_config_options__data_dir_expanduser(monkeypatch, tmpdir):
+    set_home_env(monkeypatch, tmpdir)
+    DATA_DIR_NAME = "test_data_dir"
+
+    options = IslandConfigOptions({"data_dir": f"~/{DATA_DIR_NAME}"})
+
+    assert options.data_dir == os.path.join(tmpdir, DATA_DIR_NAME)

--- a/monkey/tests/unit_tests/monkey_island/setup/test_island_config_options.py
+++ b/monkey/tests/unit_tests/monkey_island/setup/test_island_config_options.py
@@ -18,11 +18,41 @@ TEST_CONFIG_FILE_CONTENTS_UNSPECIFIED = {}
 TEST_CONFIG_FILE_CONTENTS_NO_STARTMONGO = {"mongodb": {}}
 
 
-def test_island_config_options__data_dir():
-    options = IslandConfigOptions(TEST_CONFIG_FILE_CONTENTS_SPECIFIED)
-    assert options.data_dir == "/tmp"
-    options = IslandConfigOptions(TEST_CONFIG_FILE_CONTENTS_UNSPECIFIED)
-    assert options.data_dir == DEFAULT_DATA_DIR
+def test_island_config_options__data_dir_specified():
+    assert_island_config_options_data_dir_equals(TEST_CONFIG_FILE_CONTENTS_SPECIFIED, "/tmp")
+
+
+def test_island_config_options__data_dir_uses_default():
+    assert_island_config_options_data_dir_equals(
+        TEST_CONFIG_FILE_CONTENTS_UNSPECIFIED, DEFAULT_DATA_DIR
+    )
+
+
+def test_island_config_options__data_dir_expanduser(monkeypatch, tmpdir):
+    set_home_env(monkeypatch, tmpdir)
+    DATA_DIR_NAME = "test_data_dir"
+
+    assert_island_config_options_data_dir_equals(
+        {"data_dir": f"~/{DATA_DIR_NAME}"}, os.path.join(tmpdir, DATA_DIR_NAME)
+    )
+
+
+def test_island_config_options__data_dir_expandvars(monkeypatch, tmpdir):
+    set_home_env(monkeypatch, tmpdir)
+    DATA_DIR_NAME = "test_data_dir"
+
+    assert_island_config_options_data_dir_equals(
+        {"data_dir": f"$HOME/{DATA_DIR_NAME}"}, os.path.join(tmpdir, DATA_DIR_NAME)
+    )
+
+
+def set_home_env(monkeypatch, tmpdir):
+    monkeypatch.setenv("HOME", str(tmpdir))
+
+
+def assert_island_config_options_data_dir_equals(config_file_contents, expected_data_dir):
+    options = IslandConfigOptions(config_file_contents)
+    assert options.data_dir == expected_data_dir
 
 
 def test_island_config_options__log_level():
@@ -39,25 +69,3 @@ def test_island_config_options__mongodb():
     assert options.start_mongodb == DEFAULT_START_MONGO_DB
     options = IslandConfigOptions(TEST_CONFIG_FILE_CONTENTS_NO_STARTMONGO)
     assert options.start_mongodb == DEFAULT_START_MONGO_DB
-
-
-def set_home_env(monkeypatch, tmpdir):
-    monkeypatch.setenv("HOME", str(tmpdir))
-
-
-def test_island_config_options__data_dir_expanduser(monkeypatch, tmpdir):
-    set_home_env(monkeypatch, tmpdir)
-    DATA_DIR_NAME = "test_data_dir"
-
-    options = IslandConfigOptions({"data_dir": f"~/{DATA_DIR_NAME}"})
-
-    assert options.data_dir == os.path.join(tmpdir, DATA_DIR_NAME)
-
-
-def test_island_config_options__data_dir_expandvars(monkeypatch, tmpdir):
-    set_home_env(monkeypatch, tmpdir)
-    DATA_DIR_NAME = "test_data_dir"
-
-    options = IslandConfigOptions({"data_dir": f"$HOME/{DATA_DIR_NAME}"})
-
-    assert options.data_dir == os.path.join(tmpdir, DATA_DIR_NAME)


### PR DESCRIPTION
# What does this PR do? 

1. Expand environment variables if they are in `data_dir`
2. Adds unit tests to ensure that "~" and "$HOME" are expanded if they are in `data_dir`


## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing? 
* [ ] ~~Was the CHANGELOG.md updated to reflect the changes?~~
* [ ] ~~Was the documentation framework updated to reflect the changes?~~

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running unit test suite
* [ ] ~~If applicable, add screenshots or log transcripts of the feature working~~