### PR TITLE
Ransomware readme behavior

### DIFF
--- a/monkey/infection_monkey/pyinstaller_hooks/hook-infection_monkey.ransomware.py
+++ b/monkey/infection_monkey/pyinstaller_hooks/hook-infection_monkey.ransomware.py
@@ -1,0 +1,3 @@
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files("infection_monkey.ransomware")

--- a/monkey/infection_monkey/ransomware/ransomware_readme.txt
+++ b/monkey/infection_monkey/ransomware/ransomware_readme.txt
@@ -1,0 +1,2 @@
+This is a placeholder README for the Infection Monkey Ransomware Simulation.
+Don't panic :)

--- a/monkey/monkey_island/cc/services/config_schema/ransomware.py
+++ b/monkey/monkey_island/cc/services/config_schema/ransomware.py
@@ -27,7 +27,7 @@ RANSOMWARE = {
             "type": "object",
             "properties": {
                 "readme": {
-                    "title": "Create a README.TXT file",
+                    "title": "Create a README.txt file",
                     "type": "boolean",
                     "default": True,
                     "description": "Creates a README.txt ransomware note on infected systems.",

--- a/monkey/tests/unit_tests/infection_monkey/ransomware/test_ransomware_payload.py
+++ b/monkey/tests/unit_tests/infection_monkey/ransomware/test_ransomware_payload.py
@@ -1,5 +1,5 @@
 import os
-from pathlib import PurePath
+from pathlib import Path, PurePath
 
 import pytest
 from tests.unit_tests.infection_monkey.ransomware.ransomware_target_files import (
@@ -22,7 +22,11 @@ from tests.unit_tests.infection_monkey.ransomware.ransomware_target_files import
 from tests.utils import hash_file, is_user_admin
 
 from infection_monkey.ransomware import ransomware_payload as ransomware_payload_module
-from infection_monkey.ransomware.ransomware_payload import EXTENSION, RansomewarePayload
+from infection_monkey.ransomware.ransomware_payload import (
+    EXTENSION,
+    README_DEST,
+    RansomewarePayload,
+)
 from infection_monkey.telemetry.i_telem import ITelem
 from infection_monkey.telemetry.messengers.i_telemetry_messenger import ITelemetryMessenger
 
@@ -42,7 +46,8 @@ def with_extension(filename):
 @pytest.fixture
 def ransomware_payload_config(ransomware_target):
     return {
-        "directories": {"linux_dir": str(ransomware_target), "windows_dir": str(ransomware_target)}
+        "directories": {"linux_dir": str(ransomware_target), "windows_dir": str(ransomware_target)},
+        "other_behaviors": {"readme": False},
     }
 
 
@@ -166,3 +171,19 @@ def test_telemetry_failure(monkeypatch, ransomware_payload, telemetry_messenger_
 
     assert "/file/not/exist" in telem_1.get_data()["ransomware_attempts"][0]
     assert "No such file or directory" in telem_1.get_data()["ransomware_attempts"][1]
+
+
+def test_readme_false(ransomware_payload_config, ransomware_target, telemetry_messenger_spy):
+    ransomware_payload_config["other_behaviors"]["readme"] = False
+    ransomware_payload = RansomewarePayload(ransomware_payload_config, telemetry_messenger_spy)
+
+    ransomware_payload.run_payload()
+    assert not Path(ransomware_target / README_DEST).exists()
+
+
+def test_readme_true(ransomware_payload_config, ransomware_target, telemetry_messenger_spy):
+    ransomware_payload_config["other_behaviors"]["readme"] = True
+    ransomware_payload = RansomewarePayload(ransomware_payload_config, telemetry_messenger_spy)
+
+    ransomware_payload.run_payload()
+    assert Path(ransomware_target / README_DEST).exists()


### PR DESCRIPTION
# What does this PR do? 
Issue #1244

Adds functionality to the ransomware payload that leaves a README.txt file in the ransomware target directory after encryption has finished.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing? 
* [ ] ~~Was the CHANGELOG.md updated to reflect the changes?~~
* [ ] ~~Was the documentation framework updated to reflect the changes?~~

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running unit tests, running from source, and building and running an agent binary
* [ ] ~~If applicable, add screenshots or log transcripts of the feature working~~
