### PR TITLE
Agent: Format config log messages so they are readable

### DIFF
--- a/monkey/infection_monkey/control.py
+++ b/monkey/infection_monkey/control.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import platform
+from pprint import pformat
 from socket import gethostname
 from urllib.parse import urljoin
 
@@ -206,10 +207,10 @@ class ControlClient(object):
 
         try:
             unknown_variables = WormConfiguration.from_kv(reply.json().get("config"))
-            LOG.info(
-                "New configuration was loaded from server: %r"
-                % (WormConfiguration.hide_sensitive_info(WormConfiguration.as_dict()),)
+            formatted_config = pformat(
+                WormConfiguration.hide_sensitive_info(WormConfiguration.as_dict())
             )
+            LOG.info(f"New configuration was loaded from server:\n{formatted_config}")
         except Exception as exc:
             # we don't continue with default conf here because it might be dangerous
             LOG.error(

--- a/monkey/infection_monkey/main.py
+++ b/monkey/infection_monkey/main.py
@@ -6,6 +6,7 @@ import os
 import sys
 import traceback
 from multiprocessing import freeze_support
+from pprint import pformat
 
 # dummy import for pyinstaller
 # noinspection PyUnresolvedReferences
@@ -76,10 +77,8 @@ def main():
             "default" % (config_file,)
         )
 
-    print(
-        "Loaded Configuration: %r"
-        % WormConfiguration.hide_sensitive_info(WormConfiguration.as_dict())
-    )
+    formatted_config = pformat(WormConfiguration.hide_sensitive_info(WormConfiguration.as_dict()))
+    print(f"Loaded Configuration:\n{formatted_config}")
 
     # Make sure we're not in a machine that has the kill file
     kill_path = (


### PR DESCRIPTION
# What does this PR do? 

When monkey agent logs its default/new configuration, format the output so it is more easily readable.

Add any further explanations here. 

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing? 
* [ ] ~~Was the CHANGELOG.md updated to reflect the changes?~~
* [ ] ~~Was the documentation framework updated to reflect the changes?~~

## Testing Checklist

* [ ] ~~Added relevant unit tests?~~
* [x] Have you successfully tested your changes locally? Elaborate:
    > See screenshot
* [x] If applicable, add screenshots or log transcripts of the feature working

## Screenshots

![image](https://user-images.githubusercontent.com/19957806/123957979-807f5c80-d97a-11eb-98a9-a20ddf362860.png)


