### PR TITLE
Gevent ssl traceback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Attempted to delete a directory when monkey config reset was called. #1054
 - An errant space in the windows commands to run monkey manually. #1153
+- gevent tracebacks in console output. #859
 
 ### Security
 - Address minor issues discovered by Dlint. #1075

--- a/monkey/monkey_island/cc/server_setup.py
+++ b/monkey/monkey_island/cc/server_setup.py
@@ -117,6 +117,8 @@ def _start_island_server(should_setup_only, config_options: IslandConfigOptions)
             app,
             certfile=config_options.crt_path,
             keyfile=config_options.key_path,
+            log=logger,
+            error_log=logger,
         )
         _log_init_info()
         http_server.serve_forever()

--- a/monkey/monkey_island/cc/server_utils/consts.py
+++ b/monkey/monkey_island/cc/server_utils/consts.py
@@ -52,3 +52,5 @@ DEFAULT_CERTIFICATE_PATHS = {
     "ssl_certificate_file": DEFAULT_CRT_PATH,
     "ssl_certificate_key_file": DEFAULT_KEY_PATH,
 }
+
+GEVENT_EXCEPTION_LOG = "gevent_exceptions.log"

--- a/monkey/monkey_island/cc/setup/gevent_hub_error_handler.py
+++ b/monkey/monkey_island/cc/setup/gevent_hub_error_handler.py
@@ -1,0 +1,26 @@
+import traceback
+
+import gevent.hub
+
+
+class GeventHubErrorHandler:
+    """
+    Wraps gevent.hub.Hub's handle_error() method so that the exception can be
+    logged but the traceback can be stored in a separate file. This preserves
+    the default gevent functionality and adds a useful, concise log message to
+    the Monkey Island logs.
+
+    For more information, see
+        https://github.com/guardicore/monkey/issues/859,
+        https://www.gevent.org/api/gevent.hub.html#gevent.hub.Hub.handle_error
+        https://github.com/gevent/gevent/issues/1482
+    """
+
+    def __init__(self, hub: gevent.hub.Hub, logger):
+        self._original_handle_error = hub.handle_error
+        self._logger = logger
+
+    def __call__(self, context, type_, value, tb):
+        exception_msg = traceback.format_exception_only(type_, value)
+        self._logger.warning(f"gevent caught an exception: {exception_msg}")
+        self._original_handle_error(context, type_, value, tb)

--- a/vulture_allowlist.py
+++ b/vulture_allowlist.py
@@ -170,6 +170,7 @@ ISLAND  # unused variable (monkey/monkey_island/cc/services/utils/node_states.py
 MONKEY_LINUX_RUNNING  # unused variable (monkey/monkey_island/cc/services/utils/node_states.py:26)
 import_status  # monkey_island\cc\resources\configuration_import.py:19
 config_schema  # monkey_island\cc\resources\configuration_import.py:25
+exception_stream  # unused attribute (monkey_island/cc/server_setup.py:104)
 
 # these are not needed for it to work, but may be useful extra information to understand what's going on
 WINDOWS_PBA_TYPE  # unused variable (monkey/monkey_island/cc/resources/pba_file_upload.py:23)


### PR DESCRIPTION
# What does this PR do? 

Fixes #859

The gevent hub has 2 mechanisms for controlling how errors (tracebacks) are handled.

1. The `exception_stream` controls where tracebacks are written (default=stderr): https://www.gevent.org/api/gevent.hub.html#gevent.hub.Hub.exception_stream
2. The `handle_error()` method controls what happens when an error is encountered: https://www.gevent.org/api/gevent.hub.html#gevent.hub.Hub.handle_error

If `exception_stream` is set, the user may not get any indication that a gevent error occurred. To solve this, the `handle_error()` functionality is wrapped and the exception (not traceback) is logged to WARNING. 

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing? 
* [x] Was the CHANGELOG.md updated to reflect the changes?
* [ ] ~~Was the documentation framework updated to reflect the changes?~~

## Testing Checklist

* [ ] ~~Added relevant unit tests?~~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running monkey island
* [x] If applicable, add screenshots or log transcripts of the feature working

## Screenshots
![image](https://user-images.githubusercontent.com/19957806/124498817-fcb6dd00-dd8a-11eb-9358-ac9c23d7a2a5.png)
