### PR TITLE
island: Add delimiter to windows create_certificate

### DIFF
--- a/monkey/monkey_island/windows/create_certificate.bat
+++ b/monkey/monkey_island/windows/create_certificate.bat
@@ -20,13 +20,13 @@ copy "%mydir%windows\openssl.cfg" "%mydir%bin\openssl\openssl.cfg"
 
 :: Change file permissions
 SET adminsIdentity="BUILTIN\Administrators"
-FOR /f %%O IN ('whoami') DO SET ownIdentity=%%O
+FOR /f "delims=''" %%O IN ('whoami') DO SET ownIdentity=%%O
 
 FOR %%F IN ("%mydir%cc\server.key", "%mydir%cc\server.csr", "%mydir%cc\server.crt") DO (
 
 	:: Remove all others and add admins rule (with full control)
-	echo y| cacls %%F" /p %adminsIdentity%:F
+	echo y| cacls %%F /p %adminsIdentity%:F
 
 	:: Add user rule (with read)
-	echo y| cacls %%F /e /p %ownIdentity%:R
+	echo y| cacls %%F /e /p "%ownIdentity%":R
 )


### PR DESCRIPTION
# What does this PR do? 

Fixes delimiter problem in `windows\create_certificate.bat`. 

Add any further explanations here. 

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing? 
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Have you successfully tested your changes locally? Elaborate:
    > Tested by {Running the Monkey locally with relevant config/running Island/...} 
* [ ] If applicable, add screenshots or log transcripts of the feature working

## Explain Changes

Are the commit messages enough? If not, elaborate. 
