### PR TITLE
Add file encryption UT for ransomware payload: test no ecryption when no directory specified

### DIFF
--- a/monkey/tests/unit_tests/infection_monkey/ransomware/test_ransomware_payload.py
+++ b/monkey/tests/unit_tests/infection_monkey/ransomware/test_ransomware_payload.py
@@ -163,6 +163,24 @@ def test_encryption_skipped_if_configured_false(
     assert hash_file(ransomware_target / TEST_KEYBOARD_TXT) == TEST_KEYBOARD_TXT_CLEARTEXT_SHA256
 
 
+def test_encryption_skipped_if_no_directory(
+    ransomware_payload_config, telemetry_messenger_spy, monkeypatch
+):
+    ransomware_payload_config["encryption"]["enabled"] = True
+    ransomware_payload_config["encryption"]["directories"]["linux_target_dir"] = ""
+    ransomware_payload_config["encryption"]["directories"]["windows_target_dir"] = ""
+
+    def _file_encryption_method_mock(*args, **kwargs):
+        raise Exception(
+            "Ransomware payload attempted to "
+            "encrypt files even though no directory was provided!"
+        )
+
+    ransomware_payload = RansomwarePayload(ransomware_payload_config, telemetry_messenger_spy)
+    monkeypatch.setattr(ransomware_payload, "_encrypt_files", _file_encryption_method_mock)
+    ransomware_payload.run_payload()
+
+
 def test_telemetry_success(ransomware_payload, telemetry_messenger_spy):
     ransomware_payload.run_payload()
 


### PR DESCRIPTION
Add a UT to test if ransomware payload tries to encrypt files if "linux_target_dir" and "windows_target_dir" inputs are empty.

We have empty "linux_target_dir" and "windows_target_dir" by default so it's important that ransomware payload doesn't try to encrypt files by default, without users' knowledge.

Add any further explanations here. 

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing? 
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?

## Testing Checklist

* [ ] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by Running the UT, seeing it fail.
* [ ] If applicable, add screenshots or log transcripts of the feature working

