### PR TITLE
Ransomeware bugfix: cwd encryption by default

### DIFF
--- a/monkey/common/utils/file_utils.py
+++ b/monkey/common/utils/file_utils.py
@@ -1,5 +1,11 @@
 import os
 
 
+class InvalidPath(Exception):
+    pass
+
+
 def expand_path(path: str) -> str:
+    if not path:
+        raise InvalidPath("Empty path provided")
     return os.path.expandvars(os.path.expanduser(path))

--- a/monkey/infection_monkey/ransomware/ransomware_payload.py
+++ b/monkey/infection_monkey/ransomware/ransomware_payload.py
@@ -50,7 +50,7 @@ class RansomwarePayload:
             return None
 
     def run_payload(self):
-        if self._encryption_enabled:
+        if self._encryption_enabled and self._target_dir:
             LOG.info("Running ransomware payload")
             file_list = self._find_files()
             self._encrypt_files(file_list)

--- a/monkey/infection_monkey/ransomware/ransomware_payload.py
+++ b/monkey/infection_monkey/ransomware/ransomware_payload.py
@@ -46,7 +46,8 @@ class RansomwarePayload:
 
         try:
             return Path(expand_path(target_dir_field))
-        except InvalidPath:
+        except InvalidPath as e:
+            LOG.debug(f"Target ransomware dir set to None: {e}")
             return None
 
     def run_payload(self):

--- a/monkey/tests/unit_tests/common/utils/test_common_file_utils.py
+++ b/monkey/tests/unit_tests/common/utils/test_common_file_utils.py
@@ -1,6 +1,8 @@
 import os
 
-from common.utils.file_utils import expand_path
+import pytest
+
+from common.utils.file_utils import InvalidPath, expand_path
 
 
 def test_expand_user(patched_home_env):
@@ -15,3 +17,8 @@ def test_expand_vars(patched_home_env):
     expected_path = os.path.join(patched_home_env, "test")
 
     assert expand_path(input_path) == expected_path
+
+
+def test_expand_path__empty_path_provided():
+    with pytest.raises(InvalidPath):
+        expand_path("")

--- a/monkey/tests/unit_tests/infection_monkey/ransomware/test_ransomware_payload.py
+++ b/monkey/tests/unit_tests/infection_monkey/ransomware/test_ransomware_payload.py
@@ -163,6 +163,24 @@ def test_encryption_skipped_if_configured_false(
     assert hash_file(ransomware_target / TEST_KEYBOARD_TXT) == TEST_KEYBOARD_TXT_CLEARTEXT_SHA256
 
 
+def test_encryption_skipped_if_no_directory(
+    ransomware_payload_config, telemetry_messenger_spy, monkeypatch
+):
+    ransomware_payload_config["encryption"]["enabled"] = True
+    ransomware_payload_config["encryption"]["directories"]["linux_target_dir"] = ""
+    ransomware_payload_config["encryption"]["directories"]["windows_target_dir"] = ""
+
+    def _file_encryption_method_mock(*args, **kwargs):
+        raise Exception(
+            "Ransomware payload attempted to "
+            "encrypt files even though no directory was provided!"
+        )
+
+    ransomware_payload = RansomwarePayload(ransomware_payload_config, telemetry_messenger_spy)
+    monkeypatch.setattr(ransomware_payload, "_encrypt_files", _file_encryption_method_mock)
+    ransomware_payload.run_payload()
+
+
 def test_telemetry_success(ransomware_payload, telemetry_messenger_spy):
     ransomware_payload.run_payload()
 


### PR DESCRIPTION
# What does this PR do? 

Fixes ransomware encrypting CWD by default, when no directory is specified
Improves readability in ransomware payload
Changes `expand_path` in `monkey/common/utils/file_utils.py` to raise an exception if empty path is specified.

Add any further explanations here. 

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing? 
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running unit tests
* [ ] If applicable, add screenshots or log transcripts of the feature working

