### PR TITLE
Island: Refactor test_encryption_skipped_if_no_directory()

### DIFF
--- a/monkey/tests/unit_tests/infection_monkey/ransomware/test_ransomware_payload.py
+++ b/monkey/tests/unit_tests/infection_monkey/ransomware/test_ransomware_payload.py
@@ -170,15 +170,9 @@ def test_encryption_skipped_if_no_directory(
     ransomware_payload_config["encryption"]["directories"]["linux_target_dir"] = ""
     ransomware_payload_config["encryption"]["directories"]["windows_target_dir"] = ""
 
-    def _file_encryption_method_mock(*args, **kwargs):
-        raise Exception(
-            "Ransomware payload attempted to "
-            "encrypt files even though no directory was provided!"
-        )
-
     ransomware_payload = RansomwarePayload(ransomware_payload_config, telemetry_messenger_spy)
-    monkeypatch.setattr(ransomware_payload, "_encrypt_files", _file_encryption_method_mock)
     ransomware_payload.run_payload()
+    assert len(telemetry_messenger_spy.telemetries) == 0
 
 
 def test_telemetry_success(ransomware_payload, telemetry_messenger_spy):


### PR DESCRIPTION
The old implementation tightly coupled the test to the specific
implementation of the ransomware payload. Since the ransomware payload
provides insight into its actions in the form of telemetry, it should be
sufficient to test whether or not any telemetries were sent in order to
determine whether or not encryption was skipped. This way, the test can
remain decoupled from the internal workings of the ransomware payload.


## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing? 
* [ ] ~~Was the CHANGELOG.md updated to reflect the changes?~~
* [ ] ~~Was the documentation framework updated to reflect the changes?~~

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running unit tests
* [ ] ~~If applicable, add screenshots or log transcripts of the feature working~~
