### PR TITLE
Ransomware README improvements

### DIFF
--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -477,7 +478,7 @@ class InfectionMonkey(object):
 
         try:
             RansomwarePayload(
-                WormConfiguration.ransomware, batching_telemetry_messenger
+                WormConfiguration.ransomware, batching_telemetry_messenger, shutil.copyfile
             ).run_payload()
         except Exception as ex:
             LOG.error(f"An unexpected error occurred while running the ransomware payload: {ex}")

--- a/monkey/infection_monkey/ransomware/ransomware_payload.py
+++ b/monkey/infection_monkey/ransomware/ransomware_payload.py
@@ -25,7 +25,7 @@ class RansomwarePayload:
         self,
         config: dict,
         telemetry_messenger: ITelemetryMessenger,
-        copy_file: Callable[[str, str], None],
+        copy_file: Callable[[Path, Path], None],
     ):
         LOG.debug(f"Ransomware payload configuration:\n{pformat(config)}")
 

--- a/monkey/infection_monkey/ransomware/ransomware_payload.py
+++ b/monkey/infection_monkey/ransomware/ransomware_payload.py
@@ -97,15 +97,21 @@ class RansomwarePayload:
         self._telemetry_messenger.send_telemetry(encryption_attempt)
 
     def _leave_readme(self):
-        if self._readme_enabled:
-            readme_dest_path = self._target_dir / README_DEST
-            if readme_dest_path.exists():
-                LOG.warning(f"{readme_dest_path} already exists, not leaving a new README.txt")
-                return
+        if not self._readme_enabled:
+            return
 
-            LOG.info(f"Leaving a ransomware README file at {readme_dest_path}")
+        readme_dest_path = self._target_dir / README_DEST
 
-            try:
-                self._copy_file(README_SRC, readme_dest_path)
-            except Exception as ex:
-                LOG.warning(f"An error occurred while attempting to leave a README.txt file: {ex}")
+        if readme_dest_path.exists():
+            LOG.warning(f"{readme_dest_path} already exists, not leaving a new README.txt")
+            return
+
+        self._copy_readme_file(readme_dest_path)
+
+    def _copy_readme_file(self, dest: Path):
+        LOG.info(f"Leaving a ransomware README file at {dest}")
+
+        try:
+            self._copy_file(README_SRC, dest)
+        except Exception as ex:
+            LOG.warning(f"An error occurred while attempting to leave a README.txt file: {ex}")

--- a/monkey/infection_monkey/ransomware/ransomware_payload.py
+++ b/monkey/infection_monkey/ransomware/ransomware_payload.py
@@ -99,6 +99,10 @@ class RansomwarePayload:
     def _leave_readme(self):
         if self._readme_enabled:
             readme_dest_path = self._target_dir / README_DEST
+            if readme_dest_path.exists():
+                LOG.warning(f"{readme_dest_path} already exists, not leaving a new README.txt")
+                return
+
             LOG.info(f"Leaving a ransomware README file at {readme_dest_path}")
 
             try:

--- a/monkey/tests/unit_tests/infection_monkey/ransomware/test_ransomware_payload.py
+++ b/monkey/tests/unit_tests/infection_monkey/ransomware/test_ransomware_payload.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from pathlib import Path, PurePosixPath
 
 import pytest
@@ -44,12 +45,20 @@ def ransomware_payload_config(ransomware_target):
 
 
 @pytest.fixture
-def ransomware_payload(ransomware_payload_config, telemetry_messenger_spy):
-    return RansomwarePayload(ransomware_payload_config, telemetry_messenger_spy)
+def ransomware_payload(build_ransomware_payload, ransomware_payload_config):
+    return build_ransomware_payload(ransomware_payload_config)
+
+
+@pytest.fixture
+def build_ransomware_payload(telemetry_messenger_spy):
+    def inner(config):
+        return RansomwarePayload(config, telemetry_messenger_spy, shutil.copyfile)
+
+    return inner
 
 
 def test_env_variables_in_target_dir_resolved_linux(
-    ransomware_payload_config, ransomware_target, telemetry_messenger_spy, patched_home_env
+    ransomware_payload_config, build_ransomware_payload, ransomware_target, patched_home_env
 ):
     path_with_env_variable = "$HOME/ransomware_target"
 
@@ -58,7 +67,7 @@ def test_env_variables_in_target_dir_resolved_linux(
     ] = ransomware_payload_config["encryption"]["directories"][
         "windows_target_dir"
     ] = path_with_env_variable
-    RansomwarePayload(ransomware_payload_config, telemetry_messenger_spy).run_payload()
+    build_ransomware_payload(ransomware_payload_config).run_payload()
 
     assert (
         hash_file(ransomware_target / with_extension(ALL_ZEROS_PDF))
@@ -152,11 +161,11 @@ def test_skip_already_encrypted_file(ransomware_target, ransomware_payload):
 
 
 def test_encryption_skipped_if_configured_false(
-    ransomware_payload_config, ransomware_target, telemetry_messenger_spy
+    build_ransomware_payload, ransomware_payload_config, ransomware_target
 ):
     ransomware_payload_config["encryption"]["enabled"] = False
 
-    ransomware_payload = RansomwarePayload(ransomware_payload_config, telemetry_messenger_spy)
+    ransomware_payload = build_ransomware_payload(ransomware_payload_config)
     ransomware_payload.run_payload()
 
     assert hash_file(ransomware_target / ALL_ZEROS_PDF) == ALL_ZEROS_PDF_CLEARTEXT_SHA256
@@ -164,13 +173,13 @@ def test_encryption_skipped_if_configured_false(
 
 
 def test_encryption_skipped_if_no_directory(
-    ransomware_payload_config, telemetry_messenger_spy, monkeypatch
+    build_ransomware_payload, ransomware_payload_config, telemetry_messenger_spy
 ):
     ransomware_payload_config["encryption"]["enabled"] = True
     ransomware_payload_config["encryption"]["directories"]["linux_target_dir"] = ""
     ransomware_payload_config["encryption"]["directories"]["windows_target_dir"] = ""
 
-    ransomware_payload = RansomwarePayload(ransomware_payload_config, telemetry_messenger_spy)
+    ransomware_payload = build_ransomware_payload(ransomware_payload_config)
     ransomware_payload.run_payload()
     assert len(telemetry_messenger_spy.telemetries) == 0
 
@@ -205,17 +214,17 @@ def test_telemetry_failure(monkeypatch, ransomware_payload, telemetry_messenger_
     assert "No such file or directory" in telem_1.get_data()["files"][0]["error"]
 
 
-def test_readme_false(ransomware_payload_config, ransomware_target, telemetry_messenger_spy):
+def test_readme_false(build_ransomware_payload, ransomware_payload_config, ransomware_target):
     ransomware_payload_config["other_behaviors"]["readme"] = False
-    ransomware_payload = RansomwarePayload(ransomware_payload_config, telemetry_messenger_spy)
+    ransomware_payload = build_ransomware_payload(ransomware_payload_config)
 
     ransomware_payload.run_payload()
     assert not Path(ransomware_target / README_DEST).exists()
 
 
-def test_readme_true(ransomware_payload_config, ransomware_target, telemetry_messenger_spy):
+def test_readme_true(build_ransomware_payload, ransomware_payload_config, ransomware_target):
     ransomware_payload_config["other_behaviors"]["readme"] = True
-    ransomware_payload = RansomwarePayload(ransomware_payload_config, telemetry_messenger_spy)
+    ransomware_payload = build_ransomware_payload(ransomware_payload_config)
 
     ransomware_payload.run_payload()
     assert Path(ransomware_target / README_DEST).exists()

--- a/monkey/tests/unit_tests/infection_monkey/ransomware/test_ransomware_payload.py
+++ b/monkey/tests/unit_tests/infection_monkey/ransomware/test_ransomware_payload.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 from pathlib import Path, PurePosixPath
+from unittest.mock import MagicMock
 
 import pytest
 from tests.unit_tests.infection_monkey.ransomware.ransomware_target_files import (
@@ -228,3 +229,18 @@ def test_readme_true(build_ransomware_payload, ransomware_payload_config, ransom
 
     ransomware_payload.run_payload()
     assert Path(ransomware_target / README_DEST).exists()
+
+
+def test_readme_already_exists(
+    monkeypatch, ransomware_payload_config, telemetry_messenger_spy, ransomware_target
+):
+    monkeypatch.setattr(ransomware_payload_module, "TARGETED_FILE_EXTENSIONS", set()),
+    mock_copy_file = MagicMock()
+
+    ransomware_payload_config["other_behaviors"]["readme"] = True
+    Path(ransomware_target / README_DEST).touch()
+    RansomwarePayload(
+        ransomware_payload_config, telemetry_messenger_spy, mock_copy_file
+    ).run_payload()
+
+    mock_copy_file.assert_not_called()


### PR DESCRIPTION
# What does this PR do? 

Adds a check to prevent the ransomware payload from overwriting an existing README.txt.
Adds a `copy_file` callable to the RansomwarePayload constructor to decouple RansomwarePayload from the specific file copy implementation. See f0e9109f6 for more information.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing? 
* [ ] ~~Was the CHANGELOG.md updated to reflect the changes?~~
* [ ] ~~Was the documentation framework updated to reflect the changes?~~

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running unit tests
* [ ] ~~If applicable, add screenshots or log transcripts of the feature working~~
