### PR TITLE
Ransomware README with configurable directories

### DIFF
--- a/monkey/infection_monkey/ransomware/ransomware_payload.py
+++ b/monkey/infection_monkey/ransomware/ransomware_payload.py
@@ -61,7 +61,8 @@ class RansomwarePayload:
             file_list = self._find_files()
             self._encrypt_files(file_list)
 
-        self._leave_readme()
+        if self._target_dir:
+            self._leave_readme()
 
     def _find_files(self) -> List[Path]:
         LOG.info(f"Collecting files in {self._target_dir}")

--- a/monkey/infection_monkey/ransomware/ransomware_payload.py
+++ b/monkey/infection_monkey/ransomware/ransomware_payload.py
@@ -56,12 +56,16 @@ class RansomwarePayload:
             return None
 
     def run_payload(self):
+        if not self._target_dir:
+            return
+
+        LOG.info("Running ransomware payload")
+
         if self._encryption_enabled and self._target_dir:
-            LOG.info("Running ransomware payload")
             file_list = self._find_files()
             self._encrypt_files(file_list)
 
-        if self._target_dir:
+        if self._readme_enabled:
             self._leave_readme()
 
     def _find_files(self) -> List[Path]:
@@ -93,8 +97,6 @@ class RansomwarePayload:
         self._telemetry_messenger.send_telemetry(encryption_attempt)
 
     def _leave_readme(self):
-        if not self._readme_enabled:
-            return
 
         readme_dest_path = self._target_dir / README_DEST
 

--- a/monkey/infection_monkey/ransomware/ransomware_payload.py
+++ b/monkey/infection_monkey/ransomware/ransomware_payload.py
@@ -61,7 +61,7 @@ class RansomwarePayload:
 
         LOG.info("Running ransomware payload")
 
-        if self._encryption_enabled and self._target_dir:
+        if self._encryption_enabled:
             file_list = self._find_files()
             self._encrypt_files(file_list)
 

--- a/monkey/monkey_island/cc/services/config_schema/ransomware.py
+++ b/monkey/monkey_island/cc/services/config_schema/ransomware.py
@@ -52,7 +52,8 @@ RANSOMWARE = {
                 "readme_note": {
                     "title": "",
                     "type": "object",
-                    "description": "A README.txt file will be left alongside the encrypted files.",
+                    "description": "Note: README.txt will be left in the target directory specified"
+                    " for encryption.",
                 },
             },
         },

--- a/monkey/monkey_island/cc/services/config_schema/ransomware.py
+++ b/monkey/monkey_island/cc/services/config_schema/ransomware.py
@@ -49,6 +49,11 @@ RANSOMWARE = {
                         },
                     },
                 },
+                "readme_note": {
+                    "title": "",
+                    "type": "object",
+                    "description": "A README.txt file will be left alongside the encrypted files.",
+                },
             },
         },
         "other_behaviors": {

--- a/monkey/monkey_island/cc/services/config_schema/ransomware.py
+++ b/monkey/monkey_island/cc/services/config_schema/ransomware.py
@@ -52,8 +52,8 @@ RANSOMWARE = {
                 "readme_note": {
                     "title": "",
                     "type": "object",
-                    "description": "Note: README.txt will be left in the target directory specified"
-                    " for encryption.",
+                    "description": "Note: A README.txt will be left in the specified target "
+                    "directory.",
                 },
             },
         },

--- a/monkey/monkey_island/cc/ui/src/components/configuration-components/UiSchema.js
+++ b/monkey/monkey_island/cc/ui/src/components/configuration-components/UiSchema.js
@@ -76,12 +76,9 @@ export default function UiSchema(props) {
         directories: {
             // Directory inputs are dynamically hidden
         },
-      enabled: {
-
-        'ui:widget': 'hidden'
-        }
+      enabled: {'ui:widget': 'hidden'}
       },
-      other_behaviors : {'ui:widget': 'hidden'}   
+      other_behaviors : {'ui:widget': 'hidden'}
     },
     internal: {
       general: {

--- a/monkey/monkey_island/cc/ui/src/components/configuration-components/UiSchema.js
+++ b/monkey/monkey_island/cc/ui/src/components/configuration-components/UiSchema.js
@@ -75,8 +75,13 @@ export default function UiSchema(props) {
       encryption: {
         directories: {
             // Directory inputs are dynamically hidden
+        },
+      enabled: {
+
+        'ui:widget': 'hidden'
         }
-      }
+      },
+      other_behaviors : {'ui:widget': 'hidden'}   
     },
     internal: {
       general: {

--- a/monkey/tests/unit_tests/infection_monkey/ransomware/test_ransomware_payload.py
+++ b/monkey/tests/unit_tests/infection_monkey/ransomware/test_ransomware_payload.py
@@ -252,7 +252,6 @@ def test_no_readme_if_no_directory(
     monkeypatch.setattr(ransomware_payload_module, "TARGETED_FILE_EXTENSIONS", set()),
     mock_copy_file = MagicMock()
 
-    ransomware_payload_config["encryption"]["enabled"] = True
     ransomware_payload_config["encryption"]["directories"]["linux_target_dir"] = ""
     ransomware_payload_config["encryption"]["directories"]["windows_target_dir"] = ""
     ransomware_payload_config["other_behaviors"]["readme"] = True

--- a/monkey/tests/unit_tests/infection_monkey/ransomware/test_ransomware_payload.py
+++ b/monkey/tests/unit_tests/infection_monkey/ransomware/test_ransomware_payload.py
@@ -244,3 +244,16 @@ def test_readme_already_exists(
     ).run_payload()
 
     mock_copy_file.assert_not_called()
+
+
+def test_no_readme_if_no_directory(
+    build_ransomware_payload, ransomware_payload_config, ransomware_target
+):
+    ransomware_payload_config["encryption"]["enabled"] = True
+    ransomware_payload_config["encryption"]["directories"]["linux_target_dir"] = ""
+    ransomware_payload_config["encryption"]["directories"]["windows_target_dir"] = ""
+    ransomware_payload_config["other_behaviors"]["readme"] = True
+    ransomware_payload = build_ransomware_payload(ransomware_payload_config)
+
+    ransomware_payload.run_payload()
+    assert not Path(ransomware_target / README_DEST).exists()

--- a/monkey/tests/unit_tests/infection_monkey/ransomware/test_ransomware_payload.py
+++ b/monkey/tests/unit_tests/infection_monkey/ransomware/test_ransomware_payload.py
@@ -247,13 +247,18 @@ def test_readme_already_exists(
 
 
 def test_no_readme_if_no_directory(
-    build_ransomware_payload, ransomware_payload_config, ransomware_target
+    monkeypatch, ransomware_payload_config, telemetry_messenger_spy, ransomware_target
 ):
+    monkeypatch.setattr(ransomware_payload_module, "TARGETED_FILE_EXTENSIONS", set()),
+    mock_copy_file = MagicMock()
+
     ransomware_payload_config["encryption"]["enabled"] = True
     ransomware_payload_config["encryption"]["directories"]["linux_target_dir"] = ""
     ransomware_payload_config["encryption"]["directories"]["windows_target_dir"] = ""
     ransomware_payload_config["other_behaviors"]["readme"] = True
-    ransomware_payload = build_ransomware_payload(ransomware_payload_config)
 
-    ransomware_payload.run_payload()
-    assert not Path(ransomware_target / README_DEST).exists()
+    RansomwarePayload(
+        ransomware_payload_config, telemetry_messenger_spy, mock_copy_file
+    ).run_payload()
+
+    mock_copy_file.assert_not_called()


### PR DESCRIPTION
# What does this PR do? 

Fixes first task of #1287 . If we don't specify a directory, the readme should not be left.

![image](https://user-images.githubusercontent.com/15820737/125079183-9cde7000-e0c3-11eb-95b5-7697262276e9.png)

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing? 
* [x] Was the CHANGELOG.md updated to reflect the changes?
* [x] Was the documentation framework updated to reflect the changes?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by {Running the Monkey locally with relevant config/running Island/...} 
* [x] If applicable, add screenshots or log transcripts of the feature working

## Explain Changes

Are the commit messages enough? If not, elaborate. 
