### PR TITLE
Ransomware quickstart - Hide scoutsuite run options in ransomware mode

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/Main.js
+++ b/monkey/monkey_island/cc/ui/src/components/Main.js
@@ -27,6 +27,7 @@ import {StandardLayoutComponent} from './layouts/StandardLayoutComponent';
 import LoadingScreen from './ui-components/LoadingScreen';
 
 const reportZeroTrustRoute = '/report/zeroTrust';
+const islandModeRoute = '/api/island-mode'
 
 class AppComponent extends AuthComponent {
   updateStatus = () => {
@@ -113,15 +114,26 @@ class AppComponent extends AuthComponent {
         infection_done: false,
         report_done: false,
         isLoggedIn: undefined,
-        needsRegistration: undefined
+        needsRegistration: undefined,
+        islandMode: undefined
       },
       noAuthLoginAttempted: undefined
     };
   }
 
+  updateIslandMode() {
+     this.authFetch(islandModeRoute)
+      .then(res => res.json())
+        .then(res => {
+          this.setState({islandMode: res.mode})
+        }
+      );
+  }
+
   componentDidMount() {
     this.updateStatus();
     this.interval = setInterval(this.updateStatus, 10000);
+    this.updateIslandMode()
   }
 
   componentWillUnmount() {
@@ -147,6 +159,7 @@ class AppComponent extends AuthComponent {
                                        completedSteps={this.state.completedSteps}/>)}
             {this.renderRoute('/run-monkey',
               <StandardLayoutComponent component={RunMonkeyPage}
+                                       islandMode={this.state.islandMode}
                                        onStatusChange={this.updateStatus}
                                        completedSteps={this.state.completedSteps}/>)}
             {this.renderRoute('/infection/map',

--- a/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/RunMonkeyPage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/RunMonkeyPage.js
@@ -17,7 +17,7 @@ class RunMonkeyPageComponent extends AuthComponent {
           Go ahead and run the monkey!
           <i> (Or <Link to="/configure">configure the monkey</Link> to fine tune its behavior)</i>
         </p>
-        <RunOptions />
+        <RunOptions islandMode={this.props.islandMode}/>
       </Col>
     );
   }

--- a/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/RunOptions.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/RunOptions.js
@@ -11,6 +11,7 @@ import AWSRunButton from './RunOnAWS/AWSRunButton';
 import CloudOptions from './scoutsuite-setup/CloudOptions';
 
 const CONFIG_URL = '/api/configuration/island';
+const MODE_URL = '/api/island-mode'
 
 function RunOptions(props) {
 
@@ -56,6 +57,23 @@ function RunOptions(props) {
     return InlineSelection(defaultContents, newProps);
   }
 
+  function getIslandMode() {
+    let mode = '';
+    authComponent.authFetch(MODE_URL)
+      .then(res => res.json())
+        .then(res => {
+          mode = res.mode
+        }
+      );
+
+    if (mode === 'ransomware') {
+      return false;
+    }
+    else {
+      return true;
+    }
+  }
+
   function defaultContents() {
     return (
       <>
@@ -69,14 +87,15 @@ function RunOptions(props) {
                                setComponent(LocalManualRunOptions,
                                  {ips: ips, setComponent: setComponent})
                              }}/>
-        <AWSRunButton setComponent={setComponent}/>
-        <NextSelectionButton title={'Cloud security scan'}
+        {getIslandMode() && <AWSRunButton setComponent={setComponent}/> }
+        {getIslandMode() && <NextSelectionButton title={'Cloud security scan'}
                              description={'Explains how to enable cloud security scan.'}
                              icon={faCloud}
                              onButtonClick={() => {
                                setComponent(CloudOptions,
                                  {ips: ips, setComponent: setComponent})
                              }}/>
+        }
       </>
     );
   }

--- a/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/RunOptions.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/RunOptions.js
@@ -58,20 +58,18 @@ function RunOptions(props) {
   }
 
   function getIslandMode() {
-    let mode = '';
+    let mode = 'advanced';
     authComponent.authFetch(MODE_URL)
       .then(res => res.json())
         .then(res => {
           mode = res.mode
         }
       );
+    return mode;
+  }
 
-    if (mode === 'ransomware') {
-      return false;
-    }
-    else {
-      return true;
-    }
+  function shouldShowScoutsuite(){
+    return getIslandMode() === 'advanced';
   }
 
   function defaultContents() {
@@ -87,8 +85,8 @@ function RunOptions(props) {
                                setComponent(LocalManualRunOptions,
                                  {ips: ips, setComponent: setComponent})
                              }}/>
-        {getIslandMode() && <AWSRunButton setComponent={setComponent}/> }
-        {getIslandMode() && <NextSelectionButton title={'Cloud security scan'}
+        {shouldShowScoutsuite() && <AWSRunButton setComponent={setComponent}/> }
+        {shouldShowScoutsuite() && <NextSelectionButton title={'Cloud security scan'}
                              description={'Explains how to enable cloud security scan.'}
                              icon={faCloud}
                              onButtonClick={() => {

--- a/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/RunOptions.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/RunOptions.js
@@ -11,7 +11,6 @@ import AWSRunButton from './RunOnAWS/AWSRunButton';
 import CloudOptions from './scoutsuite-setup/CloudOptions';
 
 const CONFIG_URL = '/api/configuration/island';
-const MODE_URL = '/api/island-mode'
 
 function RunOptions(props) {
 
@@ -57,22 +56,11 @@ function RunOptions(props) {
     return InlineSelection(defaultContents, newProps);
   }
 
-  function getIslandMode() {
-    let mode = 'advanced';
-    authComponent.authFetch(MODE_URL)
-      .then(res => res.json())
-        .then(res => {
-          mode = res.mode
-        }
-      );
-    return mode;
+  function shouldShowScoutsuite(islandMode){
+    return islandMode !== 'ransomware';
   }
 
-  function shouldShowScoutsuite(){
-    return getIslandMode() === 'advanced';
-  }
-
-  function defaultContents() {
+  function defaultContents(props) {
     return (
       <>
         <RunOnIslandButton title={'From Island'}
@@ -85,8 +73,8 @@ function RunOptions(props) {
                                setComponent(LocalManualRunOptions,
                                  {ips: ips, setComponent: setComponent})
                              }}/>
-        {shouldShowScoutsuite() && <AWSRunButton setComponent={setComponent}/> }
-        {shouldShowScoutsuite() && <NextSelectionButton title={'Cloud security scan'}
+        {shouldShowScoutsuite(props.islandMode) && <AWSRunButton setComponent={setComponent}/> }
+        {shouldShowScoutsuite(props.islandMode) && <NextSelectionButton title={'Cloud security scan'}
                              description={'Explains how to enable cloud security scan.'}
                              icon={faCloud}
                              onButtonClick={() => {


### PR DESCRIPTION
# What does this PR do? 

Fixes hides scoutsuite run option in ransomware mode. 

Add any further explanations here. 

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing? 
* [x] ~Was the CHANGELOG.md updated to reflect the changes?~
* [x] ~Was the documentation framework updated to reflect the changes?~

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by {Running the Monkey locally with relevant config/running Island/...} 
* [ ] If applicable, add screenshots or log transcripts of the feature working

## Explain Changes

Are the commit messages enough? If not, elaborate. 
