### PR TITLE
Fix bug where we can't change tab from attack to another tab in Configure

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
@@ -65,7 +65,6 @@ class ConfigurePageComponent extends AuthComponent {
   setInitialConfig(config) {
     // Sets a reference to know if config was changed
     config['attack'] = {}
-    this.currentFormData = {}
     this.initialConfig = JSON.parse(JSON.stringify(config));
   }
 

--- a/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
@@ -59,13 +59,13 @@ class ConfigurePageComponent extends AuthComponent {
 
   getSectionsOrder() {
     let islandMode = this.props.islandMode ? this.props.islandMode : 'advanced'
-    // TODO delete the following line before merging
-    islandMode = 'advanced'
     return CONFIGURATION_TABS_PER_MODE[islandMode];
   }
 
   setInitialConfig(config) {
     // Sets a reference to know if config was changed
+    config['attack'] = {}
+    this.currentFormData = {}
     this.initialConfig = JSON.parse(JSON.stringify(config));
   }
 
@@ -230,6 +230,9 @@ class ConfigurePageComponent extends AuthComponent {
 
   onChange = ({formData}) => {
     let configuration = this.state.configuration;
+    if (this.state.selectedSection === 'attack'){
+      formData = {};
+    }
     configuration[this.state.selectedSection] = formData;
     this.setState({currentFormData: formData, configuration: configuration});
   };
@@ -237,10 +240,7 @@ class ConfigurePageComponent extends AuthComponent {
   updateConfigSection = () => {
     let newConfig = this.state.configuration;
 
-    if (this.currentSection === 'attack' && this.state.currentFormData === undefined) {
-      this.state.currentFormData = this.state.attackConfig;
-    }
-    else if (Object.keys(this.state.currentFormData).length > 0) {
+    if (Object.keys(this.state.currentFormData).length > 0) {
       newConfig[this.currentSection] = this.state.currentFormData;
     }
     this.setState({configuration: newConfig, lastAction: 'none'});
@@ -340,14 +340,13 @@ class ConfigurePageComponent extends AuthComponent {
       this.setState({showAttackAlert: true});
       return;
     }
+
     this.updateConfigSection();
     this.currentSection = key;
-
     this.setState({
       selectedSection: key,
       currentFormData: this.state.configuration[key]
     });
-
   };
 
   resetConfig = () => {
@@ -359,6 +358,7 @@ class ConfigurePageComponent extends AuthComponent {
       })
       .then(res => res.json())
       .then(res => {
+          res.configuration['attack'] = {}
           this.setState({
             lastAction: 'reset',
             schema: res.schema,

--- a/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
@@ -59,6 +59,8 @@ class ConfigurePageComponent extends AuthComponent {
 
   getSectionsOrder() {
     let islandMode = this.props.islandMode ? this.props.islandMode : 'advanced'
+    // TODO delete the following line before merging
+    islandMode = 'advanced'
     return CONFIGURATION_TABS_PER_MODE[islandMode];
   }
 
@@ -234,7 +236,11 @@ class ConfigurePageComponent extends AuthComponent {
 
   updateConfigSection = () => {
     let newConfig = this.state.configuration;
-    if (Object.keys(this.state.currentFormData).length > 0) {
+
+    if (this.currentSection === 'attack' && this.state.currentFormData === undefined) {
+      this.state.currentFormData = this.state.attackConfig;
+    }
+    else if (Object.keys(this.state.currentFormData).length > 0) {
       newConfig[this.currentSection] = this.state.currentFormData;
     }
     this.setState({configuration: newConfig, lastAction: 'none'});
@@ -309,10 +315,16 @@ class ConfigurePageComponent extends AuthComponent {
   }
 
   userChangedConfig() {
-    if (JSON.stringify(this.state.configuration) === JSON.stringify(this.initialConfig)) {
-      if (Object.keys(this.state.currentFormData).length === 0 ||
-        JSON.stringify(this.initialConfig[this.currentSection]) === JSON.stringify(this.state.currentFormData)) {
-        return false;
+    try {
+      if (JSON.stringify(this.state.configuration) === JSON.stringify(this.initialConfig)) {
+        if (Object.keys(this.state.currentFormData).length === 0 ||
+          JSON.stringify(this.initialConfig[this.currentSection]) === JSON.stringify(this.state.currentFormData)) {
+          return false;
+        }
+      }
+    } catch (TypeError) {
+      if (JSON.stringify(this.initialConfig[this.currentSection]) === JSON.stringify(this.state.currentFormData)){
+         return false;
       }
     }
     return true;
@@ -330,10 +342,12 @@ class ConfigurePageComponent extends AuthComponent {
     }
     this.updateConfigSection();
     this.currentSection = key;
+
     this.setState({
       selectedSection: key,
       currentFormData: this.state.configuration[key]
     });
+
   };
 
   resetConfig = () => {


### PR DESCRIPTION
# What does this PR do? 

Fixes #1293  . 

Add any further explanations here. 

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing? 
* [x] ~Was the CHANGELOG.md updated to reflect the changes?~
* [x] ~Was the documentation framework updated to reflect the changes?~

## Testing Checklist

* [x] ~Added relevant unit tests?~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by {Running the Monkey locally with relevant config/running Island/...} 
* [x] If applicable, add screenshots or log transcripts of the feature working

## Explain Changes

Note: I didn't do the test on Network or Ransomware. Check the fix in #1330 .

![AttackBug](https://user-images.githubusercontent.com/15820737/125939482-d9552c15-d599-4b4d-939d-b9b294fc1e9c.gif)
