### PR TITLE
Set island mode in `Main.tsx`'s constructor

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/Main.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/Main.tsx
@@ -70,6 +70,7 @@ class AppComponent extends AuthComponent {
       noAuthLoginAttempted: undefined
     };
     this.interval = undefined;
+    this.setMode();
   }
 
   updateStatus = () => {


### PR DESCRIPTION
# What does this PR do? 

Fixes #1339 

Setting the island mode in `Main.tsx`'s constructor ensures that no bugs (such as #1339) arise because the island mode hasn't been correctly set yet. 

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing? 
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running Monkey Island and playing around with it.
* [x] If applicable, add screenshots or log transcripts of the feature working

https://user-images.githubusercontent.com/44770317/126481939-3a409add-8993-43b6-807c-c8b6f14d9dfd.mp4

