### PR TITLE
Island: Hide sidebar nav links if mode is not set

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/Main.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/Main.tsx
@@ -30,7 +30,7 @@ import Timeout = NodeJS.Timeout;
 import IslandHttpClient from "./IslandHttpClient";
 import _ from "lodash";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-import {faFileCode, faLightbulb} from "@fortawesome/free-solid-svg-icons";
+import {faFileCode, faLightbulb, faTimes} from "@fortawesome/free-solid-svg-icons";
 
 
 let notificationIcon = require('../images/notification-logo-512x512.png');
@@ -192,8 +192,10 @@ class AppComponent extends AuthComponent {
   getIslandModeTitle(){
     if(this.state.islandMode === 'ransomware'){
       return this.formIslandModeTitle("Ransomware", faFileCode);
-    } else {
+    } else if(this.state.islandMode === 'advanced') {
       return this.formIslandModeTitle("Custom", faLightbulb);
+    } else {
+      return this.formIslandModeTitle("", faTimes);
     }
   }
 
@@ -223,7 +225,8 @@ class AppComponent extends AuthComponent {
               <SidebarLayoutComponent component={LandingPage}
                                       sideNavDisabled={true}
                                       completedSteps={new CompletedSteps()}
-                                      onStatusChange={this.updateStatus}/>)}
+                                      onStatusChange={this.updateStatus}
+                                      {...defaultSideNavProps}/>)}
             {this.renderRoute(Routes.GettingStartedPage,
               <SidebarLayoutComponent component={GettingStartedPage} {...defaultSideNavProps}/>,
               true)}

--- a/monkey/monkey_island/cc/ui/src/components/SideNavComponent.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/SideNavComponent.tsx
@@ -27,7 +27,6 @@ const SideNavComponent = ({disabled,
                            completedSteps,
                            defaultReport,
                            header=null}: Props) => {
-
   return (
     <>
       <NavLink to={Routes.GettingStartedPage} exact={true}>
@@ -37,67 +36,65 @@ const SideNavComponent = ({disabled,
         </div>
       </NavLink>
 
-      <ul className='navigation'>
-        {(header !== null) &&
-        <>
+      <div className={getNavSectionClass()}>
+        <ul className='navigation'>
+          <>
+            <li>
+              {header}
+            </li>
+            <hr />
+          </>
+
           <li>
-            {header}
+            <NavLink to={Routes.RunMonkeyPage}>
+              <span className='number'>1.</span>
+              Run Monkey
+              {completedSteps.runMonkey ?
+                <FontAwesomeIcon icon={faCheck} className='pull-right checkmark'/>
+                : ''}
+            </NavLink>
           </li>
-          <hr/>
-        </>}
+          <li>
+            <NavLink to={Routes.MapPage}>
+              <span className='number'>2.</span>
+              Infection Map
+              {completedSteps.infectionDone ?
+                <FontAwesomeIcon icon={faCheck} className='pull-right checkmark'/>
+                : ''}
+            </NavLink>
+          </li>
+          <li>
+            <NavLink to={defaultReport}
+                     isActive={(_match, location) => {
+                       return (isReportRoute(location.pathname))
+                     }}>
+              <span className='number'>3.</span>
+              Security Reports
+              {completedSteps.reportDone ?
+                <FontAwesomeIcon icon={faCheck} className='pull-right checkmark'/>
+                : ''}
+            </NavLink>
+          </li>
+          <li>
+            <NavLink to={Routes.StartOverPage}>
+              <span className='number'><FontAwesomeIcon icon={faUndo} style={{'marginLeft': '-1px'}}/></span>
+              Start Over
+            </NavLink>
+          </li>
+        </ul>
 
-        <li>
-          <NavLink to={Routes.RunMonkeyPage} className={getNavLinkClass()}>
-            <span className='number'>1.</span>
-            Run Monkey
-            {completedSteps.runMonkey ?
-              <FontAwesomeIcon icon={faCheck} className='pull-right checkmark'/>
-              : ''}
-          </NavLink>
-        </li>
-        <li>
-          <NavLink to={Routes.MapPage} className={getNavLinkClass()}>
-            <span className='number'>2.</span>
-            Infection Map
-            {completedSteps.infectionDone ?
-              <FontAwesomeIcon icon={faCheck} className='pull-right checkmark'/>
-              : ''}
-          </NavLink>
-        </li>
-        <li>
-          <NavLink to={defaultReport}
-                   className={getNavLinkClass()}
-                   isActive={(_match, location) => {
-                     return (isReportRoute(location.pathname))
-                   }}>
-            <span className='number'>3.</span>
-            Security Reports
-            {completedSteps.reportDone ?
-              <FontAwesomeIcon icon={faCheck} className='pull-right checkmark'/>
-              : ''}
-          </NavLink>
-        </li>
-        <li>
-          <NavLink to={Routes.StartOverPage} className={getNavLinkClass()}>
-            <span className='number'><FontAwesomeIcon icon={faUndo} style={{'marginLeft': '-1px'}}/></span>
-            Start Over
-          </NavLink>
-        </li>
-      </ul>
+        <hr />
+        <ul>
+          <li><NavLink to={Routes.ConfigurePage}>
+            Configuration
+          </NavLink></li>
+          <li><NavLink to='/infection/telemetry'>
+            Logs
+          </NavLink></li>
+        </ul>
+      </div>
 
-      <hr/>
-      <ul>
-        <li><NavLink to={Routes.ConfigurePage}
-                     className={getNavLinkClass()}>
-          Configuration
-        </NavLink></li>
-        <li><NavLink to='/infection/telemetry'
-        className={getNavLinkClass()}>
-          Logs
-        </NavLink></li>
-      </ul>
-
-      <hr/>
+      <hr />
       <div className='guardicore-link text-center' style={{'marginBottom': '0.5em'}}>
         <span>Powered by</span>
         <a href='http://www.guardicore.com' rel='noopener noreferrer' target='_blank'>
@@ -114,9 +111,9 @@ const SideNavComponent = ({disabled,
       <VersionComponent/>
     </>);
 
-  function getNavLinkClass() {
+  function getNavSectionClass() {
     if(disabled){
-      return `nav-link disabled`
+      return 'placeholder'
     } else {
       return ''
     }

--- a/monkey/monkey_island/cc/ui/src/styles/Main.scss
+++ b/monkey/monkey_island/cc/ui/src/styles/Main.scss
@@ -83,3 +83,7 @@ div.collapse.card-body ul, div.collapsing.card-body ul {
 .hidden{
   display: None;
 }
+
+.placeholder {
+    visibility: hidden;
+}


### PR DESCRIPTION
# What does this PR do? 

Having the links in the sidebar when the mode is not selected may be confusing for the user. Hide sidebar nav links if mode is not selected.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing? 
* [ ] ~~Was the CHANGELOG.md updated to reflect the changes?~~
* [ ] ~~Was the documentation framework updated to reflect the changes?~~

## Testing Checklist

* [ ] ~~Added relevant unit tests?~~
* [x] Have you successfully tested your changes locally? Elaborate:
    > See gif
* [x] If applicable, add screenshots or log transcripts of the feature working
* [ ] 
![hide-nav](https://user-images.githubusercontent.com/19957806/126535828-1a9a9b06-1257-4c82-8b48-22e84c24cb50.gif)

