### PR TITLE
Sleep for 0.5 seconds after setting the scenario

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/pages/LandingPage.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/pages/LandingPage.tsx
@@ -6,6 +6,9 @@ import {faFileCode, faLightbulb} from '@fortawesome/free-solid-svg-icons';
 import '../../styles/pages/LandingPage.scss';
 import IslandHttpClient from "../IslandHttpClient";
 
+function sleep(milliseconds) {
+  return new Promise(resolve => setTimeout(resolve, milliseconds))
+}
 
 const LandingPageComponent = (props) => {
 
@@ -56,7 +59,7 @@ const LandingPageComponent = (props) => {
 
   function setScenario(scenario: string) {
     IslandHttpClient.post('/api/island-mode', {'mode': scenario});
-    props.onStatusChange();
+    sleep(500).then(_ => {props.onStatusChange();});
   }
 }
 


### PR DESCRIPTION
# What does this PR do? 

Fixes #1338  

This is done to give a small time gap between sending the selected mode to the backend in `LandingPage.tsx`'s `setScenario`, and fetching and setting the mode in the frontend in `Main.tsx`'s `setMode()`. Without the small time gap, the backend is not able to register the selected mode in time for the frontend to fetch the selected mode. This causes a big gap (at most 10 seconds) when nothing happens on the frontend until the periodic `updateStatus()` is called (which calls `setMode()`) and sets the correct mode this time.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing? 
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running Monkey Island. 
* [x] If applicable, add screenshots or log transcripts of the feature working

https://user-images.githubusercontent.com/44770317/126622655-a92f5adc-6ca3-4536-8d25-df66e8f88254.mp4

