### PR TITLE
Skip connectivity check in BB tests

### DIFF
--- a/envs/monkey_zoo/blackbox/config_templates/base_template.py
+++ b/envs/monkey_zoo/blackbox/config_templates/base_template.py
@@ -14,4 +14,5 @@ class BaseTemplate(ConfigTemplate):
         ],
         "monkey.post_breach.post_breach_actions": [],
         "internal.general.keep_tunnel_open_time": 0,
+        "internal.monkey.internet_services": [],
     }


### PR DESCRIPTION
# What does this PR do? 

Fixes #1371 . 

Disabling `internal.monkey.internet_services` is skipping connectivity check making the bb tests faster.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing? 
* [x] Was the CHANGELOG.md updated to reflect the changes?
* [x] Was the documentation framework updated to reflect the changes?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by {Running the Monkey locally with relevant config/running Island/...} 
* [x] If applicable, add screenshots or log transcripts of the feature working

## Explain Changes

There where done multiple checks on  ssh exploit tests.

With connectivity check: 
![image](https://user-images.githubusercontent.com/15820737/127637847-42a77b6d-0d7f-4b31-81fa-c44dd3d375cb.png)
![image](https://user-images.githubusercontent.com/15820737/127638107-0c62ee02-f3cd-425f-94c4-1ef4cf198777.png)


Without connectivity check:
![image](https://user-images.githubusercontent.com/15820737/127637928-40f7ac97-622a-4559-9e97-cb3f0c1d9a3e.png)
![image](https://user-images.githubusercontent.com/15820737/127637998-e32bf553-c1f0-4e8c-b1b1-fbb5aadabeee.png)


