### PR TITLE
Fix breaking monkey on german system language by adding cp850 encoding to ping scanner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Misaligned buttons and input fields on exploiter and network configuration
   pages. #1353
+- Crash when unexpected character encoding is used by ping command on German
+  language systems. #1175
+
 
 ## [1.11.0] - 2021-08-13
 ### Added

--- a/monkey/infection_monkey/network/ping_scanner.py
+++ b/monkey/infection_monkey/network/ping_scanner.py
@@ -43,13 +43,12 @@ class PingScanner(HostScanner, HostFinger):
         if not "win32" == sys.platform:
             timeout /= 1000
 
-        Encoding = "cp850"
         sub_proc = subprocess.Popen(
             ["ping", PING_COUNT_FLAG, "1", PING_TIMEOUT_FLAG, str(timeout), host.ip_addr],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
-            encoding=Encoding,
+            encoding=os.device_encoding(1),
         )
 
         output = " ".join(sub_proc.communicate())

--- a/monkey/infection_monkey/network/ping_scanner.py
+++ b/monkey/infection_monkey/network/ping_scanner.py
@@ -38,22 +38,24 @@ class PingScanner(HostScanner, HostFinger):
         )
 
     def get_host_fingerprint(self, host):
-
         timeout = self._config.ping_scan_timeout
         if not "win32" == sys.platform:
             timeout /= 1000
 
         ping_cmd = ["ping", PING_COUNT_FLAG, "1", PING_TIMEOUT_FLAG, str(timeout), host.ip_addr]
-        encoding = os.device_encoding(1)
-
         LOG.debug(f"Running ping command: {' '.join(ping_cmd)}")
 
+        # If stdout is not connected to a terminal (i.e. redirected to a pipe or file), the result
+        # of os.device_encoding(1) will be None. Setting errors="backslashreplace" prevents a crash
+        # in this case. See #1175 and #1403 for more information.
+        encoding = os.device_encoding(1)
         sub_proc = subprocess.Popen(
             ping_cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
             encoding=encoding,
+            errors="backslashreplace",
         )
 
         LOG.debug(f"Retrieving ping command output using {encoding} encoding")

--- a/monkey/infection_monkey/network/ping_scanner.py
+++ b/monkey/infection_monkey/network/ping_scanner.py
@@ -43,11 +43,13 @@ class PingScanner(HostScanner, HostFinger):
         if not "win32" == sys.platform:
             timeout /= 1000
 
+        Encoding = "cp850"
         sub_proc = subprocess.Popen(
             ["ping", PING_COUNT_FLAG, "1", PING_TIMEOUT_FLAG, str(timeout), host.ip_addr],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            encoding=Encoding,
         )
 
         output = " ".join(sub_proc.communicate())

--- a/monkey/infection_monkey/network/ping_scanner.py
+++ b/monkey/infection_monkey/network/ping_scanner.py
@@ -43,14 +43,20 @@ class PingScanner(HostScanner, HostFinger):
         if not "win32" == sys.platform:
             timeout /= 1000
 
+        ping_cmd = ["ping", PING_COUNT_FLAG, "1", PING_TIMEOUT_FLAG, str(timeout), host.ip_addr]
+        encoding = os.device_encoding(1)
+
+        LOG.debug(f"Running ping command: {' '.join(ping_cmd)}")
+
         sub_proc = subprocess.Popen(
-            ["ping", PING_COUNT_FLAG, "1", PING_TIMEOUT_FLAG, str(timeout), host.ip_addr],
+            ping_cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
-            encoding=os.device_encoding(1),
+            encoding=encoding,
         )
 
+        LOG.debug(f"Retrieving ping command output using {encoding} encoding")
         output = " ".join(sub_proc.communicate())
         regex_result = self._ttl_regex.search(output)
         if regex_result:


### PR DESCRIPTION
# What does this PR do? 

Fixes #1175. 

Add encoding cp850 to subprocess of ping scanner.
This adds the ability for the monkey to work on other system languages that use DOS-Latin-1 as encoding.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing? 
* [x] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?

## Testing Checklist

* [ ] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running the Monkey locally on a system using the german (and english of course) system language
* [ ] If applicable, add screenshots or log transcripts of the feature working

## Explain Changes

Are the commit messages enough? If not, elaborate. 
