### PR TITLE
Add Swimm unit for adding a PBA

### DIFF
--- a/.swm/afMu3y3ny5lnrYFWl3EI.swm
+++ b/.swm/afMu3y3ny5lnrYFWl3EI.swm
@@ -13,7 +13,7 @@
     "content": [
         {
             "type": "text",
-            "text": "Read our documentation about adding a new PBA.\n\nAfter that we want you to add the AccountDiscovery PBA. The commands that add users for Windows and Linux can be retrieved from \\`get\\_commands\\_to\\_discover\\_accounts\\` — make sure you see how to use this function correctly.\n\nNote that the PBA should impact the T1087 MITRE technique as well!\n\n**Manual test to confirm**\n--------------------------\n\n1.  Run the Monkey Island.\n    \n2.  Make sure your new PBA is enabled by default in the config. For this test, disable network scanning, exploiting, and all other PBAs.\n    \n3.  Run the Monkey Agent.\n    \n4.  See the PBA in the security report and in the MITRE report under the relevant technique."
+            "text": "Read our [documentation](https://www.guardicore.com/infectionmonkey/docs/development/adding-post-breach-actions/) about adding a new PBA.\n\nAfter that we want you to add the AccountDiscovery PBA. The commands that add users for Windows and Linux can be retrieved from \\`get\\_commands\\_to\\_discover\\_accounts\\` — make sure you see how to use this function correctly.\n\nNote that the PBA should impact the T1087 MITRE technique as well.\n\n**Manual test to confirm**\n--------------------------\n\n1.  Run the Monkey Island.\n    \n2.  Make sure your new PBA is enabled by default in the config. For this test, disable network scanning, exploiting, and all other PBAs.\n    \n3.  Run the Monkey Agent.\n    \n4.  See the PBA in the security report and in the MITRE report under the relevant technique."
         },
         {
             "type": "snippet",
@@ -71,7 +71,7 @@
         },
         {
             "type": "text",
-            "text": ""
+            "text": "Many PBAs use shell commands or scripts — see `Timestomping` and `AccountDiscovery`.\n\nOn the other hand, some are less straightforward. You can override functions and implement new classes depending on what is required, to implement complicated PBAs — see `SignedScriptProxyExecution` and `ModifyShellStartupFiles`.  \n  \n\nThis PBA, along with the others, will run on a system after it has been breached. The purpose of this code is to test whether target systems allow attackers to gather details about all the user accounts that are present on a system or in an environment."
         }
     ],
     "symbols": {},

--- a/.swm/afMu3y3ny5lnrYFWl3EI.swm
+++ b/.swm/afMu3y3ny5lnrYFWl3EI.swm
@@ -1,0 +1,87 @@
+{
+    "id": "afMu3y3ny5lnrYFWl3EI",
+    "name": "Add a new Post Breach Action (PBA)",
+    "task": {
+        "dod": "You should add a new PBA to the Monkey which discovers all user accounts on the machine.",
+        "tests": [],
+        "hints": [
+            "See `ScheduleJobs` PBA for an example of a PBA which only uses shell commands.",
+            "Make sure to add the PBA to the configuration as well.",
+            "MITRE ATT&CK technique T1087 articulates that adversaries may attempt to get a listing of accounts on a system or within an environment which can help them determine which accounts can aid in follow-on behavior. Therefore, the AccountDiscovery PBA is relevant to it. Make sure to map this PBA to the MITRE ATT&CK configuration and report."
+        ]
+    },
+    "content": [
+        {
+            "type": "text",
+            "text": "Read our documentation about adding a new PBA.\n\nAfter that we want you to add the AccountDiscovery PBA. The commands that add users for Windows and Linux can be retrieved from \\`get\\_commands\\_to\\_discover\\_accounts\\` — make sure you see how to use this function correctly.\n\nNote that the PBA should impact the T1087 MITRE technique as well!\n\n**Manual test to confirm**\n--------------------------\n\n1.  Run the Monkey Island.\n    \n2.  Make sure your new PBA is enabled by default in the config. For this test, disable network scanning, exploiting, and all other PBAs.\n    \n3.  Run the Monkey Agent.\n    \n4.  See the PBA in the security report and in the MITRE report under the relevant technique."
+        },
+        {
+            "type": "snippet",
+            "lines": [
+                " POST_BREACH_JOB_SCHEDULING = \"Schedule jobs\"",
+                " POST_BREACH_TIMESTOMPING = \"Modify files' timestamps\"",
+                " POST_BREACH_SIGNED_SCRIPT_PROXY_EXEC = \"Signed script proxy execution\"",
+                "*POST_BREACH_ACCOUNT_DISCOVERY = \"Account discovery\"",
+                "+# SWIMMER: Put the new const here!",
+                " POST_BREACH_CLEAR_CMD_HISTORY = \"Clear command history\""
+            ],
+            "firstLineNumber": 7,
+            "path": "monkey/common/common_consts/post_breach_consts.py",
+            "comments": []
+        },
+        {
+            "type": "snippet",
+            "lines": [
+                " ",
+                " class AccountDiscovery(PBA):",
+                "     def __init__(self):",
+                "*        linux_cmds, windows_cmds = get_commands_to_discover_accounts()",
+                "+        # SWIMMER: Implement here!",
+                "*        super().__init__(",
+                "+        pass",
+                "*            POST_BREACH_ACCOUNT_DISCOVERY, linux_cmd=\" \".join(linux_cmds), windows_cmd=windows_cmds",
+                "*        )"
+            ],
+            "firstLineNumber": 7,
+            "path": "monkey/infection_monkey/post_breach/actions/discover_accounts.py",
+            "comments": []
+        },
+        {
+            "type": "snippet",
+            "lines": [
+                "             \"with the help of a pre-existing signed script.\",",
+                "             \"attack_techniques\": [\"T1216\"],",
+                "         },",
+                "*        {",
+                "+        # SWIMMER: Add details here!",
+                "*            \"type\": \"string\",",
+                "*            \"enum\": [\"AccountDiscovery\"],",
+                "*            \"title\": \"Account Discovery\",",
+                "*            \"safe\": True,",
+                "*            \"info\": \"Attempts to get a listing of user accounts on the system.\",",
+                "*            \"attack_techniques\": [\"T1087\"],",
+                "*        },",
+                "         {",
+                "             \"type\": \"string\",",
+                "             \"enum\": [\"ClearCommandHistory\"],"
+            ],
+            "firstLineNumber": 80,
+            "path": "monkey/monkey_island/cc/services/config_schema/definitions/post_breach_actions.py",
+            "comments": []
+        },
+        {
+            "type": "text",
+            "text": ""
+        }
+    ],
+    "symbols": {},
+    "file_version": "2.0.3",
+    "meta": {
+        "app_version": "0.5.7-0",
+        "file_blobs": {
+            "monkey/common/common_consts/post_breach_consts.py": "01d31448269e5581dbe0176c289f7dd36cc5854f",
+            "monkey/infection_monkey/post_breach/actions/discover_accounts.py": "8fdebd0df97655e4cba3aebcdcf3c5ed1d1b6cbd",
+            "monkey/monkey_island/cc/services/config_schema/definitions/post_breach_actions.py": "88a3e8cb59fb0d1c07c9487bcb4eaab7b8087d84"
+        }
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ script:
 
 # verify swimm
 - cd $TRAVIS_BUILD_DIR
-- curl -L https://github.com/swimmio/SwimmReleases/releases/download/v0.5.0-0/swimm-cli.js --output swimm_cli
+- curl -L https://github.com/swimmio/SwimmReleases/releases/download/v0.5.7-0/swimm-cli.js --output swimm_cli
 - node swimm_cli --version
 - node swimm_cli verify
 


### PR DESCRIPTION
# What does this PR do? 

#1410 

Since we removed the BackdoorUser PBA in #1433, the existing PBA Swimm unit was removed. This PR adds a Swimm unit for a different PBA.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing? 
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running Swimm 
* [] ~If applicable, add screenshots or log transcripts of the feature working~

