### PR TITLE
Agent: Change trap command signal to TERM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,11 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
   language systems. #1175
 - Malfunctioning timestomping PBA. #1405
 - Malfunctioning shell startup script PBA. #1419
+- Trap command produced no output. #1406
 
 ### Security
-- Generate a random password when creating a new user for CommunicateAsNewUser PBA. #1434
+- Generate a random password when creating a new user for CommunicateAsNewUser
+  PBA. #1434
 
 ## [1.11.0] - 2021-08-13
 ### Added
@@ -62,8 +64,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
   instead of $HOME. #1143
 - Put environment config options in `server_config.json` into a separate
   section named "environment". #1161
-- Automatically register if BlackBox tests are run on a fresh installation.
-  #1180
+- Automatically register if BlackBox tests are run on a fresh
+  installation. #1180
 - Limit the ports used for scanning in blackbox tests. #1368
 - Limit the propagation depth of most blackbox tests. #1400
 - Wait less time for monkeys to die when running BlackBox tests. #1400

--- a/monkey/infection_monkey/post_breach/actions/use_trap_command.py
+++ b/monkey/infection_monkey/post_breach/actions/use_trap_command.py
@@ -6,4 +6,4 @@ from infection_monkey.post_breach.trap_command.trap_command import get_trap_comm
 class TrapCommand(PBA):
     def __init__(self):
         linux_cmds = get_trap_commands()
-        super(TrapCommand, self).__init__(POST_BREACH_TRAP_COMMAND, linux_cmd=linux_cmds)
+        super(TrapCommand, self).__init__(POST_BREACH_TRAP_COMMAND, linux_cmd=" ".join(linux_cmds))

--- a/monkey/infection_monkey/post_breach/trap_command/linux_trap_command.py
+++ b/monkey/infection_monkey/post_breach/trap_command/linux_trap_command.py
@@ -1,6 +1,6 @@
 def get_linux_trap_commands():
     return [
-        # trap and send SIGINT signal
-        "trap 'echo \"Successfully used trap command\"' INT && kill -2 $$ ;",
-        "trap - INT",  # untrap SIGINT
+        # trap and send SIGTERM signal
+        "trap 'echo \"Successfully used trap command\"' TERM && kill -15 $$ ;",
+        "trap - TERM",  # untrap SIGTERM
     ]

--- a/monkey/monkey_island/cc/services/config_schema/definitions/post_breach_actions.py
+++ b/monkey/monkey_island/cc/services/config_schema/definitions/post_breach_actions.py
@@ -39,7 +39,7 @@ POST_BREACH_ACTIONS = {
             "enum": ["TrapCommand"],
             "title": "Trap",
             "safe": True,
-            "info": "On Linux systems, attempts to trap an interrupt signal in order "
+            "info": "On Linux systems, attempts to trap a terminate signal in order "
             "to execute a command "
             "upon receiving that signal. Removes the trap afterwards.",
             "attack_techniques": ["T1154"],


### PR DESCRIPTION
# What does this PR do? 

Fixes #1406 .

Trap command was showing no output when run from Island because the kill command never sends it.
As the technique allows for any kind of interrupt signals ( check [this](https://attack.mitre.org/techniques/T1546/005/) and [this](https://github.com/Kirtar22/Litmus_Test/blob/master/Persistence/T1154/T1154.md) ) I have changed the INT with TERM.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing? 
* [x] Was the CHANGELOG.md updated to reflect the changes?
* [x] Was the documentation framework updated to reflect the changes?

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by {Running the Monkey locally with relevant config/running Island/...} 
* [x] If applicable, add screenshots or log transcripts of the feature working

## Explain Changes

![image](https://user-images.githubusercontent.com/15820737/131708531-a175b9fd-7794-4815-9627-c29398140ef1.png)
