### PR TITLE
Upgrade python dependencies

### DIFF
--- a/monkey/infection_monkey/Pipfile
+++ b/monkey/infection_monkey/Pipfile
@@ -23,7 +23,7 @@ pymssql = "==2.1.5"
 pypykatz = "==0.3.12"
 pysmb = "==1.2.5"
 requests = ">=2.24"
-urllib3 = "==1.25.8"
+urllib3 = "==1.26.5"
 simplejson = "*"
 "WinSys-3.x" = ">=0.5.2"
 WMI = {version = "==1.5.1", sys_platform = "== 'win32'"}

--- a/monkey/infection_monkey/Pipfile.lock
+++ b/monkey/infection_monkey/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "96a125018d143a7446fe9b2849991c00d79f37c433694db77e616c1135baeaf9"
+            "sha256": "43cdbb12fe6858c82a2fffa8dd1c38292b02dd326d2fa82cc8c1ab48a9d5b262"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -804,7 +804,7 @@
                 "sha256:65540c21bfe14405a3a77e4c085ecfce88724743a4ead47c66b84defcf82c32e",
                 "sha256:9ce5fa65b8992dfa373bddc5b6e0864ead8f291c94fbfec05fbd5c836162e67b"
             ],
-            "markers": "sys_platform == 'win32'",
+            "markers": "python_version < '3.8' and sys_platform == 'win32'",
             "version": "==2.1"
         },
         "pysmb": {
@@ -982,7 +982,7 @@
                 "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
             ],
             "index": "pypi",
-            "version": "==1.25.8"
+            "version": "==1.26.5"
         },
         "wcwidth": {
             "hashes": [


### PR DESCRIPTION
# What does this PR do? 

Fixes #1469

All vulnerabilities in `infection_monkey/` have been resolved. The packages in `monkey_island/` having vulnerabilities can't be updated since `awscli`'s version is fixed to 1.18.131, which needs specific versions of other packages. Why `awscli`'s version was fixed and whether we can update it still needs to be investigated.

`monkey_island/` vulnerabilities:
![image](https://user-images.githubusercontent.com/44770317/134007477-4b847e71-5b03-4698-bfea-c1bbe7bf09b5.png)

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing? 
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Have you successfully tested your changes locally? Elaborate:
    > Tested by {Running the Monkey locally with relevant config/running Island/...} 
* [ ] If applicable, add screenshots or log transcripts of the feature working

## Explain Changes

Are the commit messages enough? If not, elaborate. 
