### PR TITLE
Duplicate credentials in system info telem

### DIFF
--- a/monkey/infection_monkey/system_info/windows_info_collector.py
+++ b/monkey/infection_monkey/system_info/windows_info_collector.py
@@ -47,7 +47,6 @@ class WindowsInfoCollector(InfoCollector):
             if credentials:
                 if "credentials" in self.info:
                     self.info["credentials"].update(credentials)
-                self.info["mimikatz"] = credentials
                 logger.info("Mimikatz info gathered successfully")
             else:
                 logger.info("No mimikatz info was gathered")

--- a/monkey/monkey_island/cc/models/telemetries/telemetry_dal.py
+++ b/monkey/monkey_island/cc/models/telemetries/telemetry_dal.py
@@ -13,10 +13,7 @@ from monkey_island.cc.server_utils.encryption import (
     encrypt_dict,
 )
 
-sensitive_fields = [
-    SensitiveField("data.credentials", MimikatzResultsEncryptor),
-    SensitiveField("data.mimikatz", MimikatzResultsEncryptor),
-]
+sensitive_fields = [SensitiveField("data.credentials", MimikatzResultsEncryptor)]
 
 
 def save_telemetry(telemetry_dict: dict):


### PR DESCRIPTION
# What does this PR do? 
Removes the unnecessary "mimikatz" info from telemetry data since the exact same data is stored under "credentials" key

Couldn't find any usages or reason for duplicating credentials into "mimikatz" key

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing? 
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~

## Testing Checklist

* [ ] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by building monkey, gathering credentials, testing the report
* [ ] If applicable, add screenshots or log transcripts of the feature working

