### PR TITLE
Check for empty result in Modify shell files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
 - Encryptor breaking with UTF-8 characters. (Passwords in different languages can be submitted in
   the config successfully now.) #1490
 - Mimikatz collector no longer fails if Azure credential collector is disabled. #1512 #1493
+- Unhandled error when "modify shell startup files PBA" is unable to find regular users. #1507
 
 
 ### Security

--- a/monkey/infection_monkey/post_breach/actions/modify_shell_startup_files.py
+++ b/monkey/infection_monkey/post_breach/actions/modify_shell_startup_files.py
@@ -20,6 +20,13 @@ class ModifyShellStartupFiles(PBA):
 
     def run(self):
         results = [pba.run() for pba in self.modify_shell_startup_PBA_list()]
+        if not results:
+            results = [
+                (
+                    "Modify shell startup files PBA failed: Unable to find any regular users",
+                    False,
+                )
+            ]
         PostBreachTelem(self, results).send()
 
     def modify_shell_startup_PBA_list(self):
@@ -61,6 +68,7 @@ class ModifyShellStartupFiles(PBA):
                         output = subprocess.check_output(  # noqa: DUO116
                             self.command, stderr=subprocess.STDOUT, shell=True
                         ).decode()
+
                         return output, True
                     except subprocess.CalledProcessError as e:
                         # Return error output of the command


### PR DESCRIPTION
# What does this PR do? 

Fixes #1507 and #1055 . 

In docker container `/etc/passwd` doesn't have any regular users. The modify shell script searches for those kind of users and if it doesn't find it return empty list which then we send telemetry without any result making the post breach action to fail.
Here we check if we have empty result from the running of command and send failed result with explanation.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing? 
* [x] Was the CHANGELOG.md updated to reflect the changes?
* [x] Was the documentation framework updated to reflect the changes?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by {Running the Monkey locally with relevant config/running Island/...} 
* [x] If applicable, add screenshots or log transcripts of the feature working

## Explain Changes

![image](https://user-images.githubusercontent.com/15820737/135891766-79773b28-d4a6-4f98-a55b-984091788414.png)
