### PR TITLE
1597 implement scan target generator

### DIFF
--- a/monkey/common/network/network_range.py
+++ b/monkey/common/network/network_range.py
@@ -178,7 +178,7 @@ class SingleIpRange(NetworkRange):
         :return: A tuple in format (IP, domain_name). Eg. (192.168.55.1, www.google.com)
         """
         # The most common use case is to enter ip/range into "Scan IP/subnet list"
-        domain_name = ""
+        domain_name = None
 
         # Try casting user's input as IP
         try:

--- a/monkey/common/network/network_range.py
+++ b/monkey/common/network/network_range.py
@@ -44,9 +44,11 @@ class NetworkRange(object, metaclass=ABCMeta):
         if not address_str:  # Empty string
             return None
         address_str = address_str.strip()
+        if address_str.endswith("/32"):
+            address_str = address_str[:-3]
         if NetworkRange.check_if_range(address_str):
             return IpRange(ip_range=address_str)
-        if -1 != address_str.find("/"):
+        if "/" in address_str:
             return CidrRange(cidr_range=address_str)
         return SingleIpRange(ip_address=address_str)
 

--- a/monkey/common/network/network_range.py
+++ b/monkey/common/network/network_range.py
@@ -54,6 +54,7 @@ class NetworkRange(object, metaclass=ABCMeta):
     def check_if_range(address_str):
         if -1 != address_str.find("-"):
             ips = address_str.split("-")
+            ips = [ip.strip() for ip in ips]
             try:
                 ipaddress.ip_address(ips[0]) and ipaddress.ip_address(ips[1])
             except ValueError:

--- a/monkey/common/network/network_range.py
+++ b/monkey/common/network/network_range.py
@@ -4,6 +4,7 @@ import random
 import socket
 import struct
 from abc import ABCMeta, abstractmethod
+from typing import Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -55,14 +56,19 @@ class NetworkRange(object, metaclass=ABCMeta):
     @staticmethod
     def check_if_range(address_str):
         if -1 != address_str.find("-"):
-            ips = address_str.split("-")
-            ips = [ip.strip() for ip in ips]
             try:
-                ipaddress.ip_address(ips[0]) and ipaddress.ip_address(ips[1])
+                NetworkRange._range_to_ips(address_str)
             except ValueError:
                 return False
             return True
         return False
+
+    @staticmethod
+    def _range_to_ips(ip_range: str) -> Tuple[str, str]:
+        ips = ip_range.split("-")
+        ips = [ip.strip() for ip in ips]
+        ips = sorted(ips, key=lambda ip: socket.inet_aton(ip))
+        return ips[0], ips[1]
 
     @staticmethod
     def _ip_to_number(address):
@@ -97,12 +103,7 @@ class IpRange(NetworkRange):
     def __init__(self, ip_range=None, lower_end_ip=None, higher_end_ip=None, shuffle=True):
         super(IpRange, self).__init__(shuffle=shuffle)
         if ip_range is not None:
-            addresses = ip_range.split("-")
-            if len(addresses) != 2:
-                raise ValueError(
-                    "Illegal IP range format: %s. Format is 192.168.0.5-192.168.0.20" % ip_range
-                )
-            self._lower_end_ip, self._higher_end_ip = [x.strip() for x in addresses]
+            self._lower_end_ip, self._higher_end_ip = IpRange._range_to_ips(ip_range)
         elif (lower_end_ip is not None) and (higher_end_ip is not None):
             self._lower_end_ip = lower_end_ip.strip()
             self._higher_end_ip = higher_end_ip.strip()

--- a/monkey/common/network/network_range.py
+++ b/monkey/common/network/network_range.py
@@ -4,7 +4,7 @@ import random
 import socket
 import struct
 from abc import ABCMeta, abstractmethod
-from typing import Tuple
+from typing import List, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +56,18 @@ class NetworkRange(object, metaclass=ABCMeta):
         if "/" in address_str:
             return CidrRange(cidr_range=address_str)
         return SingleIpRange(ip_address=address_str)
+
+    @staticmethod
+    def filter_invalid_ranges(ranges: List[str], error_msg: str) -> List[str]:
+        valid_ranges = []
+        for target_range in ranges:
+            try:
+                NetworkRange.validate_range(target_range)
+            except InvalidNetworkRangeError as e:
+                logger.error(f"{error_msg} {e}")
+                continue
+            valid_ranges.append(target_range)
+        return valid_ranges
 
     @staticmethod
     def validate_range(address_str: str):

--- a/monkey/infection_monkey/network/network_scanner.py
+++ b/monkey/infection_monkey/network/network_scanner.py
@@ -41,6 +41,8 @@ class NetworkScanner(object):
         self._ranges += self._get_inaccessible_subnets_ips()
         logger.info("Base local networks to scan are: %r", self._ranges)
 
+    # TODO remove afret agent refactoring,
+    #  it's already handled in network.scan_target_generator._get_inaccessible_subnets_ips
     def _get_inaccessible_subnets_ips(self):
         """
         For each of the machine's IPs, checks if it's in one of the subnets specified in the
@@ -113,6 +115,8 @@ class NetworkScanner(object):
                 time.sleep(WormConfiguration.tcp_scan_interval / float(1000))
 
     @staticmethod
+    # TODO remove afret agent refactoring,
+    #  it's already handled in network.scan_target_generator._is_any_ip_in_subnet
     def _is_any_ip_in_subnet(ip_addresses, subnet_str):
         for ip_address in ip_addresses:
             if NetworkRange.get_range_obj(subnet_str).is_in_range(ip_address):

--- a/monkey/infection_monkey/network/scan_target_generator.py
+++ b/monkey/infection_monkey/network/scan_target_generator.py
@@ -1,12 +1,12 @@
 import itertools
 import logging
 from collections import namedtuple
-from typing import List, Set
+from typing import List
 
 from common.network.network_range import InvalidNetworkRangeError, NetworkRange
 
 NetworkInterface = namedtuple("NetworkInterface", ("address", "netmask"))
-
+NetworkAddress = namedtuple("NetworkAddress", ("ip", "domain"))
 
 logger = logging.getLogger(__name__)
 
@@ -17,73 +17,101 @@ def compile_scan_target_list(
     inaccessible_subnets: List[str],
     blocklisted_ips: List[str],
     enable_local_network_scan: bool,
-) -> List[str]:
-
+) -> List[NetworkAddress]:
     scan_targets = _get_ips_from_ranges_to_scan(ranges_to_scan)
 
     if enable_local_network_scan:
-        scan_targets.update(_get_ips_to_scan_from_local_interface(local_network_interfaces))
+        scan_targets.extend(_get_ips_to_scan_from_local_interface(local_network_interfaces))
 
     if inaccessible_subnets:
         inaccessible_subnets = _get_segmentation_check_targets(
             inaccessible_subnets, local_network_interfaces
         )
-        scan_targets.update(inaccessible_subnets)
+        scan_targets.extend(inaccessible_subnets)
 
-    _remove_interface_ips(scan_targets, local_network_interfaces)
-    _remove_blocklisted_ips(scan_targets, blocklisted_ips)
+    scan_targets = _remove_interface_ips(scan_targets, local_network_interfaces)
+    scan_targets = _remove_blocklisted_ips(scan_targets, blocklisted_ips)
+    scan_targets = _remove_redundant_targets(scan_targets)
+    scan_targets.sort()
 
-    scan_target_list = list(scan_targets)
-    scan_target_list.sort()
-
-    return scan_target_list
+    return scan_targets
 
 
-def _get_ips_from_ranges_to_scan(ranges_to_scan: List[str]) -> Set[str]:
-    scan_targets = set()
+def _remove_redundant_targets(targets: List[NetworkAddress]) -> List[NetworkAddress]:
+    target_dict = {}
+    for target in targets:
+        domain_name = target.domain
+        ip = target.ip
+        if ip not in target_dict or (target_dict[ip] is None and domain_name is not None):
+            target_dict[ip] = domain_name
+    return [NetworkAddress(key, value) for (key, value) in target_dict.items()]
+
+
+def _range_to_addresses(range_obj: NetworkRange) -> List[NetworkAddress]:
+    addresses = []
+    for address in range_obj:
+        if hasattr(range_obj, "domain_name"):
+            addresses.append(NetworkAddress(address, range_obj.domain_name))
+        else:
+            addresses.append(NetworkAddress(address, None))
+    return addresses
+
+
+def _get_ips_from_ranges_to_scan(ranges_to_scan: List[str]) -> List[NetworkAddress]:
+    scan_targets = []
 
     ranges_to_scan = _filter_invalid_ranges(
         ranges_to_scan, "Bad network range input for targets to scan:"
     )
 
     network_ranges = [NetworkRange.get_range_obj(_range) for _range in ranges_to_scan]
+
     for _range in network_ranges:
-        scan_targets.update(set(_range))
+        scan_targets.extend(_range_to_addresses(_range))
     return scan_targets
 
 
-def _get_ips_to_scan_from_local_interface(interfaces: List[NetworkInterface]) -> Set[str]:
+def _get_ips_to_scan_from_local_interface(
+    interfaces: List[NetworkInterface],
+) -> List[NetworkAddress]:
     ranges = [f"{interface.address}{interface.netmask}" for interface in interfaces]
 
     ranges = _filter_invalid_ranges(ranges, "Local network interface returns an invalid IP:")
     return _get_ips_from_ranges_to_scan(ranges)
 
 
-def _remove_interface_ips(scan_targets: Set[str], interfaces: List[NetworkInterface]):
+def _remove_interface_ips(
+    scan_targets: List[NetworkAddress], interfaces: List[NetworkInterface]
+) -> List[NetworkAddress]:
     interface_ips = [interface.address for interface in interfaces]
-    _remove_ips_from_scan_targets(scan_targets, interface_ips)
+    return _remove_ips_from_scan_targets(scan_targets, interface_ips)
 
 
-def _remove_blocklisted_ips(scan_targets: Set[str], blocked_ips: List[str]):
+def _remove_blocklisted_ips(
+    scan_targets: List[NetworkAddress], blocked_ips: List[str]
+) -> List[NetworkAddress]:
     filtered_blocked_ips = _filter_invalid_ranges(blocked_ips, "Invalid blocked IP provided:")
     if not len(filtered_blocked_ips) == len(blocked_ips):
         raise InvalidNetworkRangeError("Received an invalid blocked IP. Aborting just in case.")
-    _remove_ips_from_scan_targets(scan_targets, blocked_ips)
+    return _remove_ips_from_scan_targets(scan_targets, filtered_blocked_ips)
 
 
-def _remove_ips_from_scan_targets(scan_targets: Set[str], ips_to_remove: List[str]):
+def _remove_ips_from_scan_targets(
+    scan_targets: List[NetworkAddress], ips_to_remove: List[str]
+) -> List[NetworkAddress]:
     for ip in ips_to_remove:
         try:
-            scan_targets.remove(ip)
+            scan_targets = [address for address in scan_targets if address.ip != ip]
         except KeyError:
             # We don't need to remove the ip if it's already missing from the scan_targets
             pass
+    return scan_targets
 
 
 def _get_segmentation_check_targets(
     inaccessible_subnets: List[str], local_interfaces: List[NetworkInterface]
-):
-    subnets_to_scan = set()
+) -> List[NetworkAddress]:
+    subnets_to_scan = []
     local_ips = [interface.address for interface in local_interfaces]
 
     local_ips = _filter_invalid_ranges(local_ips, "Invalid local IP found: ")
@@ -97,7 +125,7 @@ def _get_segmentation_check_targets(
     for (subnet1, subnet2) in subnet_pairs:
         if _is_segmentation_check_required(local_ips, subnet1, subnet2):
             ips = _get_ips_from_ranges_to_scan(subnet2)
-            subnets_to_scan.update(ips)
+            subnets_to_scan.extend(ips)
 
     return subnets_to_scan
 

--- a/monkey/infection_monkey/network/scan_target_generator.py
+++ b/monkey/infection_monkey/network/scan_target_generator.py
@@ -1,0 +1,25 @@
+from typing import List
+
+from common.network.network_range import NetworkRange
+
+
+def compile_scan_target_list(
+    local_ips: List[str],
+    ranges_to_scan: List[str],
+    inaccessible_subnets: List[str],
+    blocklisted_ips: List[str],
+    enable_local_network_scan: bool,
+) -> List[str]:
+    scan_target_list = _get_ips_from_ranges_to_scan(ranges_to_scan)
+
+    return scan_target_list
+
+
+def _get_ips_from_ranges_to_scan(ranges_to_scan):
+    scan_target_list = []
+
+    network_ranges = [NetworkRange.get_range_obj(_range) for _range in ranges_to_scan]
+    for _range in network_ranges:
+        scan_target_list.extend([ip for ip in _range])
+
+    return scan_target_list

--- a/monkey/infection_monkey/network/scan_target_generator.py
+++ b/monkey/infection_monkey/network/scan_target_generator.py
@@ -99,13 +99,8 @@ def _remove_blocklisted_ips(
 def _remove_ips_from_scan_targets(
     scan_targets: List[NetworkAddress], ips_to_remove: List[str]
 ) -> List[NetworkAddress]:
-    for ip in ips_to_remove:
-        try:
-            scan_targets = [address for address in scan_targets if address.ip != ip]
-        except KeyError:
-            # We don't need to remove the ip if it's already missing from the scan_targets
-            pass
-    return scan_targets
+    ips_to_remove_set = set(ips_to_remove)
+    return [address for address in scan_targets if address.ip not in ips_to_remove_set]
 
 
 def _get_segmentation_check_targets(

--- a/monkey/infection_monkey/network/scan_target_generator.py
+++ b/monkey/infection_monkey/network/scan_target_generator.py
@@ -91,7 +91,7 @@ def _remove_blocklisted_ips(
     scan_targets: List[NetworkAddress], blocked_ips: List[str]
 ) -> List[NetworkAddress]:
     filtered_blocked_ips = _filter_invalid_ranges(blocked_ips, "Invalid blocked IP provided:")
-    if not len(filtered_blocked_ips) == len(blocked_ips):
+    if len(filtered_blocked_ips) != len(blocked_ips):
         raise InvalidNetworkRangeError("Received an invalid blocked IP. Aborting just in case.")
     return _remove_ips_from_scan_targets(scan_targets, filtered_blocked_ips)
 

--- a/monkey/infection_monkey/network/scan_target_generator.py
+++ b/monkey/infection_monkey/network/scan_target_generator.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Set
 
 from common.network.network_range import NetworkRange
 
@@ -10,16 +10,18 @@ def compile_scan_target_list(
     blocklisted_ips: List[str],
     enable_local_network_scan: bool,
 ) -> List[str]:
-    scan_target_list = _get_ips_from_ranges_to_scan(ranges_to_scan)
+    scan_targets = _get_ips_from_ranges_to_scan(ranges_to_scan)
 
+    scan_target_list = list(scan_targets)
+    scan_target_list.sort()
     return scan_target_list
 
 
-def _get_ips_from_ranges_to_scan(ranges_to_scan):
-    scan_target_list = []
+def _get_ips_from_ranges_to_scan(ranges_to_scan: List[str]) -> Set[str]:
+    scan_targets = set()
 
     network_ranges = [NetworkRange.get_range_obj(_range) for _range in ranges_to_scan]
     for _range in network_ranges:
-        scan_target_list.extend([ip for ip in _range])
+        scan_targets.update(set(_range))
 
-    return scan_target_list
+    return scan_targets

--- a/monkey/infection_monkey/network/scan_target_generator.py
+++ b/monkey/infection_monkey/network/scan_target_generator.py
@@ -12,8 +12,11 @@ def compile_scan_target_list(
 ) -> List[str]:
     scan_targets = _get_ips_from_ranges_to_scan(ranges_to_scan)
 
+    _remove_blocklisted_ips(scan_targets, blocklisted_ips)
+
     scan_target_list = list(scan_targets)
     scan_target_list.sort()
+
     return scan_target_list
 
 
@@ -25,3 +28,12 @@ def _get_ips_from_ranges_to_scan(ranges_to_scan: List[str]) -> Set[str]:
         scan_targets.update(set(_range))
 
     return scan_targets
+
+
+def _remove_blocklisted_ips(scan_targets: Set[str], blocked_ips: List[str]):
+    for blocked_ip in blocked_ips:
+        try:
+            scan_targets.remove(blocked_ip)
+        except KeyError:
+            # We don't need to remove the blocked ip if it's already missing from the scan_targets
+            pass

--- a/monkey/infection_monkey/network/scan_target_generator.py
+++ b/monkey/infection_monkey/network/scan_target_generator.py
@@ -1,5 +1,6 @@
 import itertools
 import logging
+import socket
 from collections import namedtuple
 from typing import List
 
@@ -32,7 +33,7 @@ def compile_scan_target_list(
     scan_targets = _remove_interface_ips(scan_targets, local_network_interfaces)
     scan_targets = _remove_blocklisted_ips(scan_targets, blocklisted_ips)
     scan_targets = _remove_redundant_targets(scan_targets)
-    scan_targets.sort()
+    scan_targets.sort(key=lambda network_address: socket.inet_aton(network_address.ip))
 
     return scan_targets
 

--- a/monkey/infection_monkey/network/scan_target_generator.py
+++ b/monkey/infection_monkey/network/scan_target_generator.py
@@ -1,3 +1,4 @@
+import itertools
 from collections import namedtuple
 from typing import List, Set
 
@@ -9,7 +10,6 @@ NetworkInterface = namedtuple("NetworkInterface", ("address", "netmask"))
 
 
 # TODO: Validate all parameters
-# TODO: Implement inaccessible_subnets
 def compile_scan_target_list(
     local_network_interfaces: List[NetworkInterface],
     ranges_to_scan: List[str],
@@ -21,6 +21,12 @@ def compile_scan_target_list(
 
     if enable_local_network_scan:
         scan_targets.update(_get_ips_to_scan_from_local_interface(local_network_interfaces))
+
+    if inaccessible_subnets:
+        inaccessible_subnets = _get_segmentation_check_targets(
+            inaccessible_subnets, local_network_interfaces
+        )
+        scan_targets.update(inaccessible_subnets)
 
     _remove_interface_ips(scan_targets, local_network_interfaces)
     _remove_blocklisted_ips(scan_targets, blocklisted_ips)
@@ -62,3 +68,37 @@ def _remove_ips_from_scan_targets(scan_targets: Set[str], ips_to_remove: List[st
         except KeyError:
             # We don't need to remove the ip if it's already missing from the scan_targets
             pass
+
+
+def _get_segmentation_check_targets(
+    inaccessible_subnets: List[str], local_interfaces: List[NetworkInterface]
+):
+    subnets_to_scan = set()
+    local_ips = [interface.address for interface in local_interfaces]
+
+    inaccessible_subnets = _convert_to_range_object(inaccessible_subnets)
+    subnet_pairs = itertools.product(inaccessible_subnets, inaccessible_subnets)
+
+    for (subnet1, subnet2) in subnet_pairs:
+        if _is_segmentation_check_required(local_ips, subnet1, subnet2):
+            ips = _get_ips_from_ranges_to_scan(subnet2)
+            subnets_to_scan.update(ips)
+
+    return subnets_to_scan
+
+
+def _convert_to_range_object(subnets: List[str]) -> List[NetworkRange]:
+    return [NetworkRange.get_range_obj(subnet) for subnet in subnets]
+
+
+def _is_segmentation_check_required(
+    local_ips: List[str], subnet1: NetworkRange, subnet2: NetworkRange
+):
+    return _is_any_ip_in_subnet(local_ips, subnet1) and not _is_any_ip_in_subnet(local_ips, subnet2)
+
+
+def _is_any_ip_in_subnet(ip_addresses: List[str], subnet: NetworkRange):
+    for ip_address in ip_addresses:
+        if subnet.is_in_range(ip_address):
+            return True
+    return False

--- a/monkey/infection_monkey/network/scan_target_generator.py
+++ b/monkey/infection_monkey/network/scan_target_generator.py
@@ -12,6 +12,7 @@ def compile_scan_target_list(
 ) -> List[str]:
     scan_targets = _get_ips_from_ranges_to_scan(ranges_to_scan)
 
+    _remove_local_ips(scan_targets, local_ips)
     _remove_blocklisted_ips(scan_targets, blocklisted_ips)
 
     scan_target_list = list(scan_targets)
@@ -30,10 +31,18 @@ def _get_ips_from_ranges_to_scan(ranges_to_scan: List[str]) -> Set[str]:
     return scan_targets
 
 
+def _remove_local_ips(scan_targets: Set[str], local_ips: List[str]):
+    _remove_ips_from_scan_targets(scan_targets, local_ips)
+
+
 def _remove_blocklisted_ips(scan_targets: Set[str], blocked_ips: List[str]):
-    for blocked_ip in blocked_ips:
+    _remove_ips_from_scan_targets(scan_targets, blocked_ips)
+
+
+def _remove_ips_from_scan_targets(scan_targets: Set[str], ips_to_remove: List[str]):
+    for ip in ips_to_remove:
         try:
-            scan_targets.remove(blocked_ip)
+            scan_targets.remove(ip)
         except KeyError:
-            # We don't need to remove the blocked ip if it's already missing from the scan_targets
+            # We don't need to remove the ip if it's already missing from the scan_targets
             pass

--- a/monkey/infection_monkey/network/scan_target_generator.py
+++ b/monkey/infection_monkey/network/scan_target_generator.py
@@ -1,10 +1,17 @@
+from collections import namedtuple
 from typing import List, Set
 
 from common.network.network_range import NetworkRange
 
+# TODO: Convert to class and validate the format of the address and netmask
+#       Example: address="192.168.1.1", netmask="/24"
+NetworkInterface = namedtuple("NetworkInterface", ("address", "netmask"))
 
+
+# TODO: Validate all parameters
+# TODO: Implement inaccessible_subnets
 def compile_scan_target_list(
-    local_ips: List[str],
+    local_network_interfaces: List[NetworkInterface],
     ranges_to_scan: List[str],
     inaccessible_subnets: List[str],
     blocklisted_ips: List[str],
@@ -12,7 +19,10 @@ def compile_scan_target_list(
 ) -> List[str]:
     scan_targets = _get_ips_from_ranges_to_scan(ranges_to_scan)
 
-    _remove_local_ips(scan_targets, local_ips)
+    if enable_local_network_scan:
+        scan_targets.update(_get_ips_to_scan_from_local_interface(local_network_interfaces))
+
+    _remove_interface_ips(scan_targets, local_network_interfaces)
     _remove_blocklisted_ips(scan_targets, blocklisted_ips)
 
     scan_target_list = list(scan_targets)
@@ -31,8 +41,14 @@ def _get_ips_from_ranges_to_scan(ranges_to_scan: List[str]) -> Set[str]:
     return scan_targets
 
 
-def _remove_local_ips(scan_targets: Set[str], local_ips: List[str]):
-    _remove_ips_from_scan_targets(scan_targets, local_ips)
+def _get_ips_to_scan_from_local_interface(interfaces: List[NetworkInterface]) -> Set[str]:
+    ranges = [f"{interface.address}{interface.netmask}" for interface in interfaces]
+    return _get_ips_from_ranges_to_scan(ranges)
+
+
+def _remove_interface_ips(scan_targets: Set[str], interfaces: List[NetworkInterface]):
+    interface_ips = [interface.address for interface in interfaces]
+    _remove_ips_from_scan_targets(scan_targets, interface_ips)
 
 
 def _remove_blocklisted_ips(scan_targets: Set[str], blocked_ips: List[str]):

--- a/monkey/tests/unit_tests/common/network/test_network_range.py
+++ b/monkey/tests/unit_tests/common/network/test_network_range.py
@@ -1,0 +1,35 @@
+from common.network.network_range import NetworkRange
+
+
+def test_range_filtering():
+    invalid_ranges = [
+        # Invalid IP segment
+        "172.60.999.109",
+        "172.60.-1.109",
+        "172.60.999.109 - 172.60.1.109",
+        "172.60.999.109/32",
+        "172.60.999.109/24",
+        # Invalid CIDR
+        "172.60.1.109/33",
+        "172.60.1.109/-1",
+        # Typos
+        "172.60.9.109 -t 172.60.1.109",
+        "172.60..9.109",
+        "172.60,9.109",
+        " 172.60 .9.109 ",
+    ]
+
+    valid_ranges = [
+        " 172.60.9.109 ",
+        "172.60.9.109 - 172.60.1.109",
+        "172.60.9.109- 172.60.1.109",
+        "0.0.0.0",
+        "localhost",
+    ]
+
+    invalid_ranges.extend(valid_ranges)
+
+    remaining = NetworkRange.filter_invalid_ranges(invalid_ranges, "Test error:")
+    for _range in remaining:
+        assert _range in valid_ranges
+    assert len(remaining) == len(valid_ranges)

--- a/monkey/tests/unit_tests/infection_monkey/model/test_victim_host_generator.py
+++ b/monkey/tests/unit_tests/infection_monkey/model/test_victim_host_generator.py
@@ -39,8 +39,3 @@ class TestVictimHostGenerator(TestCase):
         victims = list(generator.generate_victims_from_range(self.local_host_range))
         self.assertEqual(len(victims), 1)
         self.assertEqual(victims[0].domain_name, "localhost")
-
-        # don't generate for other victims
-        victims = list(generator.generate_victims_from_range(self.random_single_ip_range))
-        self.assertEqual(len(victims), 1)
-        self.assertEqual(victims[0].domain_name, "")

--- a/monkey/tests/unit_tests/infection_monkey/network/test_scan_target_generator.py
+++ b/monkey/tests/unit_tests/infection_monkey/network/test_scan_target_generator.py
@@ -6,7 +6,6 @@ from common.network.network_range import InvalidNetworkRangeError
 from infection_monkey.network.scan_target_generator import (
     NetworkAddress,
     NetworkInterface,
-    _filter_invalid_ranges,
     compile_scan_target_list,
 )
 
@@ -448,40 +447,6 @@ def test_invalid_inputs():
 
     for ip in [148, 149, 150]:
         assert NetworkAddress(f"172.60.145.{ip}", None) in scan_targets
-
-
-def test_range_filtering():
-    invalid_ranges = [
-        # Invalid IP segment
-        "172.60.999.109",
-        "172.60.-1.109",
-        "172.60.999.109 - 172.60.1.109",
-        "172.60.999.109/32",
-        "172.60.999.109/24",
-        # Invalid CIDR
-        "172.60.1.109/33",
-        "172.60.1.109/-1",
-        # Typos
-        "172.60.9.109 -t 172.60.1.109",
-        "172.60..9.109",
-        "172.60,9.109",
-        " 172.60 .9.109 ",
-    ]
-
-    valid_ranges = [
-        " 172.60.9.109 ",
-        "172.60.9.109 - 172.60.1.109",
-        "172.60.9.109- 172.60.1.109",
-        "0.0.0.0",
-        "localhost",
-    ]
-
-    invalid_ranges.extend(valid_ranges)
-
-    remaining = _filter_invalid_ranges(invalid_ranges, "Test error:")
-    for _range in remaining:
-        assert _range in valid_ranges
-    assert len(remaining) == len(valid_ranges)
 
 
 def test_invalid_blocklisted_ip():

--- a/monkey/tests/unit_tests/infection_monkey/network/test_scan_target_generator.py
+++ b/monkey/tests/unit_tests/infection_monkey/network/test_scan_target_generator.py
@@ -466,3 +466,18 @@ def test_invalid_blocklisted_ip():
             blocklisted_ips=blocklisted,
             enable_local_network_scan=False,
         )
+
+
+def test_sorted_scan_targets():
+    expected_results = [f"10.1.0.{i}" for i in range(0, 255)]
+    expected_results.extend([f"10.2.0.{i}" for i in range(0, 255)])
+    expected_results.extend([f"10.10.0.{i}" for i in range(0, 255)])
+    expected_results.extend([f"10.20.0.{i}" for i in range(0, 255)])
+
+    scan_targets = compile_scan_target_list(
+        [], ["10.1.0.0/24", "10.10.0.0/24", "10.20.0.0/24", "10.2.0.0/24"], [], [], False
+    )
+
+    actual_results = [network_address.ip for network_address in scan_targets]
+
+    assert expected_results == actual_results

--- a/monkey/tests/unit_tests/infection_monkey/network/test_scan_target_generator.py
+++ b/monkey/tests/unit_tests/infection_monkey/network/test_scan_target_generator.py
@@ -57,7 +57,8 @@ def test_middle_of_range_subnet():
 
 
 @pytest.mark.parametrize(
-    "ip_range", ["192.168.56.25-192.168.56.33", "192.168.56.25 - 192.168.56.33"]
+    "ip_range",
+    ["192.168.56.25-192.168.56.33", "192.168.56.25 - 192.168.56.33", "192.168.56.33-192.168.56.25"],
 )
 def test_ip_range(ip_range):
     scan_targets = compile_ranges_only([ip_range])

--- a/monkey/tests/unit_tests/infection_monkey/network/test_scan_target_generator.py
+++ b/monkey/tests/unit_tests/infection_monkey/network/test_scan_target_generator.py
@@ -1,0 +1,65 @@
+import pytest
+
+from infection_monkey.network.scan_target_generator import compile_scan_target_list
+
+
+def compile_ranges_only(ranges):
+    return compile_scan_target_list(
+        local_ips=[],
+        ranges_to_scan=ranges,
+        inaccessible_subnets=[],
+        blocklisted_ips=[],
+        enable_local_network_scan=False,
+    )
+
+
+def test_single_subnet():
+    scan_targets = compile_ranges_only(["10.0.0.0/24"])
+
+    assert len(scan_targets) == 255
+
+    for i in range(0, 255):
+        assert f"10.0.0.{i}" in scan_targets
+
+
+@pytest.mark.parametrize("single_ip", ["10.0.0.2", "10.0.0.2/32", "10.0.0.2-10.0.0.2"])
+def test_single_ip(single_ip):
+    print(single_ip)
+    scan_targets = compile_ranges_only([single_ip])
+
+    assert len(scan_targets) == 1
+    assert "10.0.0.2" in scan_targets
+    assert "10.0.0.2" == scan_targets[0]
+
+
+def test_multiple_subnet():
+    scan_targets = compile_ranges_only(["10.0.0.0/24", "192.168.56.8/29"])
+
+    assert len(scan_targets) == 262
+
+    for i in range(0, 255):
+        assert f"10.0.0.{i}" in scan_targets
+
+    for i in range(8, 15):
+        assert f"192.168.56.{i}" in scan_targets
+
+
+def test_middle_of_range_subnet():
+    scan_targets = compile_ranges_only(["192.168.56.4/29"])
+
+    assert len(scan_targets) == 7
+
+    for i in range(0, 7):
+        assert f"192.168.56.{i}" in scan_targets
+
+
+@pytest.mark.parametrize(
+    "ip_range", ["192.168.56.25-192.168.56.33", "192.168.56.25 - 192.168.56.33"]
+)
+def test_ip_range(ip_range):
+    scan_targets = compile_ranges_only([ip_range])
+
+    assert len(scan_targets) == 9
+
+    for i in range(25, 34):
+        assert f"192.168.56.{i}" in scan_targets

--- a/monkey/tests/unit_tests/infection_monkey/network/test_scan_target_generator.py
+++ b/monkey/tests/unit_tests/infection_monkey/network/test_scan_target_generator.py
@@ -1,11 +1,12 @@
 from itertools import chain
 
 import pytest
-from network.scan_target_generator import NetworkAddress, _filter_invalid_ranges
 
 from common.network.network_range import InvalidNetworkRangeError
 from infection_monkey.network.scan_target_generator import (
+    NetworkAddress,
     NetworkInterface,
+    _filter_invalid_ranges,
     compile_scan_target_list,
 )
 

--- a/monkey/tests/unit_tests/infection_monkey/network/test_scan_target_generator.py
+++ b/monkey/tests/unit_tests/infection_monkey/network/test_scan_target_generator.py
@@ -1,3 +1,5 @@
+from itertools import chain
+
 import pytest
 
 from infection_monkey.network.scan_target_generator import (
@@ -191,9 +193,7 @@ def test_local_subnet_added():
 
     assert len(scan_targets) == 254
 
-    for ip in range(0, 5):
-        assert f"10.0.0.{ip} in scan_targets"
-    for ip in range(6, 255):
+    for ip in chain(range(0, 5), range(6, 255)):
         assert f"10.0.0.{ip} in scan_targets"
 
 
@@ -213,14 +213,10 @@ def test_multiple_local_subnets_added():
 
     assert len(scan_targets) == 2 * (255 - 1)
 
-    for ip in range(0, 5):
-        assert f"10.0.0.{ip} in scan_targets"
-    for ip in range(6, 255):
+    for ip in chain(range(0, 5), range(6, 255)):
         assert f"10.0.0.{ip} in scan_targets"
 
-    for ip in range(0, 99):
-        assert f"172.33.66.{ip} in scan_targets"
-    for ip in range(100, 255):
+    for ip in chain(range(0, 99), range(100, 255)):
         assert f"172.33.66.{ip} in scan_targets"
 
 

--- a/monkey/tests/unit_tests/infection_monkey/network/test_scan_target_generator.py
+++ b/monkey/tests/unit_tests/infection_monkey/network/test_scan_target_generator.py
@@ -63,3 +63,43 @@ def test_ip_range(ip_range):
 
     for i in range(25, 34):
         assert f"192.168.56.{i}" in scan_targets
+
+
+def test_no_duplicates():
+    scan_targets = compile_ranges_only(["192.168.56.0/29", "192.168.56.2", "192.168.56.4"])
+
+    assert len(scan_targets) == 7
+
+    for i in range(0, 7):
+        assert f"192.168.56.{i}" in scan_targets
+
+
+def test_blocklisted_ips():
+    blocklisted_ips = ["10.0.0.5", "10.0.0.32", "10.0.0.119", "192.168.1.33"]
+
+    scan_targets = compile_scan_target_list(
+        local_ips=[],
+        ranges_to_scan=["10.0.0.0/24"],
+        inaccessible_subnets=[],
+        blocklisted_ips=blocklisted_ips,
+        enable_local_network_scan=False,
+    )
+
+    assert len(scan_targets) == 252
+    for blocked_ip in blocklisted_ips:
+        assert blocked_ip not in scan_targets
+
+
+@pytest.mark.parametrize("ranges_to_scan", [["10.0.0.5"], []])
+def test_only_ip_blocklisted(ranges_to_scan):
+    blocklisted_ips = ["10.0.0.5"]
+
+    scan_targets = compile_scan_target_list(
+        local_ips=[],
+        ranges_to_scan=ranges_to_scan,
+        inaccessible_subnets=[],
+        blocklisted_ips=blocklisted_ips,
+        enable_local_network_scan=False,
+    )
+
+    assert len(scan_targets) == 0


### PR DESCRIPTION
# What does this PR do? 

Implements scan target generator. These changes extract the step of scan target generation into a method that takes inputs like scan targets, local interfaces, segmentation test targets, blocked IP's etc. and produces a list of IP's that agent needs to scan.

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing? 
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running UT's

