### PR TITLE
Island: Change the order of log messages on startup to improve UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
 - "Communicate as Backdoor User" PBA's HTTP requests to request headers only and
   include a timeout. #1577
 - The setup procedure for custom server_config.json files to be simpler. #1576
+- The order and content of Monkey Island's initialization logging to give
+  clearer instructions to the user and avoid confusion. #1684
 
 ### Removed
 - The VSFTPD exploiter. #1533

--- a/monkey/monkey_island/cc/server_setup.py
+++ b/monkey/monkey_island/cc/server_setup.py
@@ -167,11 +167,17 @@ def _start_bootloader_server() -> Thread:
 
 
 def _log_init_info():
+    MonkeyDownload.log_executable_hashes()
+
     logger.info("Monkey Island Server is running!")
     logger.info(f"version: {get_version()}")
+
+    _log_web_interface_access_urls()
+
+
+def _log_web_interface_access_urls():
+    web_interface_urls = ", ".join([f"https://{ip}:{ISLAND_PORT}" for ip in local_ip_addresses()])
     logger.info(
-        "Listening on the following URLs: {}".format(
-            ", ".join(["https://{}:{}".format(x, ISLAND_PORT) for x in local_ip_addresses()])
-        )
+        "To access the web interface, navigate to one of the the following URLs using your "
+        f"browser: {web_interface_urls}"
     )
-    MonkeyDownload.log_executable_hashes()


### PR DESCRIPTION
# What does this PR do? 
Two users contacted me (coincidentally on the same day) and were confused when Monkey Island started. They thought it had frozen when the agent binary hashes were printed to the screen. The instructions for accessing the island are buried in the Island's output and it may be difficult for users to find the appropriate messages.

### Before
![image](https://user-images.githubusercontent.com/19957806/151210844-39bcf67a-23c2-47c5-9976-8462242be0e8.png)

### After

![image](https://user-images.githubusercontent.com/19957806/151211183-08741c28-4f5d-4060-a559-da8d4d02e8a4.png)

By changing the order and content of the log statements, I hope to alleviate this confusion.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] ~Is the TravisCI build passing?~ 
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] ~Was the documentation framework updated to reflect the changes?~

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running locally
* [x] If applicable, add screenshots or log transcripts of the feature working
