### PR TITLE
Remove dropper_target_path_win_32 bit config option

### DIFF
--- a/monkey/infection_monkey/config.py
+++ b/monkey/infection_monkey/config.py
@@ -89,7 +89,6 @@ class Configuration(object):
     dropper_set_date = True
     dropper_date_reference_path_windows = r"%windir%\system32\kernel32.dll"
     dropper_date_reference_path_linux = "/bin/sh"
-    dropper_target_path_win_32 = r"C:\Windows\temp\monkey32.exe"
     dropper_target_path_win_64 = r"C:\Windows\temp\monkey64.exe"
     dropper_target_path_linux = "/tmp/monkey"
 

--- a/monkey/infection_monkey/example.conf
+++ b/monkey/infection_monkey/example.conf
@@ -19,7 +19,6 @@
   "dropper_log_path_windows": "%temp%\\~df1562.tmp",
   "dropper_log_path_linux": "/tmp/user-1562",
   "dropper_set_date": true,
-  "dropper_target_path_win_32": "C:\\Windows\\temp\\monkey32.exe",
   "dropper_target_path_win_64": "C:\\Windows\\temp\\monkey64.exe",
   "dropper_target_path_linux": "/tmp/monkey",
 

--- a/monkey/infection_monkey/exploit/tools/helpers.py
+++ b/monkey/infection_monkey/exploit/tools/helpers.py
@@ -65,8 +65,6 @@ def get_monkey_dest_path(url_to_monkey):
     try:
         if "linux" in url_to_monkey:
             return WormConfiguration.dropper_target_path_linux
-        elif "windows-32" in url_to_monkey:
-            return WormConfiguration.dropper_target_path_win_32
         elif "windows-64" in url_to_monkey:
             return WormConfiguration.dropper_target_path_win_64
         else:

--- a/monkey/infection_monkey/exploit/web_rce.py
+++ b/monkey/infection_monkey/exploit/web_rce.py
@@ -34,7 +34,7 @@ class WebRCE(HostExploiter):
     def __init__(self, monkey_target_paths=None):
         """
         :param monkey_target_paths: Where to upload the monkey at the target host system.
-        Dict in format {'linux': '/tmp/monkey.sh', 'win32': './monkey32.exe', 'win64':... }
+        Dict in format {'linux': '/tmp/monkey.sh', 'win64':... }
         """
         super(WebRCE, self).__init__()
         self.monkey_target_paths = monkey_target_paths
@@ -410,7 +410,7 @@ class WebRCE(HostExploiter):
         """
         Gets destination path from one of WEB_RCE predetermined paths(self.monkey_target_paths).
         :param url_to_monkey: Hosted monkey's url. egz :
-        http://localserver:9999/monkey/windows-32.exe
+        http://localserver:9999/monkey/windows-64.exe
         :return: Corresponding monkey path from self.monkey_target_paths
         """
         if not url_to_monkey or ("linux" not in url_to_monkey and "windows" not in url_to_monkey):
@@ -421,9 +421,7 @@ class WebRCE(HostExploiter):
         try:
             if "linux" in url_to_monkey:
                 return self.monkey_target_paths["linux"]
-            elif "windows-32" in url_to_monkey:
-                return self.monkey_target_paths["win32"]
-            elif "windows-64" in url_to_monkey:
+            elif "windows" in url_to_monkey:
                 return self.monkey_target_paths["win64"]
             else:
                 logger.error(
@@ -433,7 +431,7 @@ class WebRCE(HostExploiter):
                 return False
         except KeyError:
             logger.error(
-                'Unknown key was found. Please use "linux", "win32" and "win64" keys to '
+                'Unknown key was found. Please use "linux" and "win64" keys to '
                 "initialize "
                 "custom dict of monkey's destination paths"
             )

--- a/monkey/infection_monkey/exploit/web_rce.py
+++ b/monkey/infection_monkey/exploit/web_rce.py
@@ -4,7 +4,6 @@ from posixpath import join
 from typing import List, Tuple
 
 from common.utils.attack_utils import BITS_UPLOAD_STRING, ScanStatus
-from infection_monkey.exploit.consts import WIN_ARCH_64
 from infection_monkey.exploit.HostExploiter import HostExploiter
 from infection_monkey.exploit.tools.helpers import get_monkey_depth, get_target_monkey
 from infection_monkey.exploit.tools.http_tools import HTTPTools
@@ -117,7 +116,6 @@ class WebRCE(HostExploiter):
         if not self.monkey_target_paths:
             self.monkey_target_paths = {
                 "linux": self.options["dropper_target_path_linux"],
-                "win32": self.options["dropper_target_path_win_32"],
                 "win64": self.options["dropper_target_path_win_64"],
             }
         self.HTTP = [str(port) for port in self.options["http_ports"]]
@@ -470,13 +468,7 @@ class WebRCE(HostExploiter):
         if self.host.os["type"] == "linux":
             return self.options["dropper_target_path_linux"]
         if self.host.os["type"] == "windows":
-            try:
-                # remove now or when 32-bit binaries are removed?
-                if self.host.os["machine"] == WIN_ARCH_64:
-                    return self.options["dropper_target_path_win_64"]
-            except KeyError:
-                logger.debug("Target's machine type was not set. Using win-32 dropper path.")
-        return self.options["dropper_target_path_win_32"]
+            return self.options["dropper_target_path_win_64"]
 
     def get_target_url(self):
         """

--- a/monkey/monkey_island/cc/services/config.py
+++ b/monkey/monkey_island/cc/services/config.py
@@ -606,7 +606,6 @@ class ConfigService:
 
         for dropper_target in [
             "dropper_target_path_linux",
-            "dropper_target_path_win_32",
             "dropper_target_path_win_64",
         ]:
             exploit_options[dropper_target] = config.get(dropper_target, "")

--- a/monkey/monkey_island/cc/services/config_schema/internal.py
+++ b/monkey/monkey_island/cc/services/config_schema/internal.py
@@ -174,14 +174,6 @@ INTERNAL = {
                     "description": "Determines where should the dropper place the monkey on a "
                     "Linux machine",
                 },
-                "dropper_target_path_win_32": {
-                    "title": "Dropper target path on Windows (32bit)",
-                    "type": "string",
-                    "default": "C:\\Windows\\temp\\monkey32.exe",
-                    "description": "Determines where should the dropper place the monkey on a "
-                    "Windows machine "
-                    "(32bit)",
-                },
                 "dropper_target_path_win_64": {
                     "title": "Dropper target path on Windows (64bit)",
                     "type": "string",

--- a/monkey/tests/data_for_tests/monkey_configs/flat_config.json
+++ b/monkey/tests/data_for_tests/monkey_configs/flat_config.json
@@ -27,7 +27,6 @@
     "dropper_log_path_windows": "%temp%\\~df1562.tmp",
     "dropper_set_date": true,
     "dropper_target_path_linux": "/tmp/monkey",
-    "dropper_target_path_win_32": "C:\\Windows\\temp\\monkey32.exe",
     "dropper_target_path_win_64": "C:\\Windows\\temp\\monkey64.exe",
     "exploit_lm_hash_list": ["lm_hash_1", "lm_hash_2"],
     "exploit_ntlm_hash_list": ["nt_hash_1", "nt_hash_2", "nt_hash_3"],

--- a/monkey/tests/data_for_tests/monkey_configs/monkey_config_standard.json
+++ b/monkey/tests/data_for_tests/monkey_configs/monkey_config_standard.json
@@ -104,7 +104,6 @@
         "dropper_date_reference_path_windows": "%windir%\\system32\\kernel32.dll",
         "dropper_date_reference_path_linux": "/bin/sh",
         "dropper_target_path_linux": "/tmp/monkey",
-        "dropper_target_path_win_32": "C:\\Windows\\temp\\monkey32.exe",
         "dropper_target_path_win_64": "C:\\Windows\\temp\\monkey64.exe"
       },
       "logging": {

--- a/monkey/tests/unit_tests/infection_monkey/exploit/test_powershell.py
+++ b/monkey/tests/unit_tests/infection_monkey/exploit/test_powershell.py
@@ -26,7 +26,6 @@ Config = namedtuple(
         "exploit_password_list",
         "exploit_lm_hash_list",
         "exploit_ntlm_hash_list",
-        "dropper_target_path_win_32",
         "dropper_target_path_win_64",
     ],
 )

--- a/monkey/tests/unit_tests/monkey_island/cc/services/test_config.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/test_config.py
@@ -173,7 +173,6 @@ def test_format_config_for_agent__exploiters(flat_monkey_config):
     expected_exploiters_config = {
         "options": {
             "dropper_target_path_linux": "/tmp/monkey",
-            "dropper_target_path_win_32": r"C:\Windows\temp\monkey32.exe",
             "dropper_target_path_win_64": r"C:\Windows\temp\monkey64.exe",
             "http_ports": [80, 443, 7001, 8008, 8080, 9200],
         },


### PR DESCRIPTION
# What does this PR do?

Removes dropper_target_path_win_32 from config. Related to #1675 .

Add any further explanations here.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] ~Is the TravisCI build passing?~
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working


![image](https://user-images.githubusercontent.com/15820737/155575111-ccdb2e35-f824-46b2-844a-935b0cb3067b.png)

## Explain Changes


