### PR TITLE
Island: Remove 32bit manual run options

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/RunManually/LocalManualRunOptions.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/RunManually/LocalManualRunOptions.js
@@ -20,9 +20,7 @@ const getContents = (props) => {
 
   const osTypes = {
     [OS_TYPES.WINDOWS_64]: 'Windows 64bit',
-    [OS_TYPES.WINDOWS_32]: 'Windows 32bit',
-    [OS_TYPES.LINUX_64]: 'Linux 64bit',
-    [OS_TYPES.LINUX_32]: 'Linux 32bit'
+    [OS_TYPES.LINUX_64]: 'Linux 64bit'
   }
 
   const [osType, setOsType] = useState(OS_TYPES.WINDOWS_64);
@@ -48,11 +46,11 @@ const getContents = (props) => {
   }
 
   function generateCommands() {
-    if (osType === OS_TYPES.WINDOWS_64 || osType === OS_TYPES.WINDOWS_32) {
-      return [{type: 'Powershell', command: GenerateLocalWindowsPowershell(selectedIp, osType, customUsername)}]
+    if (osType === OS_TYPES.WINDOWS_64) {
+      return [{type: 'Powershell', command: GenerateLocalWindowsPowershell(selectedIp, customUsername)}]
     } else {
-      return [{type: 'CURL', command: GenerateLocalLinuxCurl(selectedIp, osType, customUsername)},
-        {type: 'WGET', command: GenerateLocalLinuxWget(selectedIp, osType, customUsername)}]
+      return [{type: 'CURL', command: GenerateLocalLinuxCurl(selectedIp, customUsername)},
+        {type: 'WGET', command: GenerateLocalLinuxWget(selectedIp, customUsername)}]
     }
   }
 

--- a/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/RunOptions.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/RunOptions.js
@@ -5,7 +5,7 @@ import AuthComponent from '../../AuthComponent';
 import {faLaptopCode} from '@fortawesome/free-solid-svg-icons/faLaptopCode';
 import InlineSelection from '../../ui-components/inline-selection/InlineSelection';
 import {cloneDeep} from 'lodash';
-import {faCloud, faExpandArrowsAlt} from '@fortawesome/free-solid-svg-icons';
+import {faExpandArrowsAlt} from '@fortawesome/free-solid-svg-icons';
 import RunOnIslandButton from './RunOnIslandButton';
 import AWSRunButton from './RunOnAWS/AWSRunButton';
 

--- a/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/commands/local_linux_curl.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/commands/local_linux_curl.js
@@ -1,12 +1,8 @@
-import {OS_TYPES} from '../utils/OsTypes';
-
-
-export default function generateLocalLinuxCurl(ip, osType, username) {
-  let bitText = osType === OS_TYPES.LINUX_32 ? '32' : '64';
-  let command = `curl https://${ip}:5000/api/monkey/download/monkey-linux-${bitText} -k `
-    + `-o monkey-linux-${bitText}; `
-    + `chmod +x monkey-linux-${bitText}; `
-    + `./monkey-linux-${bitText} m0nk3y -s ${ip}:5000;`;
+export default function generateLocalLinuxCurl(ip, username) {
+  let command = `curl https://${ip}:5000/api/monkey/download/monkey-linux-64 -k `
+    + `-o monkey-linux-64; `
+    + `chmod +x monkey-linux-64; `
+    + `./monkey-linux-64 m0nk3y -s ${ip}:5000;`;
 
   if (username != '') {
     command = `su - ${username} -c "${command}"`;

--- a/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/commands/local_linux_wget.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/commands/local_linux_wget.js
@@ -1,12 +1,8 @@
-import {OS_TYPES} from '../utils/OsTypes';
-
-
-export default function generateLocalLinuxWget(ip, osType, username) {
-  let bitText = osType === OS_TYPES.LINUX_32 ? '32' : '64';
+export default function generateLocalLinuxWget(ip, username) {
   let command = `wget --no-check-certificate https://${ip}:5000/api/monkey/download/`
-    + `monkey-linux-${bitText}; `
-    + `chmod +x monkey-linux-${bitText}; `
-    + `./monkey-linux-${bitText} m0nk3y -s ${ip}:5000`;
+    + `monkey-linux-64; `
+    + `chmod +x monkey-linux-64; `
+    + `./monkey-linux-64 m0nk3y -s ${ip}:5000`;
 
   if (username != '') {
     command = `su - ${username} -c "${command}"`;

--- a/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/commands/local_windows_powershell.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/commands/local_windows_powershell.js
@@ -1,18 +1,14 @@
-import {OS_TYPES} from '../utils/OsTypes';
-
-
-function getAgentDownloadCommand(ip, osType) {
-  let bitText = osType === OS_TYPES.WINDOWS_32 ? '32' : '64';
+function getAgentDownloadCommand(ip) {
   return `$execCmd = @"\r\n`
     + `[System.Net.ServicePointManager]::ServerCertificateValidationCallback = {\`$true};`
-    + `(New-Object System.Net.WebClient).DownloadFile('https://${ip}:5000/api/monkey/download/monkey-windows-${bitText}.exe',`
+    + `(New-Object System.Net.WebClient).DownloadFile('https://${ip}:5000/api/monkey/download/monkey-windows-64.exe',`
     + `"""$env:TEMP\\monkey.exe""");Start-Process -FilePath '$env:TEMP\\monkey.exe' -ArgumentList 'm0nk3y -s ${ip}:5000';`
     + `\r\n"@; \r\n`
     + `Start-Process -FilePath powershell.exe -ArgumentList $execCmd`;
 }
 
-export default function generateLocalWindowsPowershell(ip, osType, username) {
-  let command = getAgentDownloadCommand(ip, osType)
+export default function generateLocalWindowsPowershell(ip, username) {
+  let command = getAgentDownloadCommand(ip)
   if (username !== '') {
     command += ` -Credential ${username}`;
   }

--- a/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/utils/OsTypes.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/utils/OsTypes.js
@@ -1,6 +1,4 @@
 export const OS_TYPES = {
-  WINDOWS_32: 'win32',
   WINDOWS_64: 'win64',
-  LINUX_32: 'linux32',
   LINUX_64: 'linux64'
 }

--- a/monkey/monkey_island/cc/ui/src/components/report-components/security/PostBreachParser.js
+++ b/monkey/monkey_island/cc/ui/src/components/report-components/security/PostBreachParser.js
@@ -46,7 +46,7 @@ function aggregateMultipleResultsPba(results) {
   }
 
   function modifyProcessListCollectionResult(result) {
-    result[0] = "Found " + Object.keys(result[0]).length.toString() + " running processes";
+    result[0] = 'Found ' + Object.keys(result[0]).length.toString() + ' running processes';
   }
 
   // check for pbas with multiple results and aggregate their results


### PR DESCRIPTION
# What does this PR do?

Remove 32bit manual run options. Related #1675 .

Add any further explanations here.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] ~Is the TravisCI build passing?~
* [x] ~Was the CHANGELOG.md updated to reflect the changes?~
* [x] ~Was the documentation framework updated to reflect the changes?~

## Testing Checklist

* [x] ~Added relevant unit tests?~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [x] If applicable, add screenshots or log transcripts of the feature working

![image](https://user-images.githubusercontent.com/15820737/155709922-a0fcd53d-cd4d-41d2-8a01-9cc67ca9925f.png)


## Explain Changes

Are the commit messages enough? If not, elaborate.
