### PR TITLE
Agent, Island: send network information in monkey wakeup telemetry

### DIFF
--- a/monkey/infection_monkey/control.py
+++ b/monkey/infection_monkey/control.py
@@ -13,7 +13,7 @@ import infection_monkey.tunnel as tunnel
 from common.common_consts.api_url_consts import T1216_PBA_FILE_DOWNLOAD_PATH
 from common.common_consts.timeouts import LONG_REQUEST_TIMEOUT, MEDIUM_REQUEST_TIMEOUT
 from infection_monkey.config import GUID, WormConfiguration
-from infection_monkey.network.info import local_ips
+from infection_monkey.network.info import get_host_subnets, local_ips
 from infection_monkey.transport.http import HTTPConnectProxy
 from infection_monkey.transport.tcp import TcpProxy
 from infection_monkey.utils import agent_process
@@ -48,6 +48,7 @@ class ControlClient(object):
             "guid": GUID,
             "hostname": hostname,
             "ip_addresses": local_ips(),
+            "networks": get_host_subnets(),
             "description": " ".join(platform.uname()),
             "config": WormConfiguration.as_dict(),
             "parent": parent,

--- a/monkey/monkey_island/cc/models/monkey.py
+++ b/monkey/monkey_island/cc/models/monkey.py
@@ -42,6 +42,7 @@ class Monkey(Document):
     description = StringField()
     hostname = StringField()
     ip_addresses = ListField(StringField())
+    networks = ListField()
     launch_time = FloatField()
     keepalive = DateTimeField()
     modifytime = DateTimeField()

--- a/monkey/monkey_island/cc/services/reporting/report.py
+++ b/monkey/monkey_island/cc/services/reporting/report.py
@@ -160,16 +160,11 @@ class ReportService:
 
     @staticmethod
     def get_monkey_subnets(monkey_guid):
-        network_info = mongo.db.telemetry.find_one(
-            {"telem_category": "system_info", "monkey_guid": monkey_guid},
-            {"data.network_info.networks": 1},
-        )
-        if network_info is None or not network_info["data"]:
-            return []
+        networks = Monkey.objects.get(guid=monkey_guid).networks
 
         return [
-            ipaddress.ip_interface(str(network["addr"] + "/" + network["netmask"])).network
-            for network in network_info["data"]["network_info"]["networks"]
+            ipaddress.ip_interface(f"{network['addr']}/{network['netmask']}").network
+            for network in networks
         ]
 
     @staticmethod


### PR DESCRIPTION
Network information is required for segmentation reports, that's why it gets sent in the wakeup telemetry. It could be joined with "ip_addresses", but that would require a bigger refactoring on the island side

# What does this PR do?

Fixes part of #1695 

Add any further explanations here.

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Have you successfully tested your changes locally? Elaborate:
    > Tested by running unit tests, monkey
