### PR TITLE
Agent log timestamp ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
 - The process list collection system info collector to now be a post-breach action. #1697
 - The "/api/monkey/download" endpoint to accept an OS and return a file. #1675
 - Log messages to contain human-readable thread names. #1766
-- The log file name to `infection-monkey-agent-<random_string>-<timestamp>.log`. #1761
+- The log file name to `infection-monkey-agent-<TIMESTAMP>-<RANDOM_STRING>.log`. #1761
 
 ### Removed
 - VSFTPD exploiter. #1533

--- a/docs/content/FAQ/_index.md
+++ b/docs/content/FAQ/_index.md
@@ -192,7 +192,7 @@ of directories to find an appropriate place to store the log:
    - On all other platforms, the directories `/tmp`, `/var/tmp`, and `/usr/tmp`, in that order.
 5. As a last resort, the current working directory.
 
-Infection Monkey log file name is constructed to the following pattern: `infection-monkey-agent-<random_string>-<timestamp>.log`
+Infection Monkey log file name is constructed to the following pattern: `infection-monkey-agent-<TIMESTAMP>-<RANDOM_STRING>.log`
 
 The logs contain information about the internals of the Infection Monkey agent's execution. The log will contain entries like these:
 
@@ -217,8 +217,8 @@ The logs contain information about the internals of the Infection Monkey agent's
 The Infection Monkey leaves hardly any trace on the target system. It will leave:
 
 - Log files in [temporary directories]({{< ref "/faq/#infection-monkey-agent-logs">}}):
-  - Path on Linux: `/tmp/infection-monky-agent-<random_string>-<timestamp>.log`
-  - Path on Windows: `%temp%\\infection-monky-agent-<random_string>-<timestamp>.log`
+  - Path on Linux: `/tmp/infection-monky-agent-<TIMESTAMP>-<RANDOM_STRING>.log`
+  - Path on Windows: `%temp%\\infection-monky-agent-<TIMESTAMP>-<RANDOM_STRING>.log`
 
 ### What's the Infection Monkey Agent's impact on system resources usage?
 

--- a/monkey/infection_monkey/utils/monkey_log_path.py
+++ b/monkey/infection_monkey/utils/monkey_log_path.py
@@ -7,8 +7,9 @@ from pathlib import Path
 # Cache the result of the call so that subsequent calls always return the same result
 @lru_cache(maxsize=None)
 def _get_log_path(monkey_arg: str) -> Path:
-    prefix = f"infection-monkey-{monkey_arg}-"
-    suffix = f"-{time.strftime('%Y-%m-%d-%H-%M-%S', time.gmtime())}.log"
+    timestamp = time.strftime("%Y-%m-%d-%H-%M-%S", time.gmtime())
+    prefix = f"infection-monkey-{monkey_arg}-{timestamp}-"
+    suffix = ".log"
 
     _, monkey_log_path = tempfile.mkstemp(suffix=suffix, prefix=prefix)
 


### PR DESCRIPTION
# What does this PR do?

Reorders the components of the agent log so that the timestamp comes before the random component. This allows agent logs to be sorted by timestamp more easily.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] ~Is the TravisCI build passing?~
* [x] Was the CHANGELOG.md updated to reflect the changes?
* [x] Was the documentation framework updated to reflect the changes?

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by building agent binaries and running SMB exploiter
* [ ] ~If applicable, add screenshots or log transcripts of the feature working~
