### PR TITLE
Agent: Only start/stop tunnel if the agent is able to propagate

### DIFF
--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -154,7 +154,7 @@ class InfectionMonkey:
             firewall.add_firewall_rule()
 
         self._monkey_inbound_tunnel = ControlClient.create_control_tunnel()
-        if self._monkey_inbound_tunnel:
+        if self._monkey_inbound_tunnel and self._propagation_enabled():
             self._monkey_inbound_tunnel.start()
 
         StateTelem(is_done=False, version=get_version()).send()
@@ -265,7 +265,7 @@ class InfectionMonkey:
 
             reset_signal_handlers()
 
-            if self._monkey_inbound_tunnel:
+            if self._monkey_inbound_tunnel and self._propagation_enabled():
                 self._monkey_inbound_tunnel.stop()
                 self._monkey_inbound_tunnel.join()
 
@@ -290,6 +290,12 @@ class InfectionMonkey:
             InfectionMonkey._self_delete()
 
         logger.info("Monkey is shutting down")
+
+    def _propagation_enabled(self) -> bool:
+        # If self._current_depth is None, assume that propagation is desired.
+        # The Master will ignore this value if it is None and pull the actual
+        # maximum depth from the server
+        return self._current_depth is None or self._current_depth > 0
 
     @staticmethod
     def _close_tunnel():


### PR DESCRIPTION
# What does this PR do?

Prevent the agent from opening/closing a tunnel if `depth < 1`. Since agents with `depth < 1` will not propagate, there's no need for them to open a tunnel. This greatly speeds up testing since agents that don't open a tunnel don't need to wait for the tunnel to close before exiting (60 seconds by default).

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] ~Is the TravisCI build passing?~
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running from source
    > Tested by building binaries and running
* [ ] ~If applicable, add screenshots or log transcripts of the feature working~


## Screenshots

The below GIF shows the map during the entire run. It's a little slow to get started. You'll notice that the victims are only displayed as green for a very short period. This is because they don't have to start/stop tunnels.
![test](https://user-images.githubusercontent.com/19957806/159193688-0f55bdba-fe3a-42d4-8109-3318e110449f.gif)

