### PR TITLE
Agent: Handle pypykatz permission error

### DIFF
--- a/monkey/infection_monkey/credential_collectors/mimikatz_collector/pypykatz_handler.py
+++ b/monkey/infection_monkey/credential_collectors/mimikatz_collector/pypykatz_handler.py
@@ -29,7 +29,11 @@ def get_windows_creds() -> List[WindowsCredentials]:
         logger.debug("Skipping pypykatz because the operating system is not Windows")
         return []
 
-    pypy_handle = pypykatz.go_live()
+    try:
+        pypy_handle = pypykatz.go_live()
+    except Exception as err:
+        logger.info(f"Credential gathering with pypykatz failed: {err}")
+        return []
     logon_data = pypy_handle.to_dict()
     windows_creds = _parse_pypykatz_results(logon_data)
     return windows_creds


### PR DESCRIPTION
# What does this PR do?

Fixes unhandled pypykatz error when agent doesn't have enough privileges to steal windows credentials

