### PR TITLE
Agent: Half the default smb timeout to 30sec

### DIFF
--- a/monkey/infection_monkey/exploit/tools/smb_tools.py
+++ b/monkey/infection_monkey/exploit/tools/smb_tools.py
@@ -27,9 +27,8 @@ class SmbTools(object):
         password,
         lm_hash="",
         ntlm_hash="",
-        timeout=60,
+        timeout=30,
     ) -> Optional[str]:
-        # TODO assess the 60 second timeout
         creds_for_log = get_credential_string([username, password, lm_hash, ntlm_hash])
         logger.debug(f"Attempting to copy an agent binary to {host} using SMB with {creds_for_log}")
 
@@ -188,7 +187,7 @@ class SmbTools(object):
         return remote_full_path
 
     @staticmethod
-    def new_smb_connection(host, username, password, lm_hash="", ntlm_hash="", timeout=60):
+    def new_smb_connection(host, username, password, lm_hash="", ntlm_hash="", timeout=30):
         try:
             smb = SMBConnection(host.ip_addr, host.ip_addr, sess_port=445)
         except Exception as exc:


### PR DESCRIPTION
# What does this PR do?

Fixes smb_tools todo, related to #1613 .

Times on copying the agent both in SMB and WMI are not over 0.7s each.
This timeout uses `smb_download_timeout` option which has default value of 30s, which is a safe and more then enough value for transferring the agent.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing?

## Testing Checklist

* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running WMI and SMB BB tests

## Explain Changes

Are the commit messages enough? If not, elaborate.
