### PR TITLE
Deploy: AppImage build flag --unit to create sysd service that runs on boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - credentials.json file for storing Monkey Island user login information. #1206
 - The ability to download the Monkey Island logs from the Infection Map page. #1640
+- AppImage build flag `--unit` to create systemd service that runs on boot. #1552
 
 ### Changed
 - "Communicate as Backdoor User" PBA's HTTP requests to request headers only and

--- a/build_scripts/appimage/clean.sh
+++ b/build_scripts/appimage/clean.sh
@@ -4,9 +4,18 @@
 # in order to speed up development and debugging.
 
 APPIMAGE_DIR="$(realpath $(dirname $BASH_SOURCE[0]))"
+SYSTEMD_UNIT_FILENAME="monkey.service"
+SYSTEMD_DIR="/lib/systemd/system"
 
 rm -rf "$HOME/git/monkey"
 rm -rf "$HOME/.monkey_island"
 rm -rf "$APPIMAGE_DIR/squashfs-root"
 rm "$APPIMAGE_DIR"/Infection_Monkey*.AppImage
 rm "$APPIMAGE_DIR/../dist/InfectionMonkey*.AppImage"
+
+if [ -f "${SYSTEMD_DIR}/${SYSTEMD_UNIT_FILENAME}" ] ; then
+  sudo systemctl stop "${SYSTEMD_UNIT_FILENAME}" 2>/dev/null
+  sudo systemctl disable "${SYSTEMD_UNIT_FILENAME}"
+  sudo rm "${SYSTEMD_DIR}/${SYSTEMD_UNIT_FILENAME}"
+  sudo systemctl daemon-reload
+fi

--- a/build_scripts/appimage/monkey.service.template
+++ b/build_scripts/appimage/monkey.service.template
@@ -1,0 +1,11 @@
+[Unit]
+Description=Infection Monkey AppImage Runner
+After=network.target
+
+[Service]
+User={PLACEHOLDER_UNAME}
+Type=simple
+ExecStart={PLACEHOLDER_APPIMAGE_PATH}
+
+[Install]
+WantedBy=multi-user.target

--- a/build_scripts/build_package.sh
+++ b/build_scripts/build_package.sh
@@ -49,6 +49,8 @@ echo_help() {
   echo "                               (Default: develop)"
   echo ""
   echo "--package                      Which package to build (\"appimage\" or \"docker.\")"
+  echo "--unit                         Create an AppImage systemd service that will run on boot."
+  echo "                               If used with docker package, it will have no effect."
 
   exit 0
 }
@@ -107,6 +109,7 @@ install_build_prereqs() {
 
 agent_binary_dir=""
 as_root=false
+create_unit=false
 branch="develop"
 monkey_repo="$DEFAULT_REPO_MONKEY_HOME"
 monkey_version=""
@@ -123,6 +126,10 @@ while (( "$#" )); do
       ;;
     --as-root)
       as_root=true
+      shift
+      ;;
+    --unit)
+      create_unit=true
       shift
       ;;
     --branch)
@@ -199,7 +206,7 @@ install_package_specific_build_prereqs "$WORKSPACE"
 
 setup_build_dir "$agent_binary_dir" "$monkey_repo" "$deployment_type"
 commit_id=$(get_commit_id "$monkey_repo")
-build_package "$monkey_version" "$commit_id" "$DIST_DIR"
+build_package "$monkey_version" "$commit_id" "$DIST_DIR" "$create_unit"
 
 log_message "Finished building package: $package"
 exit 0


### PR DESCRIPTION
Fixes #1552 

Adds AppImage build flag `--unit` that creates a systemd service which runs on boot as the same user that executed the build script.

Tested locally:
![1](https://user-images.githubusercontent.com/35046248/161817368-733ac634-4a8f-41fa-b3a2-97f980ee55ad.PNG)
![2](https://user-images.githubusercontent.com/35046248/161817341-b92b2b9b-c0f7-40a1-8168-ad3f8be24255.PNG)
![3](https://user-images.githubusercontent.com/35046248/161817344-7a0fe6d8-6735-4681-9e75-8c408e8bb954.PNG)
![4](https://user-images.githubusercontent.com/35046248/161817348-185599e8-a8da-4c27-abfe-f8f3f45aa6e2.PNG)
![5](https://user-images.githubusercontent.com/35046248/161817349-fb1004c0-9493-496c-b67c-5485e2e2069a.PNG)

 