### PR TITLE
Bugfix for 2 edges being created

### DIFF
--- a/monkey/monkey_island/cc/services/edge/edge.py
+++ b/monkey/monkey_island/cc/services/edge/edge.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import threading
 from typing import Dict, List
 
 from bson import ObjectId
@@ -10,6 +11,8 @@ from monkey_island.cc.models.edge import Edge
 
 RIGHT_ARROW = "\u2192"
 
+lock = threading.Lock()
+
 
 class EdgeService(Edge):
     @staticmethod
@@ -18,6 +21,7 @@ class EdgeService(Edge):
 
     @staticmethod
     def get_or_create_edge(src_node_id, dst_node_id, src_label, dst_label) -> EdgeService:
+        lock.acquire()
         edge = None
         try:
             edge = EdgeService.objects.get(src_node_id=src_node_id, dst_node_id=dst_node_id)
@@ -27,6 +31,7 @@ class EdgeService(Edge):
             if edge:
                 edge.update_label(node_id=src_node_id, label=src_label)
                 edge.update_label(node_id=dst_node_id, label=dst_label)
+        lock.release()
         return edge
 
     @staticmethod

--- a/monkey/monkey_island/cc/services/edge/edge.py
+++ b/monkey/monkey_island/cc/services/edge/edge.py
@@ -21,18 +21,17 @@ class EdgeService(Edge):
 
     @staticmethod
     def get_or_create_edge(src_node_id, dst_node_id, src_label, dst_label) -> EdgeService:
-        lock.acquire()
-        edge = None
-        try:
-            edge = EdgeService.objects.get(src_node_id=src_node_id, dst_node_id=dst_node_id)
-        except DoesNotExist:
-            edge = EdgeService(src_node_id=src_node_id, dst_node_id=dst_node_id)
-        finally:
-            if edge:
-                edge.update_label(node_id=src_node_id, label=src_label)
-                edge.update_label(node_id=dst_node_id, label=dst_label)
-        lock.release()
-        return edge
+        with lock:
+            edge = None
+            try:
+                edge = EdgeService.objects.get(src_node_id=src_node_id, dst_node_id=dst_node_id)
+            except DoesNotExist:
+                edge = EdgeService(src_node_id=src_node_id, dst_node_id=dst_node_id)
+            finally:
+                if edge:
+                    edge.update_label(node_id=src_node_id, label=src_label)
+                    edge.update_label(node_id=dst_node_id, label=dst_label)
+            return edge
 
     @staticmethod
     def get_by_dst_node(dst_node_id: ObjectId) -> List[EdgeService]:


### PR DESCRIPTION
# What does this PR do?

Fixes #1917 

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing?
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running the Agent and Island as described in the issue.
* [x] If applicable, add screenshots or log transcripts of the feature working

![image](https://user-images.githubusercontent.com/44770317/166886628-e0d9b3b8-cac9-4a2a-8b3c-fed1c9dbfdea.png)


## Explain Changes

Scanning and exploiting happen in parallel and the telemetries for both were being sent too close to each other which was causing a race condition during edge creation.
When `get_or_create_edge()` in `EdgeService` is called the first time, it has to _create_ an edge, but before that is done, it gets called a second time. It can't _get_ the edge the second time either since an edge hasn't been created yet from the first time it was called. So it decides that it needs to _create_ an edge the second time as well and two edges end up being created.