### PR TITLE
1996 agent worm config decouple

### DIFF
--- a/monkey/infection_monkey/config.py
+++ b/monkey/infection_monkey/config.py
@@ -8,7 +8,7 @@ SENSITIVE_FIELDS = [
     "exploit_user_list",
     "exploit_ssh_keys",
 ]
-LOCAL_CONFIG_VARS = ["name", "id", "current_server", "max_depth"]
+LOCAL_CONFIG_VARS = ["name", "id", "max_depth"]
 HIDDEN_FIELD_REPLACEMENT_CONTENT = "hidden"
 
 
@@ -62,10 +62,6 @@ class Configuration(object):
     # depth of propagation
     depth = 2
     max_depth = None
-    current_server = ""
-
-    # Configuration servers to try to connect to, in this order.
-    command_servers = []
 
     keep_tunnel_open_time = 30
 

--- a/monkey/infection_monkey/control.py
+++ b/monkey/infection_monkey/control.py
@@ -27,7 +27,7 @@ PBA_FILE_DOWNLOAD = "https://%s/api/pba/download/%s"
 class ControlClient:
     # TODO When we have mechanism that support telemetry messenger
     # with control clients, then this needs to be removed
-    # Ref: infection_monkey.telemetry.base_telem.py
+    # https://github.com/guardicore/monkey/blob/133f7f5da131b481561141171827d1f9943f6aec/monkey/infection_monkey/telemetry/base_telem.py
     control_client_object = None
 
     def __init__(self, server_address: str, proxies: Optional[Mapping[str, str]] = None):

--- a/monkey/infection_monkey/control.py
+++ b/monkey/infection_monkey/control.py
@@ -25,6 +25,11 @@ PBA_FILE_DOWNLOAD = "https://%s/api/pba/download/%s"
 
 
 class ControlClient:
+    # TODO Every telemetry should have its own control client
+    # for the moment that is a big refactor.
+    # Ref: infection_monkey.telemetry.base_telem.py
+    control_client_object = None
+
     def __init__(self, server_address: str, proxies: Optional[Mapping[str, str]] = None):
         self.proxies = {} if not proxies else proxies
         self.server_address = server_address

--- a/monkey/infection_monkey/control.py
+++ b/monkey/infection_monkey/control.py
@@ -25,8 +25,8 @@ PBA_FILE_DOWNLOAD = "https://%s/api/pba/download/%s"
 
 
 class ControlClient:
-    # TODO Every telemetry should have its own control client
-    # for the moment that is a big refactor.
+    # TODO When we have mechanism that support telemetry messenger
+    # with control clients, then this needs to be removed
     # Ref: infection_monkey.telemetry.base_telem.py
     control_client_object = None
 

--- a/monkey/infection_monkey/master/control_channel.py
+++ b/monkey/infection_monkey/master/control_channel.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from typing import Mapping
 
 import requests
 
@@ -14,9 +15,10 @@ logger = logging.getLogger(__name__)
 
 
 class ControlChannel(IControlChannel):
-    def __init__(self, server: str, agent_id: str):
+    def __init__(self, server: str, agent_id: str, proxies: Mapping[str, str]):
         self._agent_id = agent_id
         self._control_channel_server = server
+        self._proxies = proxies
 
     def should_agent_stop(self) -> bool:
         if not self._control_channel_server:
@@ -30,7 +32,7 @@ class ControlChannel(IControlChannel):
             response = requests.get(  # noqa: DUO123
                 url,
                 verify=False,
-                proxies=ControlClient.proxies,
+                proxies=self._proxies,
                 timeout=SHORT_REQUEST_TIMEOUT,
             )
             response.raise_for_status()
@@ -51,7 +53,7 @@ class ControlChannel(IControlChannel):
             response = requests.get(  # noqa: DUO123
                 f"https://{self._control_channel_server}/api/agent",
                 verify=False,
-                proxies=ControlClient.proxies,
+                proxies=self._proxies,
                 timeout=SHORT_REQUEST_TIMEOUT,
             )
             response.raise_for_status()
@@ -74,7 +76,7 @@ class ControlChannel(IControlChannel):
             response = requests.get(  # noqa: DUO123
                 propagation_credentials_url,
                 verify=False,
-                proxies=ControlClient.proxies,
+                proxies=self._proxies,
                 timeout=SHORT_REQUEST_TIMEOUT,
             )
             response.raise_for_status()

--- a/monkey/infection_monkey/master/control_channel.py
+++ b/monkey/infection_monkey/master/control_channel.py
@@ -5,7 +5,6 @@ from typing import Mapping
 import requests
 
 from common.common_consts.timeouts import SHORT_REQUEST_TIMEOUT
-from infection_monkey.control import ControlClient
 from infection_monkey.custom_types import PropagationCredentials
 from infection_monkey.i_control_channel import IControlChannel, IslandCommunicationError
 

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -144,11 +144,9 @@ class InfectionMonkey:
     def _connect_to_island(self):
         # Sets island's IP and port for monkey to communicate to
         if self._current_server_is_set():
-            logger.debug("Default server set to: %s" % self._control_client.server_address)
+            logger.debug(f"Default server set to: {self._control_client.server_address}")
         else:
-            raise Exception(
-                "Monkey couldn't find server with {} default tunnel.".format(self._opts.tunnel)
-            )
+            raise Exception(f"Monkey couldn't find server with {self._opts.tunnel} default tunnel.")
 
         self._control_client.wakeup(parent=self._opts.parent)
         self._control_client.load_control_config()

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -10,8 +10,8 @@ import infection_monkey.tunnel as tunnel
 from common.network.network_utils import address_to_ip_port
 from common.utils.attack_utils import ScanStatus, UsageEnum
 from common.version import get_version
-from infection_monkey.config import GUID, WormConfiguration
 from infection_monkey.control import ControlClient
+from infection_monkey.config import GUID
 from infection_monkey.credential_collectors import (
     MimikatzCredentialCollector,
     SSHCredentialCollector,
@@ -131,7 +131,7 @@ class InfectionMonkey:
         run_aws_environment_check(self._telemetry_messenger)
 
         should_stop = ControlChannel(
-            WormConfiguration.current_server, GUID, self.cc_client.proxies
+            self.cc_client.server_address, GUID, self.cc_client.proxies
         ).should_agent_stop()
         if should_stop:
             logger.info("The Monkey Island has instructed this agent to stop")

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -185,7 +185,6 @@ class InfectionMonkey:
         control_channel = ControlChannel(
             self._control_client.server_address, GUID, self._control_client.proxies
         )
-        control_client = self._control_client
         credentials_store = AggregatingCredentialsStore(control_channel)
 
         puppet = self._build_puppet(credentials_store)
@@ -207,7 +206,6 @@ class InfectionMonkey:
             control_channel,
             local_network_interfaces,
             credentials_store,
-            control_client,
         )
 
     @staticmethod

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -128,7 +128,9 @@ class InfectionMonkey:
 
         run_aws_environment_check(self._telemetry_messenger)
 
-        should_stop = ControlChannel(WormConfiguration.current_server, GUID).should_agent_stop()
+        should_stop = ControlChannel(
+            WormConfiguration.current_server, GUID, self.cc_client.proxies
+        ).should_agent_stop()
         if should_stop:
             logger.info("The Monkey Island has instructed this agent to stop")
             return
@@ -177,7 +179,9 @@ class InfectionMonkey:
         local_network_interfaces = InfectionMonkey._get_local_network_interfaces()
 
         # TODO control_channel and control_client have same responsibilities, merge them
-        control_channel = ControlChannel(self.cc_client.server_address, GUID)
+        control_channel = ControlChannel(
+            self.cc_client.server_address, GUID, self.cc_client.proxies
+        )
         control_client = self.cc_client
         credentials_store = AggregatingCredentialsStore(control_channel)
 

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -90,6 +90,8 @@ class InfectionMonkey:
         self._opts = self._get_arguments(args)
         self._cmd_island_ip, self._cmd_island_port = address_to_ip_port(self._opts.server)
         self.cc_client = ControlClient(self._opts.server)
+        # TODO Refactor the BaseTelem to have its own control client
+        ControlClient.control_client_object = self.cc_client
         self._monkey_inbound_tunnel = None
         self._telemetry_messenger = LegacyTelemetryMessengerAdapter()
         self._current_depth = self._opts.depth

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -167,7 +167,7 @@ class InfectionMonkey:
             self._monkey_inbound_tunnel.start()
 
         StateTelem(is_done=False, version=get_version()).send()
-        TunnelTelem().send()
+        TunnelTelem(self.cc_client.proxies).send()
 
         self._build_master()
 

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -10,8 +10,8 @@ import infection_monkey.tunnel as tunnel
 from common.network.network_utils import address_to_ip_port
 from common.utils.attack_utils import ScanStatus, UsageEnum
 from common.version import get_version
-from infection_monkey.control import ControlClient
 from infection_monkey.config import GUID
+from infection_monkey.control import ControlClient
 from infection_monkey.credential_collectors import (
     MimikatzCredentialCollector,
     SSHCredentialCollector,
@@ -90,7 +90,8 @@ class InfectionMonkey:
         self._opts = self._get_arguments(args)
         self._cmd_island_ip, self._cmd_island_port = address_to_ip_port(self._opts.server)
         self._control_client = ControlClient(self._opts.server)
-        # TODO Refactor the BaseTelem to have its own control client
+        # TODO Refactor the telemetry messengers to accept control client
+        # and remove control_client_object
         ControlClient.control_client_object = self._control_client
         self._monkey_inbound_tunnel = None
         self._telemetry_messenger = LegacyTelemetryMessengerAdapter()

--- a/monkey/infection_monkey/post_breach/custom_pba/custom_pba.py
+++ b/monkey/infection_monkey/post_breach/custom_pba/custom_pba.py
@@ -25,12 +25,12 @@ class CustomPBA(PBA):
     Defines user's configured post breach action.
     """
 
-    def __init__(self, telemetry_messenger: ITelemetryMessenger, cc_client: ControlClient):
+    def __init__(self, telemetry_messenger: ITelemetryMessenger, control_client: ControlClient):
         super(CustomPBA, self).__init__(
             telemetry_messenger, POST_BREACH_FILE_EXECUTION, timeout=None
         )
         self.filename = ""
-        self.cc_client = cc_client
+        self.control_client = control_client
 
     def run(self, options: Dict) -> Iterable[PostBreachData]:
         self._set_options(options)
@@ -73,7 +73,7 @@ class CustomPBA(PBA):
         :return: True if successful, false otherwise
         """
 
-        pba_file_contents = self.cc_client.get_pba_file(filename)
+        pba_file_contents = self.control_client.get_pba_file(filename)
 
         status = None
         if not pba_file_contents or not pba_file_contents.content:
@@ -86,8 +86,8 @@ class CustomPBA(PBA):
         self.telemetry_messenger.send_telemetry(
             T1105Telem(
                 status,
-                self.cc_client.server_address.split(":")[0],
-                get_interface_to_target(self.cc_client.server_address.split(":")[0]),
+                self.control_client.server_address.split(":")[0],
+                get_interface_to_target(self.control_client.server_address.split(":")[0]),
                 filename,
             )
         )

--- a/monkey/infection_monkey/post_breach/custom_pba/custom_pba.py
+++ b/monkey/infection_monkey/post_breach/custom_pba/custom_pba.py
@@ -37,9 +37,6 @@ class CustomPBA(PBA):
         return super().run(options)
 
     def _set_options(self, options: Dict):
-        # Required for attack telemetry
-        self.current_server = options["current_server"]
-
         if is_windows_os():
             # Add windows commands to PBA's
             if options["windows_filename"]:
@@ -89,8 +86,8 @@ class CustomPBA(PBA):
         self.telemetry_messenger.send_telemetry(
             T1105Telem(
                 status,
-                self.current_server.split(":")[0],
-                get_interface_to_target(self.current_server.split(":")[0]),
+                self.cc_client.server_address.split(":")[0],
+                get_interface_to_target(self.cc_client.server_address.split(":")[0]),
                 filename,
             )
         )

--- a/monkey/infection_monkey/post_breach/custom_pba/custom_pba.py
+++ b/monkey/infection_monkey/post_breach/custom_pba/custom_pba.py
@@ -25,11 +25,12 @@ class CustomPBA(PBA):
     Defines user's configured post breach action.
     """
 
-    def __init__(self, telemetry_messenger: ITelemetryMessenger):
+    def __init__(self, telemetry_messenger: ITelemetryMessenger, cc_client: ControlClient):
         super(CustomPBA, self).__init__(
             telemetry_messenger, POST_BREACH_FILE_EXECUTION, timeout=None
         )
         self.filename = ""
+        self.cc_client = cc_client
 
     def run(self, options: Dict) -> Iterable[PostBreachData]:
         self._set_options(options)
@@ -75,7 +76,7 @@ class CustomPBA(PBA):
         :return: True if successful, false otherwise
         """
 
-        pba_file_contents = ControlClient.get_pba_file(filename)
+        pba_file_contents = self.cc_client.get_pba_file(filename)
 
         status = None
         if not pba_file_contents or not pba_file_contents.content:

--- a/monkey/infection_monkey/telemetry/base_telem.py
+++ b/monkey/infection_monkey/telemetry/base_telem.py
@@ -35,7 +35,7 @@ class BaseTelem(ITelem, metaclass=abc.ABCMeta):
         data = self.get_data()
         serialized_data = json.dumps(data, cls=self.json_encoder)
         self._log_telem_sending(serialized_data, log_data)
-        ControlClient.send_telemetry(self.telem_category, serialized_data)
+        ControlClient.control_client_object.send_telemetry(self.telem_category, serialized_data)
 
     @property
     def json_encoder(self):

--- a/monkey/infection_monkey/telemetry/tunnel_telem.py
+++ b/monkey/infection_monkey/telemetry/tunnel_telem.py
@@ -1,15 +1,16 @@
+from typing import Mapping
+
 from common.common_consts.telem_categories import TelemCategoryEnum
-from infection_monkey.control import ControlClient
 from infection_monkey.telemetry.base_telem import BaseTelem
 
 
 class TunnelTelem(BaseTelem):
-    def __init__(self):
+    def __init__(self, proxy: Mapping[str, str]):
         """
         Default tunnel telemetry constructor
         """
         super(TunnelTelem, self).__init__()
-        self.proxy = ControlClient.proxies.get("https")
+        self.proxy = proxy.get("https")
 
     telem_category = TelemCategoryEnum.TUNNEL
 

--- a/monkey/tests/unit_tests/infection_monkey/post_breach/actions/test_users_custom_pba.py
+++ b/monkey/tests/unit_tests/infection_monkey/post_breach/actions/test_users_custom_pba.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from infection_monkey.control import ControlClient
 from infection_monkey.post_breach.custom_pba.custom_pba import CustomPBA
 
 MONKEY_DIR_PATH = "/dir/to/monkey/"
@@ -48,8 +49,15 @@ def fake_custom_pba_linux_options():
     }
 
 
-def test_command_linux_custom_file_and_cmd(fake_custom_pba_linux_options, set_os_linux):
-    pba = CustomPBA(MagicMock())
+@pytest.fixture
+def control_client():
+    return ControlClient(CUSTOM_SERVER)
+
+
+def test_command_linux_custom_file_and_cmd(
+    fake_custom_pba_linux_options, set_os_linux, control_client
+):
+    pba = CustomPBA(MagicMock(), control_client)
     pba._set_options(fake_custom_pba_linux_options)
     expected_command = f"cd {MONKEY_DIR_PATH} ; {CUSTOM_LINUX_CMD}"
     assert pba.command == expected_command
@@ -68,9 +76,11 @@ def fake_custom_pba_windows_options():
     }
 
 
-def test_command_windows_custom_file_and_cmd(fake_custom_pba_windows_options, set_os_windows):
+def test_command_windows_custom_file_and_cmd(
+    fake_custom_pba_windows_options, set_os_windows, control_client
+):
 
-    pba = CustomPBA(MagicMock())
+    pba = CustomPBA(MagicMock(), control_client)
     pba._set_options(fake_custom_pba_windows_options)
     expected_command = f"cd {MONKEY_DIR_PATH} & {CUSTOM_WINDOWS_CMD}"
     assert pba.command == expected_command
@@ -90,8 +100,8 @@ def fake_options_files_only():
 
 
 @pytest.mark.parametrize("os", [set_os_linux, set_os_windows])
-def test_files_only(fake_options_files_only, os):
-    pba = CustomPBA(MagicMock())
+def test_files_only(fake_options_files_only, os, control_client):
+    pba = CustomPBA(MagicMock(), control_client)
     pba._set_options(fake_options_files_only)
     assert pba.command == ""
 
@@ -108,15 +118,15 @@ def fake_options_commands_only():
     }
 
 
-def test_commands_only(fake_options_commands_only, set_os_linux):
-    pba = CustomPBA(MagicMock())
+def test_commands_only(fake_options_commands_only, set_os_linux, control_client):
+    pba = CustomPBA(MagicMock(), control_client)
     pba._set_options(fake_options_commands_only)
     assert pba.command == CUSTOM_LINUX_CMD
     assert pba.filename == ""
 
 
-def test_commands_only_windows(fake_options_commands_only, set_os_windows):
-    pba = CustomPBA(MagicMock())
+def test_commands_only_windows(fake_options_commands_only, set_os_windows, control_client):
+    pba = CustomPBA(MagicMock(), control_client)
     pba._set_options(fake_options_commands_only)
     assert pba.command == CUSTOM_WINDOWS_CMD
     assert pba.filename == ""

--- a/monkey/tests/unit_tests/infection_monkey/post_breach/actions/test_users_custom_pba.py
+++ b/monkey/tests/unit_tests/infection_monkey/post_breach/actions/test_users_custom_pba.py
@@ -2,7 +2,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from infection_monkey.control import ControlClient
 from infection_monkey.post_breach.custom_pba.custom_pba import CustomPBA
 
 MONKEY_DIR_PATH = "/dir/to/monkey/"
@@ -47,15 +46,8 @@ def fake_custom_pba_linux_options():
     }
 
 
-@pytest.fixture
-def control_client():
-    return ControlClient(CUSTOM_SERVER)
-
-
-def test_command_linux_custom_file_and_cmd(
-    fake_custom_pba_linux_options, set_os_linux, control_client
-):
-    pba = CustomPBA(MagicMock(), control_client)
+def test_command_linux_custom_file_and_cmd(fake_custom_pba_linux_options, set_os_linux):
+    pba = CustomPBA(MagicMock(), MagicMock())
     pba._set_options(fake_custom_pba_linux_options)
     expected_command = f"cd {MONKEY_DIR_PATH} ; {CUSTOM_LINUX_CMD}"
     assert pba.command == expected_command
@@ -72,11 +64,9 @@ def fake_custom_pba_windows_options():
     }
 
 
-def test_command_windows_custom_file_and_cmd(
-    fake_custom_pba_windows_options, set_os_windows, control_client
-):
+def test_command_windows_custom_file_and_cmd(fake_custom_pba_windows_options, set_os_windows):
 
-    pba = CustomPBA(MagicMock(), control_client)
+    pba = CustomPBA(MagicMock(), MagicMock())
     pba._set_options(fake_custom_pba_windows_options)
     expected_command = f"cd {MONKEY_DIR_PATH} & {CUSTOM_WINDOWS_CMD}"
     assert pba.command == expected_command
@@ -94,8 +84,8 @@ def fake_options_files_only():
 
 
 @pytest.mark.parametrize("os", [set_os_linux, set_os_windows])
-def test_files_only(fake_options_files_only, os, control_client):
-    pba = CustomPBA(MagicMock(), control_client)
+def test_files_only(fake_options_files_only, os):
+    pba = CustomPBA(MagicMock(), MagicMock())
     pba._set_options(fake_options_files_only)
     assert pba.command == ""
 
@@ -110,15 +100,15 @@ def fake_options_commands_only():
     }
 
 
-def test_commands_only(fake_options_commands_only, set_os_linux, control_client):
-    pba = CustomPBA(MagicMock(), control_client)
+def test_commands_only(fake_options_commands_only, set_os_linux):
+    pba = CustomPBA(MagicMock(), MagicMock())
     pba._set_options(fake_options_commands_only)
     assert pba.command == CUSTOM_LINUX_CMD
     assert pba.filename == ""
 
 
-def test_commands_only_windows(fake_options_commands_only, set_os_windows, control_client):
-    pba = CustomPBA(MagicMock(), control_client)
+def test_commands_only_windows(fake_options_commands_only, set_os_windows):
+    pba = CustomPBA(MagicMock(), MagicMock())
     pba._set_options(fake_options_commands_only)
     assert pba.command == CUSTOM_WINDOWS_CMD
     assert pba.filename == ""

--- a/monkey/tests/unit_tests/infection_monkey/post_breach/actions/test_users_custom_pba.py
+++ b/monkey/tests/unit_tests/infection_monkey/post_breach/actions/test_users_custom_pba.py
@@ -44,8 +44,6 @@ def fake_custom_pba_linux_options():
         "linux_filename": CUSTOM_LINUX_FILENAME,
         "windows_command": "",
         "windows_filename": "",
-        # Current server is used for attack telemetry
-        "current_server": CUSTOM_SERVER,
     }
 
 
@@ -71,8 +69,6 @@ def fake_custom_pba_windows_options():
         "linux_filename": "",
         "windows_command": CUSTOM_WINDOWS_CMD,
         "windows_filename": CUSTOM_WINDOWS_FILENAME,
-        # Current server is used for attack telemetry
-        "current_server": CUSTOM_SERVER,
     }
 
 
@@ -94,8 +90,6 @@ def fake_options_files_only():
         "linux_filename": CUSTOM_LINUX_FILENAME,
         "windows_command": "",
         "windows_filename": CUSTOM_WINDOWS_FILENAME,
-        # Current server is used for attack telemetry
-        "current_server": CUSTOM_SERVER,
     }
 
 
@@ -113,8 +107,6 @@ def fake_options_commands_only():
         "linux_filename": "",
         "windows_command": CUSTOM_WINDOWS_CMD,
         "windows_filename": "",
-        # Current server is used for attack telemetry
-        "current_server": CUSTOM_SERVER,
     }
 
 

--- a/monkey/tests/unit_tests/infection_monkey/telemetry/conftest.py
+++ b/monkey/tests/unit_tests/infection_monkey/telemetry/conftest.py
@@ -11,5 +11,7 @@ def spy_send_telemetry(monkeypatch):
 
     _spy_send_telemetry.telem_category = None
     _spy_send_telemetry.data = None
-    monkeypatch.setattr(ControlClient, "send_telemetry", _spy_send_telemetry)
+    control_client = ControlClient("localhost:5000")
+    ControlClient.control_client_object = control_client
+    monkeypatch.setattr(ControlClient.control_client_object, "send_telemetry", _spy_send_telemetry)
     return _spy_send_telemetry

--- a/monkey/tests/unit_tests/infection_monkey/telemetry/conftest.py
+++ b/monkey/tests/unit_tests/infection_monkey/telemetry/conftest.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import pytest
 
 from infection_monkey.control import ControlClient
@@ -13,5 +15,5 @@ def spy_send_telemetry(monkeypatch):
     _spy_send_telemetry.data = None
     control_client = ControlClient("localhost:5000")
     ControlClient.control_client_object = control_client
-    monkeypatch.setattr(ControlClient.control_client_object, "send_telemetry", _spy_send_telemetry)
+    ControlClient.control_client_object.send_telemetry = MagicMock(side_effect=_spy_send_telemetry)
     return _spy_send_telemetry

--- a/monkey/tests/unit_tests/infection_monkey/telemetry/conftest.py
+++ b/monkey/tests/unit_tests/infection_monkey/telemetry/conftest.py
@@ -13,7 +13,6 @@ def spy_send_telemetry(monkeypatch):
 
     _spy_send_telemetry.telem_category = None
     _spy_send_telemetry.data = None
-    control_client = ControlClient("localhost:5000")
-    ControlClient.control_client_object = control_client
+    ControlClient.control_client_object = MagicMock()
     ControlClient.control_client_object.send_telemetry = MagicMock(side_effect=_spy_send_telemetry)
     return _spy_send_telemetry

--- a/monkey/tests/unit_tests/infection_monkey/telemetry/test_tunnel_telem.py
+++ b/monkey/tests/unit_tests/infection_monkey/telemetry/test_tunnel_telem.py
@@ -7,7 +7,7 @@ from infection_monkey.telemetry.tunnel_telem import TunnelTelem
 
 @pytest.fixture
 def tunnel_telem_test_instance():
-    return TunnelTelem()
+    return TunnelTelem({})
 
 
 def test_tunnel_telem_send(tunnel_telem_test_instance, spy_send_telemetry):

--- a/monkey/tests/unit_tests/infection_monkey/test_control.py
+++ b/monkey/tests/unit_tests/infection_monkey/test_control.py
@@ -8,7 +8,7 @@ from monkey.infection_monkey.control import ControlClient
     [(True, "http://8.8.8.8:45455"), (False, "8.8.8.8:45455")],
 )
 def test_control_set_proxies(monkeypatch, is_windows_os, expected_proxy_string):
-    monkeypatch.setattr("infection_monkey.cc.control.is_windows_os", lambda: is_windows_os)
+    monkeypatch.setattr("monkey.infection_monkey.control.is_windows_os", lambda: is_windows_os)
     control_client = ControlClient("8.8.8.8:5000")
 
     control_client.set_proxies(("8.8.8.8", "45455"))

--- a/monkey/tests/unit_tests/infection_monkey/test_control.py
+++ b/monkey/tests/unit_tests/infection_monkey/test_control.py
@@ -8,8 +8,8 @@ from monkey.infection_monkey.control import ControlClient
     [(True, "http://8.8.8.8:45455"), (False, "8.8.8.8:45455")],
 )
 def test_control_set_proxies(monkeypatch, is_windows_os, expected_proxy_string):
-    monkeypatch.setattr("monkey.infection_monkey.control.is_windows_os", lambda: is_windows_os)
-    control_client = ControlClient()
+    monkeypatch.setattr("infection_monkey.cc.control.is_windows_os", lambda: is_windows_os)
+    control_client = ControlClient("8.8.8.8:5000")
 
     control_client.set_proxies(("8.8.8.8", "45455"))
 


### PR DESCRIPTION
# What does this PR do?

Mitigates the coupling of agent codebase to `current_server` property in worm config, by using server address from control channel and control client #1996

Add any further explanations here.

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running unit tests
    > Tested by running manual test, infecting machines
* [ ] If applicable, add screenshots or log transcripts of the feature working

