### PR TITLE
Agent: Change the logic of depth to represent current depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update MongoDB version to 4.4.x. #1924
 - Endpoint to get agent binaries from "/api/agent/download/<string:os>" to
   "/api/agent-binaries/<string:os>". #1978
+- Depth flag (-d) on the agent now acts the  way you would expect(it represents
+  the current depth of the agent, not hops remaining). #2033
 - Agent configuration structure. #1996, #1998, #1961, #1997, #1994, #1741,
   #1761, #1695, #1605, #2028
 

--- a/monkey/common/utils/argparse_types.py
+++ b/monkey/common/utils/argparse_types.py
@@ -3,7 +3,7 @@ import argparse
 
 def positive_int(_input: str):
     int_value = int(_input)
-    if int_value <= 0:
+    if int_value < 0:
         raise argparse.ArgumentTypeError(f"{_input} is not a positive integer")
 
     return int_value

--- a/monkey/common/utils/argparse_types.py
+++ b/monkey/common/utils/argparse_types.py
@@ -1,0 +1,9 @@
+import argparse
+
+
+def positive_int(_input: str):
+    int_value = int(_input)
+    if int_value <= 0:
+        raise argparse.ArgumentTypeError(f"{_input} is not a positive integer")
+
+    return int_value

--- a/monkey/infection_monkey/config.py
+++ b/monkey/infection_monkey/config.py
@@ -60,7 +60,7 @@ class Configuration(object):
     ###########################
 
     # depth of propagation
-    depth = 2
+    depth = 0
     max_depth = None
 
     keep_tunnel_open_time = 30

--- a/monkey/infection_monkey/dropper.py
+++ b/monkey/infection_monkey/dropper.py
@@ -46,7 +46,7 @@ class MonkeyDrops(object):
         arg_parser.add_argument("-p", "--parent")
         arg_parser.add_argument("-t", "--tunnel")
         arg_parser.add_argument("-s", "--server")
-        arg_parser.add_argument("-d", "--depth", type=positive_int)
+        arg_parser.add_argument("-d", "--depth", type=positive_int, default=0)
         arg_parser.add_argument("-l", "--location")
         arg_parser.add_argument("-vp", "--vulnerable-port")
         self.opts = arg_parser.parse_args(args)

--- a/monkey/infection_monkey/dropper.py
+++ b/monkey/infection_monkey/dropper.py
@@ -9,6 +9,7 @@ import sys
 import time
 from pathlib import PosixPath, WindowsPath
 
+from common.utils.argparse_types import positive_int
 from common.utils.attack_utils import UsageEnum
 from infection_monkey.utils.commands import (
     build_monkey_commandline_explicitly,
@@ -45,7 +46,7 @@ class MonkeyDrops(object):
         arg_parser.add_argument("-p", "--parent")
         arg_parser.add_argument("-t", "--tunnel")
         arg_parser.add_argument("-s", "--server")
-        arg_parser.add_argument("-d", "--depth", type=int)
+        arg_parser.add_argument("-d", "--depth", type=positive_int)
         arg_parser.add_argument("-l", "--location")
         arg_parser.add_argument("-vp", "--vulnerable-port")
         self.opts = arg_parser.parse_args(args)

--- a/monkey/infection_monkey/exploit/hadoop.py
+++ b/monkey/infection_monkey/exploit/hadoop.py
@@ -104,7 +104,7 @@ class HadoopExploiter(WebRCE):
 
     def _build_command(self, path, http_path):
         # Build command to execute
-        monkey_cmd = build_monkey_commandline(self.host, self.current_depth - 1)
+        monkey_cmd = build_monkey_commandline(self.host, self.current_depth + 1)
         if "linux" in self.host.os["type"]:
             base_command = HADOOP_LINUX_COMMAND
         else:

--- a/monkey/infection_monkey/exploit/log4shell.py
+++ b/monkey/infection_monkey/exploit/log4shell.py
@@ -114,7 +114,7 @@ class Log4ShellExploiter(WebRCE):
 
     def _build_command(self, path: PurePath, http_path) -> str:
         # Build command to execute
-        monkey_cmd = build_monkey_commandline(self.host, self.current_depth - 1, location=path)
+        monkey_cmd = build_monkey_commandline(self.host, self.current_depth + 1, location=path)
         if "linux" in self.host.os["type"]:
             base_command = LOG4SHELL_LINUX_COMMAND
         else:

--- a/monkey/infection_monkey/exploit/mssqlexec.py
+++ b/monkey/infection_monkey/exploit/mssqlexec.py
@@ -178,7 +178,7 @@ class MSSQLExploiter(HostExploiter):
 
     def _build_agent_launch_command(self, agent_path_on_victim: PureWindowsPath) -> str:
         agent_args = build_monkey_commandline(
-            self.host, self.current_depth - 1, agent_path_on_victim
+            self.host, self.current_depth + 1, agent_path_on_victim
         )
 
         return f"{agent_path_on_victim} {DROPPER_ARG} {agent_args}"

--- a/monkey/infection_monkey/exploit/powershell.py
+++ b/monkey/infection_monkey/exploit/powershell.py
@@ -168,7 +168,7 @@ class PowerShellExploiter(HostExploiter):
 
     def _run_monkey_executable_on_victim(self, executable_path):
         monkey_execution_command = build_monkey_execution_command(
-            self.host, self.current_depth - 1, executable_path
+            self.host, self.current_depth + 1, executable_path
         )
 
         logger.info(

--- a/monkey/infection_monkey/exploit/smbexec.py
+++ b/monkey/infection_monkey/exploit/smbexec.py
@@ -91,13 +91,13 @@ class SMBExploiter(HostExploiter):
                 "dropper_path": remote_full_path
             } + build_monkey_commandline(
                 self.host,
-                self.current_depth - 1,
+                self.current_depth + 1,
                 str(dest_path),
             )
         else:
             cmdline = MONKEY_CMDLINE_DETACHED_WINDOWS % {
                 "monkey_path": remote_full_path
-            } + build_monkey_commandline(self.host, self.current_depth - 1)
+            } + build_monkey_commandline(self.host, self.current_depth + 1)
 
         smb_conn = None
         for str_bind_format, port in SMBExploiter.KNOWN_PROTOCOLS.values():

--- a/monkey/infection_monkey/exploit/sshexec.py
+++ b/monkey/infection_monkey/exploit/sshexec.py
@@ -242,7 +242,7 @@ class SSHExploiter(HostExploiter):
 
         try:
             cmdline = f"{monkey_path_on_victim} {MONKEY_ARG}"
-            cmdline += build_monkey_commandline(self.host, self.current_depth - 1)
+            cmdline += build_monkey_commandline(self.host, self.current_depth + 1)
             cmdline += " > /dev/null 2>&1 &"
             ssh.exec_command(cmdline, timeout=SSH_EXEC_TIMEOUT)
 

--- a/monkey/infection_monkey/exploit/web_rce.py
+++ b/monkey/infection_monkey/exploit/web_rce.py
@@ -369,14 +369,14 @@ class WebRCE(HostExploiter):
             default_path = self.get_default_dropper_path()
             if default_path is False:
                 return False
-            monkey_cmd = build_monkey_commandline(self.host, self.current_depth - 1, default_path)
+            monkey_cmd = build_monkey_commandline(self.host, self.current_depth + 1, default_path)
             command = RUN_MONKEY % {
                 "monkey_path": path,
                 "monkey_type": DROPPER_ARG,
                 "parameters": monkey_cmd,
             }
         else:
-            monkey_cmd = build_monkey_commandline(self.host, self.current_depth - 1)
+            monkey_cmd = build_monkey_commandline(self.host, self.current_depth + 1)
             command = RUN_MONKEY % {
                 "monkey_path": path,
                 "monkey_type": MONKEY_ARG,

--- a/monkey/infection_monkey/exploit/wmiexec.py
+++ b/monkey/infection_monkey/exploit/wmiexec.py
@@ -96,13 +96,13 @@ class WmiExploiter(HostExploiter):
                     "dropper_path": remote_full_path
                 } + build_monkey_commandline(
                     self.host,
-                    self.current_depth - 1,
+                    self.current_depth + 1,
                     DROPPER_TARGET_PATH_WIN64,
                 )
             else:
                 cmdline = MONKEY_CMDLINE_WINDOWS % {
                     "monkey_path": remote_full_path
-                } + build_monkey_commandline(self.host, self.current_depth - 1)
+                } + build_monkey_commandline(self.host, self.current_depth + 1)
 
             # execute the remote monkey
             result = WmiTools.get_object(wmi_connection, "Win32_Process").Create(

--- a/monkey/infection_monkey/master/automated_master.py
+++ b/monkey/infection_monkey/master/automated_master.py
@@ -176,7 +176,7 @@ class AutomatedMaster(IMaster):
         if should_propagate(self._control_channel.get_config(), self._current_depth):
             self._propagator.propagate(config["propagation"], current_depth, self._stop)
         else:
-            logger.info("Skipping propagation, maximum depth reached")
+            logger.info("Skipping propagation: maximum depth reached")
 
         payload_thread = create_daemon_thread(
             target=self._run_plugins,

--- a/monkey/infection_monkey/master/automated_master.py
+++ b/monkey/infection_monkey/master/automated_master.py
@@ -169,10 +169,10 @@ class AutomatedMaster(IMaster):
         # still running.
         credential_collector_thread.join()
 
-        current_depth = self._current_depth if self._current_depth is not None else config["depth"]
+        current_depth = self._current_depth if self._current_depth is not None else 0
         logger.info(f"Current depth is {current_depth}")
 
-        if self._can_propagate() and current_depth > 0:
+        if self._can_propagate() and current_depth < config["depth"]:
             self._propagator.propagate(config["propagation"], current_depth, self._stop)
 
         payload_thread = create_daemon_thread(

--- a/monkey/infection_monkey/master/automated_master.py
+++ b/monkey/infection_monkey/master/automated_master.py
@@ -14,6 +14,7 @@ from infection_monkey.telemetry.credentials_telem import CredentialsTelem
 from infection_monkey.telemetry.messengers.i_telemetry_messenger import ITelemetryMessenger
 from infection_monkey.telemetry.post_breach_telem import PostBreachTelem
 from infection_monkey.utils.threading import create_daemon_thread, interruptible_iter
+from utils.propagation import should_propagate
 
 from . import Exploiter, IPScanner, Propagator
 from .option_parsing import custom_pba_is_enabled
@@ -172,7 +173,7 @@ class AutomatedMaster(IMaster):
         current_depth = self._current_depth if self._current_depth is not None else 0
         logger.info(f"Current depth is {current_depth}")
 
-        if self._can_propagate() and current_depth < config["depth"]:
+        if self._can_propagate():
             self._propagator.propagate(config["propagation"], current_depth, self._stop)
 
         payload_thread = create_daemon_thread(
@@ -201,7 +202,7 @@ class AutomatedMaster(IMaster):
             self._telemetry_messenger.send_telemetry(PostBreachTelem(pba_data))
 
     def _can_propagate(self) -> bool:
-        return True
+        return should_propagate(self._control_channel.get_config(), self._current_depth)
 
     def _run_payload(self, payload: Tuple[str, Dict]):
         name = payload[0]

--- a/monkey/infection_monkey/master/automated_master.py
+++ b/monkey/infection_monkey/master/automated_master.py
@@ -3,8 +3,6 @@ import threading
 import time
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple
 
-from utils.propagation import should_propagate
-
 from common.utils import Timer
 from infection_monkey.credential_store import ICredentialsStore
 from infection_monkey.i_control_channel import IControlChannel, IslandCommunicationError
@@ -15,6 +13,7 @@ from infection_monkey.network import NetworkInterface
 from infection_monkey.telemetry.credentials_telem import CredentialsTelem
 from infection_monkey.telemetry.messengers.i_telemetry_messenger import ITelemetryMessenger
 from infection_monkey.telemetry.post_breach_telem import PostBreachTelem
+from infection_monkey.utils.propagation import should_propagate
 from infection_monkey.utils.threading import create_daemon_thread, interruptible_iter
 
 from . import Exploiter, IPScanner, Propagator

--- a/monkey/infection_monkey/master/automated_master.py
+++ b/monkey/infection_monkey/master/automated_master.py
@@ -173,7 +173,7 @@ class AutomatedMaster(IMaster):
         current_depth = self._current_depth if self._current_depth is not None else 0
         logger.info(f"Current depth is {current_depth}")
 
-        if self._can_propagate():
+        if should_propagate(self._control_channel.get_config(), self._current_depth):
             self._propagator.propagate(config["propagation"], current_depth, self._stop)
         else:
             logger.info("Skipping propagation, maximum depth reached")
@@ -202,9 +202,6 @@ class AutomatedMaster(IMaster):
 
         for pba_data in self._puppet.run_pba(name, options):
             self._telemetry_messenger.send_telemetry(PostBreachTelem(pba_data))
-
-    def _can_propagate(self) -> bool:
-        return should_propagate(self._control_channel.get_config(), self._current_depth)
 
     def _run_payload(self, payload: Tuple[str, Dict]):
         name = payload[0]

--- a/monkey/infection_monkey/master/automated_master.py
+++ b/monkey/infection_monkey/master/automated_master.py
@@ -3,6 +3,8 @@ import threading
 import time
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple
 
+from utils.propagation import should_propagate
+
 from common.utils import Timer
 from infection_monkey.credential_store import ICredentialsStore
 from infection_monkey.i_control_channel import IControlChannel, IslandCommunicationError
@@ -14,7 +16,6 @@ from infection_monkey.telemetry.credentials_telem import CredentialsTelem
 from infection_monkey.telemetry.messengers.i_telemetry_messenger import ITelemetryMessenger
 from infection_monkey.telemetry.post_breach_telem import PostBreachTelem
 from infection_monkey.utils.threading import create_daemon_thread, interruptible_iter
-from utils.propagation import should_propagate
 
 from . import Exploiter, IPScanner, Propagator
 from .option_parsing import custom_pba_is_enabled
@@ -175,6 +176,8 @@ class AutomatedMaster(IMaster):
 
         if self._can_propagate():
             self._propagator.propagate(config["propagation"], current_depth, self._stop)
+        else:
+            logger.info("Skipping propagation, maximum depth reached")
 
         payload_thread = create_daemon_thread(
             target=self._run_plugins,

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -79,6 +79,7 @@ from infection_monkey.utils.monkey_dir import (
 )
 from infection_monkey.utils.monkey_log_path import get_agent_log_path
 from infection_monkey.utils.signal_handler import register_signal_handlers, reset_signal_handlers
+from utils.propagation import should_propagate
 
 logger = logging.getLogger(__name__)
 logging.getLogger("urllib3").setLevel(logging.INFO)
@@ -167,7 +168,10 @@ class InfectionMonkey:
             firewall.add_firewall_rule()
 
         self._monkey_inbound_tunnel = self._control_client.create_control_tunnel()
-        if self._monkey_inbound_tunnel:
+        config = ControlChannel(
+            self._control_client.server_address, GUID, self._control_client.proxies
+        ).get_config()
+        if self._monkey_inbound_tunnel and should_propagate(config, self._current_depth):
             self._monkey_inbound_tunnel.start()
 
         StateTelem(is_done=False, version=get_version()).send()

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -99,6 +99,7 @@ class InfectionMonkey:
         self._telemetry_messenger = LegacyTelemetryMessengerAdapter()
         self._current_depth = self._opts.depth
         self._master = None
+        self._inbound_tunnel_opened = False
 
     @staticmethod
     def _get_arguments(args):
@@ -172,6 +173,7 @@ class InfectionMonkey:
             self._control_client.server_address, GUID, self._control_client.proxies
         ).get_config()
         if self._monkey_inbound_tunnel and should_propagate(config, self._current_depth):
+            self._inbound_tunnel_opened = True
             self._monkey_inbound_tunnel.start()
 
         StateTelem(is_done=False, version=get_version()).send()
@@ -358,7 +360,7 @@ class InfectionMonkey:
 
             reset_signal_handlers()
 
-            if self._monkey_inbound_tunnel:
+            if self._inbound_tunnel_opened:
                 self._monkey_inbound_tunnel.stop()
                 self._monkey_inbound_tunnel.join()
 

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -8,6 +8,7 @@ from typing import List
 
 import infection_monkey.tunnel as tunnel
 from common.network.network_utils import address_to_ip_port
+from common.utils.argparse_types import positive_int
 from common.utils.attack_utils import ScanStatus, UsageEnum
 from common.version import get_version
 from infection_monkey.config import GUID
@@ -104,7 +105,7 @@ class InfectionMonkey:
         arg_parser.add_argument("-p", "--parent")
         arg_parser.add_argument("-t", "--tunnel")
         arg_parser.add_argument("-s", "--server")
-        arg_parser.add_argument("-d", "--depth", type=int)
+        arg_parser.add_argument("-d", "--depth", type=positive_int)
         opts = arg_parser.parse_args(args)
         InfectionMonkey._log_arguments(opts)
 

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -78,8 +78,8 @@ from infection_monkey.utils.monkey_dir import (
     remove_monkey_dir,
 )
 from infection_monkey.utils.monkey_log_path import get_agent_log_path
+from infection_monkey.utils.propagation import should_propagate
 from infection_monkey.utils.signal_handler import register_signal_handlers, reset_signal_handlers
-from utils.propagation import should_propagate
 
 logger = logging.getLogger(__name__)
 logging.getLogger("urllib3").setLevel(logging.INFO)

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -106,7 +106,7 @@ class InfectionMonkey:
         arg_parser.add_argument("-p", "--parent")
         arg_parser.add_argument("-t", "--tunnel")
         arg_parser.add_argument("-s", "--server")
-        arg_parser.add_argument("-d", "--depth", type=positive_int)
+        arg_parser.add_argument("-d", "--depth", type=positive_int, default=0)
         opts = arg_parser.parse_args(args)
         InfectionMonkey._log_arguments(opts)
 

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -166,7 +166,7 @@ class InfectionMonkey:
             firewall.add_firewall_rule()
 
         self._monkey_inbound_tunnel = self._control_client.create_control_tunnel()
-        if self._monkey_inbound_tunnel and self._propagation_enabled():
+        if self._monkey_inbound_tunnel:
             self._monkey_inbound_tunnel.start()
 
         StateTelem(is_done=False, version=get_version()).send()
@@ -353,7 +353,7 @@ class InfectionMonkey:
 
             reset_signal_handlers()
 
-            if self._monkey_inbound_tunnel and self._propagation_enabled():
+            if self._monkey_inbound_tunnel:
                 self._monkey_inbound_tunnel.stop()
                 self._monkey_inbound_tunnel.join()
 
@@ -377,12 +377,6 @@ class InfectionMonkey:
                 InfectionMonkey._self_delete()
 
         logger.info("Monkey is shutting down")
-
-    def _propagation_enabled(self) -> bool:
-        # If self._current_depth is None, assume that propagation is desired.
-        # The Master will ignore this value if it is None and pull the actual
-        # maximum depth from the server
-        return self._current_depth is None or self._current_depth > 0
 
     def _close_tunnel(self):
         tunnel_address = (

--- a/monkey/infection_monkey/utils/commands.py
+++ b/monkey/infection_monkey/utils/commands.py
@@ -40,8 +40,6 @@ def build_monkey_commandline_explicitly(
         cmdline.append("-s")
         cmdline.append(str(server))
     if depth is not None:
-        if int(depth) < 0:
-            depth = 0
         cmdline.append("-d")
         cmdline.append(str(depth))
     if location is not None:

--- a/monkey/infection_monkey/utils/propagation.py
+++ b/monkey/infection_monkey/utils/propagation.py
@@ -1,2 +1,2 @@
 def should_propagate(config: dict, depth: int) -> bool:
-    return config["config"]["depth"] < depth
+    return config["config"]["depth"] > depth

--- a/monkey/infection_monkey/utils/propagation.py
+++ b/monkey/infection_monkey/utils/propagation.py
@@ -1,0 +1,2 @@
+def should_propagate(config: dict, depth: int) -> bool:
+    return config["config"]["depth"] < depth

--- a/monkey/infection_monkey/utils/propagation.py
+++ b/monkey/infection_monkey/utils/propagation.py
@@ -1,2 +1,2 @@
-def should_propagate(config: dict, depth: int) -> bool:
-    return config["config"]["depth"] > depth
+def should_propagate(config: dict, current_depth: int) -> bool:
+    return config["config"]["depth"] > current_depth

--- a/monkey/tests/unit_tests/infection_monkey/utils/test_commands.py
+++ b/monkey/tests/unit_tests/infection_monkey/utils/test_commands.py
@@ -28,16 +28,6 @@ def test_build_monkey_commandline_explicitly_arguments():
     assert expected == actual
 
 
-def test_build_monkey_commandline_explicitly_depth_condition_less():
-    expected = [
-        "-d",
-        "0",
-    ]
-    actual = build_monkey_commandline_explicitly(depth=-50)
-
-    assert expected == actual
-
-
 def test_build_monkey_commandline_explicitly_depth_condition_greater():
     expected = [
         "-d",

--- a/monkey/tests/unit_tests/infection_monkey/utils/test_propagation.py
+++ b/monkey/tests/unit_tests/infection_monkey/utils/test_propagation.py
@@ -1,0 +1,32 @@
+from infection_monkey.utils.propagation import should_propagate
+
+
+def get_config(max_depth):
+    return {"config": {"depth": max_depth}}
+
+
+def test_should_propagate_current_less_than_max():
+    max_depth = 2
+    current_depth = 1
+
+    config = get_config(max_depth)
+
+    assert should_propagate(config, current_depth) is True
+
+
+def test_should_propagate_current_greater_than_max():
+    max_depth = 2
+    current_depth = 3
+
+    config = get_config(max_depth)
+
+    assert should_propagate(config, current_depth) is False
+
+
+def test_should_propagate_current_equal_to_max():
+    max_depth = 2
+    current_depth = max_depth
+
+    config = get_config(max_depth)
+
+    assert should_propagate(config, current_depth) is False


### PR DESCRIPTION
Based on the previous logic the depth parameter represented hops remaining, not current depth.

# What does this PR do?

Fixes incorrect depth logic on the agent side. Based on the previous logic the depth parameter represented hops remaining, not current depth. This is misleading and might result in a situation where max depth is 3 in the configuration, so the user runs the agent with `-d 2` expecting the agent to do one more hop. In reality, the agent will make 2 hops, because `--depth` was countdown to zero, not count to maximum depth.

Add any further explanations here.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing?
* [x] Was the CHANGELOG.md updated to reflect the changes?
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running agent manually with max depth
    > Tested by running unit tests
* [ ] If applicable, add screenshots or log transcripts of the feature working

