### PR TITLE
2003 retrieve submit config

### DIFF
--- a/monkey/monkey_island/cc/resources/agent_configuration.py
+++ b/monkey/monkey_island/cc/resources/agent_configuration.py
@@ -24,7 +24,7 @@ class AgentConfiguration(AbstractResource):
     @jwt_required
     def post(self):
         try:
-            configuration_object = AgentConfigurationObject.from_json(request.data)
+            configuration_object = AgentConfigurationObject.from_mapping(request.json)
             self._agent_configuration_repository.store_configuration(configuration_object)
             return make_response({}, 200)
         except (InvalidConfigurationError, json.JSONDecodeError) as err:

--- a/monkey/monkey_island/cc/ui/src/components/configuration-components/ExportConfigModal.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/configuration-components/ExportConfigModal.tsx
@@ -4,6 +4,7 @@ import React, {useState} from 'react';
 import FileSaver from 'file-saver';
 import '../../styles/components/configuration-components/ExportConfigModal.scss';
 import {encryptText} from '../utils/PasswordBasedEncryptor';
+import {reformatConfig} from './ReformatHook';
 
 
 type Props = {
@@ -21,7 +22,7 @@ const ConfigExportModal = (props: Props) => {
   }
 
   function onSubmit() {
-    let config = props.configuration;
+    let config = reformatConfig(props.configuration, true);
     let config_export = {'metadata': {}, 'contents': null};
 
     if (radioValue === 'password') {

--- a/monkey/monkey_island/cc/ui/src/components/configuration-components/ImportConfigModal.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/configuration-components/ImportConfigModal.tsx
@@ -20,8 +20,7 @@ type Props = {
 
 
 const ConfigImportModal = (props: Props) => {
-  // TODO: change this endpoint to the new configuration import endpoint
-  const configImportEndpoint = '/api/configuration/import';
+  const configImportEndpoint = '/api/agent-configuration';
 
   const [uploadStatus, setUploadStatus] = useState(UploadStatuses.clean);
   const [configContents, setConfigContents] = useState(null);
@@ -71,18 +70,15 @@ const ConfigImportModal = (props: Props) => {
       {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({
-          config: configContents,
-        })
+        body: JSON.stringify(configContents)
       }
-    ).then(res => res.json())
-      .then(res => {
-        if (res['import_status'] === 'invalid_configuration') {
-          setUploadStatus(UploadStatuses.error);
-          setErrorMessage(res['message']);
-        } else if (res['import_status'] === 'imported') {
+    ).then(res => {
+        if (res.ok) {
           resetState();
           props.onClose(true);
+        } else {
+          setUploadStatus(UploadStatuses.error);
+          setErrorMessage("Configuration file is corrupt or in an outdated format.");
         }
       })
   }

--- a/monkey/monkey_island/cc/ui/src/components/configuration-components/ReformatHook.js
+++ b/monkey/monkey_island/cc/ui/src/components/configuration-components/ReformatHook.js
@@ -1,0 +1,8 @@
+export function reformatConfig(config, reverse = false) {
+    if (reverse) {
+      config['payloads'] = [{'name': 'ransomware', 'options': config['payloads']}]
+    } else {
+      config['payloads'] = config['payloads'][0]['options'];
+    }
+    return config;
+  }

--- a/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
@@ -21,6 +21,7 @@ import {SCHEMA} from '../../services/configuration/config_schema.js';
 import {reformatConfig} from '../configuration-components/ReformatHook';
 
 const CONFIG_URL = '/api/agent-configuration';
+const RESET_URL = '/api/reset-agent-configuration';
 export const API_PBA_LINUX = '/api/file-upload/PBAlinux';
 export const API_PBA_WINDOWS = '/api/file-upload/PBAwindows';
 
@@ -145,7 +146,7 @@ class ConfigurePageComponent extends AuthComponent {
   configSubmit() {
     return this.sendConfig()
       .then(res => res.json())
-      .then(res => {
+      .then(() => {
         this.setState({
           lastAction: configSaveAction
         });
@@ -279,22 +280,16 @@ class ConfigurePageComponent extends AuthComponent {
   };
 
   resetConfig = () => {
-    this.authFetch(CONFIG_URL,
+    this.authFetch(RESET_URL,
       {
         method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({'reset': true})
       })
       .then(res => res.json())
-      .then(res => {
-          res.configuration = reformatConfig(res.configuration);
+      .then(() => {
           this.setState({
             lastAction: 'reset',
-            schema: res.schema,
-            configuration: res.configuration,
-            currentFormData: res.configuration[this.state.selectedSection]
           });
-          this.setInitialConfig(res.configuration);
+          this.updateConfig();
           this.props.onStatusChange();
         }
       ).then(() => {

--- a/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
@@ -19,7 +19,7 @@ import HtmlFieldDescription from '../configuration-components/HtmlFieldDescripti
 import CONFIGURATION_TABS_PER_MODE from '../configuration-components/ConfigurationTabs.js';
 import {SCHEMA} from '../../services/configuration/config_schema.js';
 
-const CONFIG_URL = '/api/configuration/island';
+const CONFIG_URL = '/api/agent-configuration';
 export const API_PBA_LINUX = '/api/file-upload/PBAlinux';
 export const API_PBA_WINDOWS = '/api/file-upload/PBAwindows';
 
@@ -68,10 +68,8 @@ class ConfigurePageComponent extends AuthComponent {
   }
 
   componentDidMount = () => {
-    let urls = ['/api/agent-configuration'];
-    // ??? Why fetch config here and not in `render()`?
-    Promise.all(urls.map(url => this.authFetch(url).then(res => res.json())))
-      .then(data => {
+    this.authFetch(CONFIG_URL).then(res => res.json())
+      .then(monkeyConfig => {
         let sections = [];
         let monkeyConfig = data[0];
         // TODO: Fix when we add plugins
@@ -322,7 +320,7 @@ class ConfigurePageComponent extends AuthComponent {
 
   sendConfig() {
     return (
-      this.authFetch('/api/configuration/island',
+      this.authFetch(CONFIG_URL,
         {
           method: 'POST',
           headers: {'Content-Type': 'application/json'},

--- a/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
@@ -250,22 +250,6 @@ class ConfigurePageComponent extends AuthComponent {
     );
   }
 
-  userChangedConfig() {
-    try {
-      if (JSON.stringify(this.state.configuration) === JSON.stringify(this.initialConfig)) {
-        if (Object.keys(this.state.currentFormData).length === 0 ||
-          JSON.stringify(this.initialConfig[this.currentSection]) === JSON.stringify(this.state.currentFormData)) {
-          return false;
-        }
-      }
-    } catch (TypeError) {
-      if (JSON.stringify(this.initialConfig[this.currentSection]) === JSON.stringify(this.state.currentFormData)) {
-        return false;
-      }
-    }
-    return true;
-  }
-
   setSelectedSection = (key) => {
     this.resetLastAction();
     this.updateConfigSection();

--- a/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
@@ -46,7 +46,6 @@ class ConfigurePageComponent extends AuthComponent {
       selectedSection: this.currentSection,
       showUnsubmittedConfigWarning: false,
       showUnsafeOptionsConfirmation: false,
-      showUnsafeAttackOptionsWarning: false,
       showConfigExportModal: false,
       showConfigImportModal: false
     };
@@ -204,32 +203,6 @@ class ConfigurePageComponent extends AuthComponent {
       this.setState({showConfigImportModal: false});
     }
   }
-
-  renderAttackAlertModal = () => {
-    return (<Modal show={this.state.showUnsubmittedConfigWarning} onHide={() => {
-      this.setState({showUnsubmittedConfigWarning: false})
-    }}>
-      <Modal.Body>
-        <h2>
-          <div className='text-center'>Warning</div>
-        </h2>
-        <p className='text-center' style={{'fontSize': '1.2em', 'marginBottom': '2em'}}>
-          You have unsubmitted changes. Submit them before proceeding.
-        </p>
-        <div className='text-center'>
-          <Button type='button'
-                  className='btn btn-success'
-                  size='lg'
-                  style={{margin: '5px'}}
-                  onClick={() => {
-                    this.setState({showUnsubmittedConfigWarning: false})
-                  }}>
-            Cancel
-          </Button>
-        </div>
-      </Modal.Body>
-    </Modal>)
-  };
 
   renderUnsafeOptionsConfirmationModal() {
     return (
@@ -402,7 +375,6 @@ class ConfigurePageComponent extends AuthComponent {
            className={'main'}>
         {this.renderConfigExportModal()}
         {this.renderConfigImportModal()}
-        {this.renderAttackAlertModal()}
         {this.renderUnsafeOptionsConfirmationModal()}
         {this.renderUnsafeAttackOptionsWarningModal()}
         <h1 className='page-title'>Monkey Configuration</h1>

--- a/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
@@ -64,7 +64,8 @@ class ConfigurePageComponent extends AuthComponent {
   }
 
   getSectionsOrder() {
-    let islandMode = this.props.islandMode !== 'unset' ? this.props.islandMode : 'advanced'
+    let islandModeSet = (this.props.islandMode !== 'unset' && this.props.islandMode !== undefined)
+    let islandMode = islandModeSet ? this.props.islandMode : 'advanced'
     return CONFIGURATION_TABS_PER_MODE[islandMode];
   }
 

--- a/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
@@ -59,6 +59,10 @@ class ConfigurePageComponent extends AuthComponent {
     }
   }
 
+  resetLastAction = () => {
+    this.setState({lastAction: 'none'});
+  }
+
   getSectionsOrder() {
     let islandMode = this.props.islandMode !== 'unset' ? this.props.islandMode : 'advanced'
     return CONFIGURATION_TABS_PER_MODE[islandMode];
@@ -262,13 +266,7 @@ class ConfigurePageComponent extends AuthComponent {
   }
 
   setSelectedSection = (key) => {
-
-    // TODO: Fix https://github.com/guardicore/monkey/issues/1621
-    //if ( key === 'basic' & this.userChangedConfig()) {
-    //  this.setState({showUnsubmittedConfigWarning: true});
-    //  return;
-    //}
-
+    this.resetLastAction();
     this.updateConfigSection();
     this.currentSection = key;
     let selectedSectionData = this.state.configuration[key];
@@ -351,6 +349,7 @@ class ConfigurePageComponent extends AuthComponent {
     formProperties['fields'] = {DescriptionField: HtmlFieldDescription};
     formProperties['formData'] = this.state.currentFormData;
     formProperties['onChange'] = this.onChange;
+    formProperties['onFocus'] = this.resetLastAction;
     formProperties['customFormats'] = formValidationFormats;
     formProperties['transformErrors'] = transformErrors;
     formProperties['className'] = 'config-form';

--- a/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
@@ -44,7 +44,6 @@ class ConfigurePageComponent extends AuthComponent {
       schema: {},
       sections: [],
       selectedSection: this.currentSection,
-      showUnsubmittedConfigWarning: false,
       showUnsafeOptionsConfirmation: false,
       showConfigExportModal: false,
       showConfigImportModal: false
@@ -214,15 +213,6 @@ class ConfigurePageComponent extends AuthComponent {
     );
   }
 
-  renderUnsafeAttackOptionsWarningModal() {
-    return (
-      <UnsafeOptionsWarningModal
-        show={this.state.showUnsafeAttackOptionsWarning}
-        onContinueClick={this.onUnsafeAttackContinueClick}
-      />
-    );
-  }
-
   setSelectedSection = (key) => {
     this.resetLastAction();
     this.updateConfigSection();
@@ -376,7 +366,6 @@ class ConfigurePageComponent extends AuthComponent {
         {this.renderConfigExportModal()}
         {this.renderConfigImportModal()}
         {this.renderUnsafeOptionsConfirmationModal()}
-        {this.renderUnsafeAttackOptionsWarningModal()}
         <h1 className='page-title'>Monkey Configuration</h1>
         {this.renderNav()}
         {content}

--- a/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/ConfigurePage.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Form from 'react-jsonschema-form-bs4';
-import {Button, Col, Modal, Nav} from 'react-bootstrap';
+import {Col, Nav} from 'react-bootstrap';
 import AuthComponent from '../AuthComponent';
 import UiSchema from '../configuration-components/UiSchema';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
@@ -10,7 +10,6 @@ import {formValidationFormats} from '../configuration-components/ValidationForma
 import transformErrors from '../configuration-components/ValidationErrorMessages';
 import UnsafeConfigOptionsConfirmationModal
   from '../configuration-components/UnsafeConfigOptionsConfirmationModal.js';
-import UnsafeOptionsWarningModal from '../configuration-components/UnsafeOptionsWarningModal.js';
 import isUnsafeOptionSelected from '../utils/SafeOptionValidator.js';
 import ConfigExportModal from '../configuration-components/ExportConfigModal';
 import ConfigImportModal from '../configuration-components/ImportConfigModal';
@@ -107,10 +106,6 @@ class ConfigurePageComponent extends AuthComponent {
       this.configSubmit();
       this.setState({showConfigExportModal: true});
     }
-  }
-
-  onUnsafeAttackContinueClick = () => {
-    this.setState({showUnsafeAttackOptionsWarning: false});
   }
 
   updateConfig = () => {
@@ -228,12 +223,12 @@ class ConfigurePageComponent extends AuthComponent {
   resetConfig = () => {
     this.authFetch(RESET_URL,
       {
-        method: 'POST',
+        method: 'POST'
       })
       .then(res => res.json())
       .then(() => {
           this.setState({
-            lastAction: 'reset',
+            lastAction: 'reset'
           });
           this.updateConfig();
           this.props.onStatusChange();

--- a/monkey/monkey_island/cc/ui/src/components/ui-components/AdvancedMultiSelect.js
+++ b/monkey/monkey_island/cc/ui/src/components/ui-components/AdvancedMultiSelect.js
@@ -182,7 +182,7 @@ class AdvancedMultiSelect extends React.Component {
     } = this.props;
 
     return (
-      <div className={'advanced-multi-select'}>
+      <div className={'advanced-multi-select'} onFocus={this.props.onFocus}>
         <AdvancedMultiSelectHeader title={schema.title}
                                    onCheckboxClick={this.onMasterCheckboxClick}
                                    checkboxState={this.getMasterCheckboxState(


### PR DESCRIPTION
# What does this PR do?

Fixes part of #2003
Enables submit, import, export and reset buttons in the configuration page

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by manually running import, export, submit, reset, refreshing the page, changing tabs, importing malformed configs, etc.
* [ ] If applicable, add screenshots or log transcripts of the feature working
