### PR TITLE
Switch singleton resources from POST to PUT

### DIFF
--- a/monkey/monkey_island/cc/resources/agent_configuration.py
+++ b/monkey/monkey_island/cc/resources/agent_configuration.py
@@ -22,7 +22,7 @@ class AgentConfiguration(AbstractResource):
         return make_response(configuration_json, 200)
 
     @jwt_required
-    def post(self):
+    def put(self):
         try:
             configuration_object = AgentConfigurationObject.from_mapping(request.json)
             self._agent_configuration_repository.store_configuration(configuration_object)

--- a/monkey/monkey_island/cc/resources/island_mode.py
+++ b/monkey/monkey_island/cc/resources/island_mode.py
@@ -19,7 +19,7 @@ class IslandMode(AbstractResource):
         self._island_mode_service = island_mode_service
 
     @jwt_required
-    def post(self):
+    def put(self):
         try:
             body = json.loads(request.data)
             mode = IslandModeEnum(body.get("mode"))


### PR DESCRIPTION
# What does this PR do?
These singleton resources should be modified using the PUT verb instead of the POST verb. POST should be used to create a resource. PUT should be used to update an existing resource. Since these resources always exist, PUT is the appropriate verb.

https://github.com/guardicore/monkey/issues/2071

Fixes #`put issue number here`.
Changed the verb from post to put

Add any further explanations here.

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Have you successfully tested your changes locally? Elaborate:
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
