### PR TITLE
Island: Remove trailing slashes before registering a URL

### DIFF
--- a/monkey/monkey_island/cc/app.py
+++ b/monkey/monkey_island/cc/app.py
@@ -128,7 +128,14 @@ class FlaskDIWrapper:
             raise ValueError(f"Resource {resource.__name__} has no defined URLs")
 
         self._reserve_urls(resource.urls)
-        resource.urls = map(lambda url: url.rstrip("/"), resource.urls)
+
+        # enforce our rule that URLs should not contain a trailing slash
+        for url in resource.urls:
+            if url.endswith("/"):
+                raise ValueError(
+                    f"Resource {resource.__name__} has an invalid URL: A URL "
+                    "should not have a trailing slash."
+                )
         dependencies = self._container.resolve_dependencies(resource)
         self._api.add_resource(resource, *resource.urls, resource_class_args=dependencies)
 

--- a/monkey/monkey_island/cc/app.py
+++ b/monkey/monkey_island/cc/app.py
@@ -128,7 +128,7 @@ class FlaskDIWrapper:
             raise ValueError(f"Resource {resource.__name__} has no defined URLs")
 
         self._reserve_urls(resource.urls)
-
+        resource.urls = map(lambda url: url.rstrip("/"), resource.urls)
         dependencies = self._container.resolve_dependencies(resource)
         self._api.add_resource(resource, *resource.urls, resource_class_args=dependencies)
 

--- a/monkey/monkey_island/cc/resources/propagation_credentials.py
+++ b/monkey/monkey_island/cc/resources/propagation_credentials.py
@@ -11,7 +11,7 @@ _stolen_collection = "stolen-credentials"
 
 
 class PropagationCredentials(AbstractResource):
-    urls = ["/api/propagation-credentials/", "/api/propagation-credentials/<string:collection>"]
+    urls = ["/api/propagation-credentials", "/api/propagation-credentials/<string:collection>"]
 
     def __init__(self, credentials_repository: ICredentialsRepository):
         self._credentials_repository = credentials_repository

--- a/monkey/tests/unit_tests/monkey_island/cc/resources/test_propagation_credentials.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/resources/test_propagation_credentials.py
@@ -22,8 +22,8 @@ from monkey_island.cc.resources.propagation_credentials import (
 )
 
 ALL_CREDENTIALS_URL = PropagationCredentials.urls[0]
-CONFIGURED_CREDENTIALS_URL = urljoin(ALL_CREDENTIALS_URL, _configured_collection)
-STOLEN_CREDENTIALS_URL = urljoin(ALL_CREDENTIALS_URL, _stolen_collection)
+CONFIGURED_CREDENTIALS_URL = urljoin(ALL_CREDENTIALS_URL + "/", _configured_collection)
+STOLEN_CREDENTIALS_URL = urljoin(ALL_CREDENTIALS_URL + "/", _stolen_collection)
 
 
 @pytest.fixture
@@ -105,7 +105,7 @@ def test_all_propagation_credentials_endpoint__put_not_allowed(flask_client):
     assert resp.status_code == HTTPStatus.METHOD_NOT_ALLOWED
 
 
-NON_EXISTENT_COLLECTION_URL = urljoin(ALL_CREDENTIALS_URL, "bogus-credentials")
+NON_EXISTENT_COLLECTION_URL = urljoin(ALL_CREDENTIALS_URL + "/", "bogus-credentials")
 
 
 def test_propagation_credentials_endpoint__get_not_found(flask_client):

--- a/monkey/tests/unit_tests/monkey_island/cc/test_app.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/test_app.py
@@ -81,3 +81,11 @@ def test_url_check_slash_stripping__path_separation(resource_manager):
     # Following shouldn't raise and exception
     resource_manager.add_resource(resource3)
     resource_manager.add_resource(resource4)
+
+
+def test_trailing_slash_removal(resource_manager):
+    bogus_endpoint = "/beef/face"
+    resource3 = get_mock_resource("res3", [f"{bogus_endpoint}/"])
+    resource_manager.add_resource(resource3)
+    registered_rules = resource_manager._api.app.url_map._rules
+    assert any([rule.rule == bogus_endpoint for rule in registered_rules])

--- a/monkey/tests/unit_tests/monkey_island/cc/test_app.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/test_app.py
@@ -75,7 +75,7 @@ def test_url_check_slash_stripping__trailing_slash(resource_manager):
 
 
 def test_url_check_slash_stripping__path_separation(resource_manager):
-    resource3 = get_mock_resource("res3", ["/beef/face/"])
+    resource3 = get_mock_resource("res3", ["/beef/face"])
     resource4 = get_mock_resource("res4", ["/beefface"])
 
     # Following shouldn't raise and exception
@@ -83,9 +83,8 @@ def test_url_check_slash_stripping__path_separation(resource_manager):
     resource_manager.add_resource(resource4)
 
 
-def test_trailing_slash_removal(resource_manager):
-    bogus_endpoint = "/beef/face"
-    resource3 = get_mock_resource("res3", [f"{bogus_endpoint}/"])
-    resource_manager.add_resource(resource3)
-    registered_rules = resource_manager._api.app.url_map._rules
-    assert any([rule.rule == bogus_endpoint for rule in registered_rules])
+def test_trailing_slash_enforcement(resource_manager):
+    bad_endpoint = "/beef/face/"
+    with pytest.raises(ValueError):
+        resource3 = get_mock_resource("res3", [f"{bad_endpoint}"])
+        resource_manager.add_resource(resource3)


### PR DESCRIPTION
Strict slashes seems to not handle a case when URL is defined with a trailing slash, but request is sent without one. Removing trailing slashes before registering a URL will solve the burden of remembering to register URLS without slashes

# What does this PR do?

Fixes the 404 in  #2191

Add any further explanations here.

## PR Checklist
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running the Agent
