### PR TITLE
Agent: Fix credentials repository return value

### DIFF
--- a/monkey/tests/unit_tests/infection_monkey/credential_store/test_aggregating_propagation_credentials_repository.py
+++ b/monkey/tests/unit_tests/infection_monkey/credential_store/test_aggregating_propagation_credentials_repository.py
@@ -122,3 +122,16 @@ def test_all_keys_if_credentials_empty():
     assert "exploit_password_list" in actual_stored_credentials
     assert "exploit_ntlm_hash_list" in actual_stored_credentials
     assert "exploit_ssh_keys" in actual_stored_credentials
+
+
+def test_credentials_obtained_if_propagation_credentials_fails():
+    control_channel = MagicMock()
+    control_channel.get_credentials_for_propagation.return_value = EMPTY_CHANNEL_CREDENTIALS
+    control_channel.get_credentials_for_propagation.side_effect = Exception(
+        "No credentials for you!"
+    )
+    credentials_repository = AggregatingPropagationCredentialsRepository(control_channel)
+
+    credentials = credentials_repository.get_credentials()
+
+    assert credentials is not None


### PR DESCRIPTION
# What does this PR do?

The AggregatingPropagationCredentialsRepository would clear the repository and return None if it failed to get credentials from the Island. It has been updated so that the repository is no longer cleared, and it will return its stored credentials even if it fails to retrieve any from the Island.

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Have you successfully tested your changes locally? Elaborate:
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
