### PR TITLE
Island: Don't drop collections that starts with "config"

### DIFF
--- a/monkey/monkey_island/cc/services/database.py
+++ b/monkey/monkey_island/cc/services/database.py
@@ -36,6 +36,7 @@ class Database(object):
         return (
             not collection.startswith("system.")
             and not collection == AttackMitigations.COLLECTION_NAME
+            and not collection.startswith("config")
         )
 
     @staticmethod


### PR DESCRIPTION
Also fix one type annotation because of mypy

# What does this PR do?

Fixes #2210 

We have condition where we check which collections should be dropped. That condition was causing configured credentials to be deleted. I added another condition that it will not drop anything that starts with "config"

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Have you successfully tested your changes locally? Elaborate:
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
