### PR TITLE
2218 get network interfaces

### DIFF
--- a/monkey/infection_monkey/master/automated_master.py
+++ b/monkey/infection_monkey/master/automated_master.py
@@ -2,7 +2,7 @@ import logging
 import threading
 import time
 from ipaddress import IPv4Interface
-from typing import Any, Callable, Iterable, List, Optional
+from typing import Any, Callable, Collection, List, Optional
 
 from common.agent_configuration import CustomPBAConfiguration, PluginConfiguration
 from common.utils import Timer
@@ -206,7 +206,7 @@ class AutomatedMaster(IMaster):
 
     def _run_pbas(
         self,
-        plugins: Iterable[PluginConfiguration],
+        plugins: Collection[PluginConfiguration],
         callback: Callable[[Any], None],
         custom_pba_options: CustomPBAConfiguration,
     ):
@@ -221,7 +221,7 @@ class AutomatedMaster(IMaster):
 
     def _run_plugins(
         self,
-        plugins: Iterable[PluginConfiguration],
+        plugins: Collection[PluginConfiguration],
         plugin_type: str,
         callback: Callable[[Any], None],
     ):

--- a/monkey/infection_monkey/master/ip_scanner.py
+++ b/monkey/infection_monkey/master/ip_scanner.py
@@ -41,7 +41,7 @@ class IPScanner:
     ):
         # Pre-fill a Queue with all IPs to scan so that threads know they can safely exit when the
         # queue is empty.
-        addresses = Queue()
+        addresses: Queue = Queue()
         for address in addresses_to_scan:
             addresses.put(address)
 

--- a/monkey/infection_monkey/master/propagator.py
+++ b/monkey/infection_monkey/master/propagator.py
@@ -45,7 +45,7 @@ class Propagator:
         self._exploiter = exploiter
         self._victim_host_factory = victim_host_factory
         self._local_network_interfaces = local_network_interfaces
-        self._hosts_to_exploit = None
+        self._hosts_to_exploit: Queue = Queue()
 
     def propagate(
         self, propagation_config: PropagationConfiguration, current_depth: int, stop: Event

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -41,7 +41,7 @@ from infection_monkey.master import AutomatedMaster
 from infection_monkey.master.control_channel import ControlChannel
 from infection_monkey.model import VictimHostFactory
 from infection_monkey.network.firewall import app as firewall
-from infection_monkey.network.info import get_local_network_interfaces
+from infection_monkey.network.info import get_network_interfaces
 from infection_monkey.network_scanning.elasticsearch_fingerprinter import ElasticSearchFingerprinter
 from infection_monkey.network_scanning.http_fingerprinter import HTTPFingerprinter
 from infection_monkey.network_scanning.mssql_fingerprinter import MSSQLFingerprinter
@@ -240,7 +240,7 @@ class InfectionMonkey:
 
     @staticmethod
     def _get_local_network_interfaces() -> List[IPv4Interface]:
-        local_network_interfaces = get_local_network_interfaces()
+        local_network_interfaces = get_network_interfaces()
         for interface in local_network_interfaces:
             logger.debug(f"Found local interface {str(interface)}")
 

--- a/monkey/infection_monkey/network/info.py
+++ b/monkey/infection_monkey/network/info.py
@@ -26,10 +26,6 @@ class NetworkAddress:
 
 
 def get_network_interfaces() -> List[IPv4Interface]:
-    return get_local_network_interfaces()
-
-
-def get_local_network_interfaces() -> List[IPv4Interface]:
     return [IPv4Interface(f"{i['addr']}/{i['netmask']}") for i in get_host_subnets()]
 
 

--- a/monkey/infection_monkey/network/info.py
+++ b/monkey/infection_monkey/network/info.py
@@ -25,6 +25,10 @@ class NetworkAddress:
     domain: str
 
 
+def get_network_interfaces() -> List[IPv4Interface]:
+    return get_local_network_interfaces()
+
+
 def get_local_network_interfaces() -> List[IPv4Interface]:
     return [IPv4Interface(f"{i['addr']}/{i['netmask']}") for i in get_host_subnets()]
 


### PR DESCRIPTION
# What does this PR do?

Fixes #2218.

Renames `get_local_network_interfaces()` to `get_network_interfaces()` and adds it to the `AgentRegistrationData`.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing?
* [ ] ~~Was the CHANGELOG.md updated to reflect the changes?~~
* [ ] ~~Was the documentation framework updated to reflect the changes?~~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~~Added relevant unit tests?~~
* [ ] Have you successfully tested your changes locally? Elaborate:
    > I tested the call on Windows to ensure that it runs correctly
* [x] If applicable, add screenshots or log transcripts of the feature working
![Screen Shot 2022-08-31 at 11 26 17 AM](https://user-images.githubusercontent.com/11077625/187720533-b164a40b-435f-44f3-a622-a819eca0a45d.jpg)
![Screen Shot 2022-08-31 at 11 28 40 AM](https://user-images.githubusercontent.com/11077625/187720548-733ef294-0d16-4940-bb76-474259dc5d48.jpg)

