### PR TITLE
Agent: Add relay to servers list for exploited hosts

### DIFF
--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -40,7 +40,7 @@ from infection_monkey.master import AutomatedMaster
 from infection_monkey.master.control_channel import ControlChannel
 from infection_monkey.model import VictimHostFactory
 from infection_monkey.network.firewall import app as firewall
-from infection_monkey.network.info import get_free_tcp_port, get_network_interfaces
+from infection_monkey.network.info import get_free_tcp_port, get_network_interfaces, local_ips
 from infection_monkey.network.relay import TCPRelay
 from infection_monkey.network.relay.utils import (
     find_server,
@@ -192,6 +192,7 @@ class InfectionMonkey:
             int(self._cmd_island_port),
             client_disconnect_timeout=config.keep_tunnel_open_time,
         )
+        relay_servers = [f"{ip}:{relay_port}" for ip in local_ips()]
 
         if not maximum_depth_reached(config.propagation.maximum_depth, self._current_depth):
             self._relay.start()
@@ -199,11 +200,11 @@ class InfectionMonkey:
         StateTelem(is_done=False, version=get_version()).send()
         TunnelTelem(self._control_client.proxies).send()
 
-        self._build_master()
+        self._build_master(relay_servers)
 
         register_signal_handlers(self._master)
 
-    def _build_master(self):
+    def _build_master(self, relay_servers: List[str]):
         local_network_interfaces = InfectionMonkey._get_local_network_interfaces()
 
         # TODO control_channel and control_client have same responsibilities, merge them
@@ -227,7 +228,7 @@ class InfectionMonkey:
 
         self._master = AutomatedMaster(
             self._current_depth,
-            self._opts.servers,
+            self._opts.servers + relay_servers,
             puppet,
             telemetry_messenger,
             victim_host_factory,


### PR DESCRIPTION
# What does this PR do?

Fixes part of #2216.

The exploited machines need to be given the relay connection details in case they can't communicate with the server.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~~Was the CHANGELOG.md updated to reflect the changes?~~
* [ ] ~~Was the documentation framework updated to reflect the changes?~~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~~Added relevant unit tests?~~
* [ ] Have you successfully tested your changes locally? Elaborate:
    > Tested by running the Monkey in the zoo and verifying that the server list is updated
* [ ] If applicable, add screenshots or log transcripts of the feature working
