### PR TITLE
2180 mongo event repository

### DIFF
--- a/monkey/monkey_island/cc/repository/__init__.py
+++ b/monkey/monkey_island/cc/repository/__init__.py
@@ -27,3 +27,4 @@ from .mongo_machine_repository import MongoMachineRepository
 from .mongo_agent_repository import MongoAgentRepository
 from .mongo_node_repository import MongoNodeRepository
 from .stubbed_event_repository import StubbedEventRepository
+from .mongo_event_repository import MongoEventRepository

--- a/monkey/monkey_island/cc/repository/mongo_event_repository.py
+++ b/monkey/monkey_island/cc/repository/mongo_event_repository.py
@@ -64,5 +64,5 @@ class MongoEventRepository(IEventRepository):
         return serializer.deserialize(mongo_record)
 
     def _query_events(self, query: Dict[Any, Any]) -> Sequence[AbstractAgentEvent]:
-        serialized_events = list(self._events_collection.find(query, {MONGO_OBJECT_ID_KEY: False}))
+        serialized_events = self._events_collection.find(query, {MONGO_OBJECT_ID_KEY: False})
         return list(map(self._deserialize, serialized_events))

--- a/monkey/monkey_island/cc/repository/mongo_event_repository.py
+++ b/monkey/monkey_island/cc/repository/mongo_event_repository.py
@@ -1,0 +1,52 @@
+from typing import Sequence, Type
+
+from pymongo import MongoClient
+
+from common.events import AbstractAgentEvent
+from common.types import AgentID
+from monkey_island.cc.repository import IEventRepository
+
+from . import RemovalError, RetrievalError, StorageError
+
+
+class MongoEventRepository(IEventRepository):
+    def __init__(self, mongo_client: MongoClient):
+        self._events_collection = mongo_client.monkey_island.events
+
+    def save_event(self, event: AbstractAgentEvent):
+        try:
+            self._events_collection.insert_one(event.dict(simplify=True))
+        except Exception as err:
+            raise StorageError(err)
+
+    def get_events(self) -> Sequence[AbstractAgentEvent]:
+        try:
+            return list(self._events_collection.find())
+        except Exception as err:
+            raise RetrievalError(f"Error retrieving events: {err}")
+
+    def get_events_by_type(
+        self, event_type: Type[AbstractAgentEvent]
+    ) -> Sequence[AbstractAgentEvent]:
+        try:
+            return []
+        except Exception as err:
+            raise RetrievalError(f"Error retrieving events for type {event_type}: {err}")
+
+    def get_events_by_tag(self, tag: str) -> Sequence[AbstractAgentEvent]:
+        try:
+            return list(self._events_collection.find({"tags": {"$in": [tag]}}))
+        except Exception as err:
+            raise RetrievalError(f"Error retrieving events for tag {tag}: {err}")
+
+    def get_events_by_source(self, source: AgentID) -> Sequence[AbstractAgentEvent]:
+        try:
+            return list(self._events_collection.find({"source": source}))
+        except Exception as err:
+            raise RetrievalError(f"Error retrieving events for source {source}: {err}")
+
+    def reset(self):
+        try:
+            self._events_collection.drop()
+        except Exception as err:
+            raise RemovalError(f"Error resetting the repository: {err}")

--- a/monkey/monkey_island/cc/repository/mongo_event_repository.py
+++ b/monkey/monkey_island/cc/repository/mongo_event_repository.py
@@ -12,6 +12,8 @@ from .consts import MONGO_OBJECT_ID_KEY
 
 
 class MongoEventRepository(IEventRepository):
+    """A repository for storing and retrieving events in MongoDB"""
+
     def __init__(self, mongo_client: MongoClient, serializer_registry: EventSerializerRegistry):
         self._events_collection = mongo_client.monkey_island.events
         self._serializers = serializer_registry

--- a/monkey/monkey_island/cc/repository/mongo_event_repository.py
+++ b/monkey/monkey_island/cc/repository/mongo_event_repository.py
@@ -1,27 +1,33 @@
-from typing import Sequence, Type
+from typing import Any, MutableMapping, Sequence, Type
 
 from pymongo import MongoClient
 
+from common.event_serializers import EVENT_TYPE_FIELD, EventSerializerRegistry
 from common.events import AbstractAgentEvent
 from common.types import AgentID
 from monkey_island.cc.repository import IEventRepository
 
 from . import RemovalError, RetrievalError, StorageError
+from .consts import MONGO_OBJECT_ID_KEY
 
 
 class MongoEventRepository(IEventRepository):
-    def __init__(self, mongo_client: MongoClient):
+    def __init__(self, mongo_client: MongoClient, serializer_registry: EventSerializerRegistry):
         self._events_collection = mongo_client.monkey_island.events
+        self._serializers = serializer_registry
 
     def save_event(self, event: AbstractAgentEvent):
         try:
-            self._events_collection.insert_one(event.dict(simplify=True))
+            serializer = self._serializers[type(event)]
+            serialized_event = serializer.serialize(event)
+            self._events_collection.insert_one(serialized_event)
         except Exception as err:
             raise StorageError(err)
 
     def get_events(self) -> Sequence[AbstractAgentEvent]:
         try:
-            return list(self._events_collection.find())
+            serialized_events = list(self._events_collection.find())
+            return list(map(self._deserialize, serialized_events))
         except Exception as err:
             raise RetrievalError(f"Error retrieving events: {err}")
 
@@ -29,19 +35,22 @@ class MongoEventRepository(IEventRepository):
         self, event_type: Type[AbstractAgentEvent]
     ) -> Sequence[AbstractAgentEvent]:
         try:
-            return []
+            serialized_events = list(self._events_collection.find({EVENT_TYPE_FIELD: event_type}))
+            return list(map(self._deserialize, serialized_events))
         except Exception as err:
             raise RetrievalError(f"Error retrieving events for type {event_type}: {err}")
 
     def get_events_by_tag(self, tag: str) -> Sequence[AbstractAgentEvent]:
         try:
-            return list(self._events_collection.find({"tags": {"$in": [tag]}}))
+            serialized_events = list(self._events_collection.find({"tags": {"$in": [tag]}}))
+            return list(map(self._deserialize, serialized_events))
         except Exception as err:
             raise RetrievalError(f"Error retrieving events for tag {tag}: {err}")
 
     def get_events_by_source(self, source: AgentID) -> Sequence[AbstractAgentEvent]:
         try:
-            return list(self._events_collection.find({"source": source}))
+            serialized_events = list(self._events_collection.find({"source": source}))
+            return list(map(self._deserialize, serialized_events))
         except Exception as err:
             raise RetrievalError(f"Error retrieving events for source {source}: {err}")
 
@@ -50,3 +59,9 @@ class MongoEventRepository(IEventRepository):
             self._events_collection.drop()
         except Exception as err:
             raise RemovalError(f"Error resetting the repository: {err}")
+
+    def _deserialize(self, mongo_record: MutableMapping[str, Any]) -> AbstractAgentEvent:
+        del mongo_record[MONGO_OBJECT_ID_KEY]
+        event_type = mongo_record[EVENT_TYPE_FIELD]
+        serializer = self._serializers[event_type]
+        return serializer.deserialize(mongo_record)

--- a/monkey/monkey_island/cc/repository/mongo_event_repository.py
+++ b/monkey/monkey_island/cc/repository/mongo_event_repository.py
@@ -35,7 +35,9 @@ class MongoEventRepository(IEventRepository):
         self, event_type: Type[AbstractAgentEvent]
     ) -> Sequence[AbstractAgentEvent]:
         try:
-            serialized_events = list(self._events_collection.find({EVENT_TYPE_FIELD: event_type}))
+            serialized_events = list(
+                self._events_collection.find({EVENT_TYPE_FIELD: event_type.__name__})
+            )
             return list(map(self._deserialize, serialized_events))
         except Exception as err:
             raise RetrievalError(f"Error retrieving events for type {event_type}: {err}")

--- a/monkey/monkey_island/cc/repository/mongo_event_repository.py
+++ b/monkey/monkey_island/cc/repository/mongo_event_repository.py
@@ -24,7 +24,7 @@ class MongoEventRepository(IEventRepository):
             serialized_event = serializer.serialize(event)
             self._events_collection.insert_one(serialized_event)
         except Exception as err:
-            raise StorageError(err)
+            raise StorageError(f"Error saving event: {err}")
 
     def get_events(self) -> Sequence[AbstractAgentEvent]:
         try:

--- a/monkey/monkey_island/cc/repository/mongo_event_repository.py
+++ b/monkey/monkey_island/cc/repository/mongo_event_repository.py
@@ -51,7 +51,7 @@ class MongoEventRepository(IEventRepository):
 
     def get_events_by_source(self, source: AgentID) -> Sequence[AbstractAgentEvent]:
         try:
-            serialized_events = list(self._events_collection.find({"source": source}))
+            serialized_events = list(self._events_collection.find({"source": str(source)}))
             return list(map(self._deserialize, serialized_events))
         except Exception as err:
             raise RetrievalError(f"Error retrieving events for source {source}: {err}")

--- a/monkey/tests/unit_tests/monkey_island/cc/repository/test_mongo_event_repository.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/repository/test_mongo_event_repository.py
@@ -1,0 +1,159 @@
+import uuid
+from typing import List
+from unittest.mock import MagicMock
+
+import mongomock
+import pytest
+
+from monkey.common.events.abstract_agent_event import AbstractAgentEvent
+from monkey.monkey_island.cc.repository import (
+    IEventRepository,
+    MongoEventRepository,
+    RemovalError,
+    RetrievalError,
+    StorageError,
+)
+
+
+class FakeAgentEvent(AbstractAgentEvent):
+    item: str
+
+
+EVENTS: List[AbstractAgentEvent] = [
+    AbstractAgentEvent(source=uuid.uuid4(), tags={"foo"}),
+    AbstractAgentEvent(source=uuid.uuid4(), tags={"foo", "bar"}),
+    AbstractAgentEvent(source=uuid.uuid4(), tags={"bar", "baz"}),
+    FakeAgentEvent(source=uuid.uuid4(), tags={"baz"}, item="blah"),
+]
+
+
+@pytest.fixture
+def mongo_client():
+    client = mongomock.MongoClient()
+    client.monkey_island.events.insert_many((e.dict(simplify=True) for e in EVENTS))
+    return client
+
+
+@pytest.fixture
+def mongo_repository(mongo_client) -> IEventRepository:
+    return MongoEventRepository(mongo_client)
+
+
+@pytest.fixture
+def error_raising_mongo_client(mongo_client) -> mongomock.MongoClient:
+    mongo_client = MagicMock(spec=mongomock.MongoClient)
+    mongo_client.monkey_island = MagicMock(spec=mongomock.Database)
+    mongo_client.monkey_island.events = MagicMock(spec=mongomock.Collection)
+
+    # The first call to find() must succeed
+    mongo_client.monkey_island.events.find = MagicMock(
+        # side_effect=chain([MagicMock()], repeat(Exception("some exception")))
+        side_effect=Exception("some exception")
+    )
+    mongo_client.monkey_island.events.find_one = MagicMock(side_effect=Exception("some exception"))
+    mongo_client.monkey_island.events.insert_one = MagicMock(
+        side_effect=Exception("some exception")
+    )
+    mongo_client.monkey_island.events.replace_one = MagicMock(
+        side_effect=Exception("some exception")
+    )
+    mongo_client.monkey_island.events.drop = MagicMock(side_effect=Exception("some exception"))
+
+    return mongo_client
+
+
+@pytest.fixture
+def error_raising_mongo_repository(error_raising_mongo_client) -> IEventRepository:
+    return MongoEventRepository(error_raising_mongo_client)
+
+
+def assert_same_contents(a, b):
+    assert len(a) == len(b)
+    difference = set(a) ^ set(b)
+    assert not difference
+
+
+def test_mongo_event_repository__save_event(mongo_repository: IEventRepository):
+    event = AbstractAgentEvent(source=uuid.uuid4())
+    mongo_repository.save_event(event)
+    events = mongo_repository.get_events()
+
+    assert event in events
+
+
+def test_mongo_event_repository__save_event_raises(
+    error_raising_mongo_repository: IEventRepository,
+):
+    event = AbstractAgentEvent(source=uuid.uuid4())
+
+    with pytest.raises(StorageError):
+        error_raising_mongo_repository.save_event(event)
+
+
+def test_mongo_event_repository__get_events(mongo_repository: IEventRepository):
+    events = mongo_repository.get_events()
+
+    assert_same_contents(events, EVENTS)
+
+
+def test_mongo_event_repository__get_events_raises(
+    error_raising_mongo_repository: IEventRepository,
+):
+    with pytest.raises(RetrievalError):
+        error_raising_mongo_repository.get_events()
+
+
+def test_mongo_event_repository__get_events_by_type(mongo_repository: IEventRepository):
+    events = mongo_repository.get_events_by_type(FakeAgentEvent)
+
+    expected_events = [EVENTS[3]]
+    assert_same_contents(events, expected_events)
+
+
+def test_mongo_event_repository__get_events_by_type_raises(
+    error_raising_mongo_repository: IEventRepository,
+):
+    with pytest.raises(RetrievalError):
+        error_raising_mongo_repository.get_events_by_type(FakeAgentEvent)
+
+
+def test_mongo_event_repository__get_events_by_tag(mongo_repository: IEventRepository):
+    events = mongo_repository.get_events_by_tag("bar")
+
+    expected_events = [EVENTS[1], EVENTS[2]]
+    assert_same_contents(events, expected_events)
+
+
+def test_mongo_event_repository__get_events_by_tag_raises(
+    error_raising_mongo_repository: IEventRepository,
+):
+    with pytest.raises(RetrievalError):
+        error_raising_mongo_repository.get_events_by_tag("bar")
+
+
+def test_mongo_event_repository__get_events_by_source(mongo_repository: IEventRepository):
+    source_event = EVENTS[2]
+    events = mongo_repository.get_events_by_source(source_event.source)
+
+    expected_events = [source_event]
+    assert_same_contents(events, expected_events)
+
+
+def test_mongo_event_repository__get_events_by_source_raises(
+    error_raising_mongo_repository: IEventRepository,
+):
+    with pytest.raises(RetrievalError):
+        source_event = EVENTS[2]
+        error_raising_mongo_repository.get_events_by_source(source_event.source)
+
+
+def test_mongo_event_repository__reset(mongo_repository: IEventRepository):
+    mongo_repository.reset()
+    events = mongo_repository.get_events()
+
+    assert not events
+
+
+def test_mongo_event_repository__reset_raises(error_raising_mongo_repository: IEventRepository):
+    with pytest.raises(RemovalError):
+        error_raising_mongo_repository.reset()

--- a/monkey/tests/unit_tests/monkey_island/cc/repository/test_mongo_event_repository.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/repository/test_mongo_event_repository.py
@@ -61,16 +61,8 @@ def error_raising_mongo_client(mongo_client) -> mongomock.MongoClient:
     mongo_client.monkey_island = MagicMock(spec=mongomock.Database)
     mongo_client.monkey_island.events = MagicMock(spec=mongomock.Collection)
 
-    # The first call to find() must succeed
-    mongo_client.monkey_island.events.find = MagicMock(
-        # side_effect=chain([MagicMock()], repeat(Exception("some exception")))
-        side_effect=Exception("some exception")
-    )
-    mongo_client.monkey_island.events.find_one = MagicMock(side_effect=Exception("some exception"))
+    mongo_client.monkey_island.events.find = MagicMock(side_effect=Exception("some exception"))
     mongo_client.monkey_island.events.insert_one = MagicMock(
-        side_effect=Exception("some exception")
-    )
-    mongo_client.monkey_island.events.replace_one = MagicMock(
         side_effect=Exception("some exception")
     )
     mongo_client.monkey_island.events.drop = MagicMock(side_effect=Exception("some exception"))

--- a/monkey/tests/unit_tests/monkey_island/cc/repository/test_mongo_event_repository.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/repository/test_mongo_event_repository.py
@@ -4,9 +4,11 @@ from unittest.mock import MagicMock
 
 import mongomock
 import pytest
+from pydantic import Field
 
-from monkey.common.events.abstract_agent_event import AbstractAgentEvent
-from monkey.monkey_island.cc.repository import (
+from common.event_serializers import EventSerializerRegistry, PydanticEventSerializer
+from common.events import AbstractAgentEvent
+from monkey_island.cc.repository import (
     IEventRepository,
     MongoEventRepository,
     RemovalError,
@@ -16,27 +18,41 @@ from monkey.monkey_island.cc.repository import (
 
 
 class FakeAgentEvent(AbstractAgentEvent):
+    data = Field(default=435)
+
+
+class FakeAgentItemEvent(AbstractAgentEvent):
     item: str
 
 
 EVENTS: List[AbstractAgentEvent] = [
-    AbstractAgentEvent(source=uuid.uuid4(), tags={"foo"}),
-    AbstractAgentEvent(source=uuid.uuid4(), tags={"foo", "bar"}),
-    AbstractAgentEvent(source=uuid.uuid4(), tags={"bar", "baz"}),
-    FakeAgentEvent(source=uuid.uuid4(), tags={"baz"}, item="blah"),
+    FakeAgentEvent(source=uuid.uuid4(), tags={"foo"}),
+    FakeAgentEvent(source=uuid.uuid4(), tags={"foo", "bar"}),
+    FakeAgentEvent(source=uuid.uuid4(), tags={"bar", "baz"}),
+    FakeAgentItemEvent(source=uuid.uuid4(), tags={"baz"}, item="blah"),
 ]
 
 
 @pytest.fixture
-def mongo_client():
+def event_serializer_registry() -> EventSerializerRegistry:
+    registry = EventSerializerRegistry()
+    registry[FakeAgentEvent] = PydanticEventSerializer(FakeAgentEvent)
+    registry[FakeAgentItemEvent] = PydanticEventSerializer(FakeAgentItemEvent)
+    return registry
+
+
+@pytest.fixture
+def mongo_client(event_serializer_registry):
     client = mongomock.MongoClient()
-    client.monkey_island.events.insert_many((e.dict(simplify=True) for e in EVENTS))
+    client.monkey_island.events.insert_many(
+        (event_serializer_registry[type(e)].serialize(e) for e in EVENTS)
+    )
     return client
 
 
 @pytest.fixture
-def mongo_repository(mongo_client) -> IEventRepository:
-    return MongoEventRepository(mongo_client)
+def mongo_repository(mongo_client, event_serializer_registry) -> IEventRepository:
+    return MongoEventRepository(mongo_client, event_serializer_registry)
 
 
 @pytest.fixture
@@ -63,18 +79,20 @@ def error_raising_mongo_client(mongo_client) -> mongomock.MongoClient:
 
 
 @pytest.fixture
-def error_raising_mongo_repository(error_raising_mongo_client) -> IEventRepository:
-    return MongoEventRepository(error_raising_mongo_client)
+def error_raising_mongo_repository(
+    error_raising_mongo_client, event_serializer_registry
+) -> IEventRepository:
+    return MongoEventRepository(error_raising_mongo_client, event_serializer_registry)
 
 
 def assert_same_contents(a, b):
     assert len(a) == len(b)
-    difference = set(a) ^ set(b)
-    assert not difference
+    for item in a:
+        assert item in b
 
 
 def test_mongo_event_repository__save_event(mongo_repository: IEventRepository):
-    event = AbstractAgentEvent(source=uuid.uuid4())
+    event = FakeAgentEvent(source=uuid.uuid4())
     mongo_repository.save_event(event)
     events = mongo_repository.get_events()
 
@@ -84,7 +102,7 @@ def test_mongo_event_repository__save_event(mongo_repository: IEventRepository):
 def test_mongo_event_repository__save_event_raises(
     error_raising_mongo_repository: IEventRepository,
 ):
-    event = AbstractAgentEvent(source=uuid.uuid4())
+    event = FakeAgentEvent(source=uuid.uuid4())
 
     with pytest.raises(StorageError):
         error_raising_mongo_repository.save_event(event)
@@ -104,7 +122,7 @@ def test_mongo_event_repository__get_events_raises(
 
 
 def test_mongo_event_repository__get_events_by_type(mongo_repository: IEventRepository):
-    events = mongo_repository.get_events_by_type(FakeAgentEvent)
+    events = mongo_repository.get_events_by_type(FakeAgentItemEvent)
 
     expected_events = [EVENTS[3]]
     assert_same_contents(events, expected_events)
@@ -114,7 +132,7 @@ def test_mongo_event_repository__get_events_by_type_raises(
     error_raising_mongo_repository: IEventRepository,
 ):
     with pytest.raises(RetrievalError):
-        error_raising_mongo_repository.get_events_by_type(FakeAgentEvent)
+        error_raising_mongo_repository.get_events_by_type(FakeAgentItemEvent)
 
 
 def test_mongo_event_repository__get_events_by_tag(mongo_repository: IEventRepository):

--- a/monkey/tests/unit_tests/monkey_island/cc/repository/test_mongo_event_repository.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/repository/test_mongo_event_repository.py
@@ -158,6 +158,9 @@ def test_mongo_event_repository__get_events_by_source_raises(
 
 
 def test_mongo_event_repository__reset(mongo_repository: IEventRepository):
+    initial_events = mongo_repository.get_events()
+    assert initial_events
+
     mongo_repository.reset()
     events = mongo_repository.get_events()
 

--- a/vulture_allowlist.py
+++ b/vulture_allowlist.py
@@ -312,6 +312,7 @@ IEventRepository.save_event
 IEventRepository.get_events_by_type
 IEventRepository.get_events_by_tag
 IEventRepository.get_events_by_source
+MongoEventRepository
 
 
 # pydantic base models


### PR DESCRIPTION
# What does this PR do?

Fixes part of  #2180.

Add a repository for storing events in MongoDB.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~~Was the CHANGELOG.md updated to reflect the changes?~~
* [ ] ~~Was the documentation framework updated to reflect the changes?~~
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Just ran the unit tests
* [ ] ~~If applicable, add screenshots or log transcripts of the feature working~~
