### PR TITLE
Use HTTPIslandAPIClient in ControlClient

### DIFF
--- a/monkey/infection_monkey/control.py
+++ b/monkey/infection_monkey/control.py
@@ -6,7 +6,7 @@ from socket import gethostname
 import requests
 from urllib3 import disable_warnings
 
-from common.common_consts.timeouts import LONG_REQUEST_TIMEOUT, MEDIUM_REQUEST_TIMEOUT
+from common.common_consts.timeouts import MEDIUM_REQUEST_TIMEOUT
 from common.network.network_utils import get_my_ip_addresses
 from infection_monkey.config import GUID
 from infection_monkey.island_api_client import HTTPIslandAPIClient
@@ -16,8 +16,6 @@ from infection_monkey.utils import agent_process
 disable_warnings()  # noqa DUO131
 
 logger = logging.getLogger(__name__)
-
-PBA_FILE_DOWNLOAD = "https://%s/api/pba/download/%s"
 
 
 class ControlClient:
@@ -85,10 +83,6 @@ class ControlClient:
 
     def get_pba_file(self, filename):
         try:
-            return requests.get(  # noqa: DUO123
-                PBA_FILE_DOWNLOAD % (self.server_address, filename),
-                verify=False,
-                timeout=LONG_REQUEST_TIMEOUT,
-            )
+            HTTPIslandAPIClient(self.server_address).get_pba_file(filename)
         except requests.exceptions.RequestException:
             return False

--- a/monkey/infection_monkey/control.py
+++ b/monkey/infection_monkey/control.py
@@ -9,6 +9,7 @@ from urllib3 import disable_warnings
 from common.common_consts.timeouts import LONG_REQUEST_TIMEOUT, MEDIUM_REQUEST_TIMEOUT
 from common.network.network_utils import get_my_ip_addresses
 from infection_monkey.config import GUID
+from infection_monkey.island_api_client import HTTPIslandAPIClient
 from infection_monkey.network.info import get_host_subnets
 from infection_monkey.utils import agent_process
 
@@ -78,13 +79,7 @@ class ControlClient:
             return
         try:
             telemetry = {"monkey_guid": GUID, "log": json.dumps(log)}
-            requests.post(  # noqa: DUO123
-                "https://%s/api/log" % (self.server_address,),
-                data=json.dumps(telemetry),
-                headers={"content-type": "application/json"},
-                verify=False,
-                timeout=MEDIUM_REQUEST_TIMEOUT,
-            )
+            HTTPIslandAPIClient(self.server_address).send_log(json.dumps(telemetry))
         except Exception as exc:
             logger.warning(f"Error connecting to control server {self.server_address}: {exc}")
 

--- a/monkey/infection_monkey/control.py
+++ b/monkey/infection_monkey/control.py
@@ -78,7 +78,7 @@ class ControlClient:
             return
         try:
             telemetry = {"monkey_guid": GUID, "log": json.dumps(log)}
-            HTTPIslandAPIClient.send_log(self.server_address, json.dumps(telemetry))
+            self._island_api_client.send_log(json.dumps(telemetry))
         except Exception as exc:
             logger.warning(f"Error connecting to control server {self.server_address}: {exc}")
 

--- a/monkey/infection_monkey/control.py
+++ b/monkey/infection_monkey/control.py
@@ -9,7 +9,7 @@ from urllib3 import disable_warnings
 from common.common_consts.timeouts import MEDIUM_REQUEST_TIMEOUT
 from common.network.network_utils import get_my_ip_addresses
 from infection_monkey.config import GUID
-from infection_monkey.island_api_client import HTTPIslandAPIClient
+from infection_monkey.island_api_client import HTTPIslandAPIClient, IIslandAPIClient
 from infection_monkey.network.info import get_host_subnets
 from infection_monkey.utils import agent_process
 
@@ -24,8 +24,9 @@ class ControlClient:
     # https://github.com/guardicore/monkey/blob/133f7f5da131b481561141171827d1f9943f6aec/monkey/infection_monkey/telemetry/base_telem.py
     control_client_object = None
 
-    def __init__(self, server_address: str):
+    def __init__(self, server_address: str, island_api_client: IIslandAPIClient):
         self.server_address = server_address
+        self._island_api_client = island_api_client
 
     def wakeup(self, parent=None):
         if parent:

--- a/monkey/infection_monkey/control.py
+++ b/monkey/infection_monkey/control.py
@@ -84,5 +84,5 @@ class ControlClient:
     def get_pba_file(self, filename):
         try:
             HTTPIslandAPIClient.get_pba_file(self.server_address, filename)
-        except requests.exceptions.RequestException:
-            return False
+        except Exception as exc:
+            logger.warning(f"Error connecting to control server {self.server_address}: {exc}")

--- a/monkey/infection_monkey/control.py
+++ b/monkey/infection_monkey/control.py
@@ -9,7 +9,7 @@ from urllib3 import disable_warnings
 from common.common_consts.timeouts import MEDIUM_REQUEST_TIMEOUT
 from common.network.network_utils import get_my_ip_addresses
 from infection_monkey.config import GUID
-from infection_monkey.island_api_client import HTTPIslandAPIClient, IIslandAPIClient
+from infection_monkey.island_api_client import IIslandAPIClient
 from infection_monkey.network.info import get_host_subnets
 from infection_monkey.utils import agent_process
 
@@ -84,6 +84,6 @@ class ControlClient:
 
     def get_pba_file(self, filename):
         try:
-            HTTPIslandAPIClient.get_pba_file(self.server_address, filename)
+            return self._island_api_client.get_pba_file(filename)
         except Exception as exc:
             logger.warning(f"Error connecting to control server {self.server_address}: {exc}")

--- a/monkey/infection_monkey/control.py
+++ b/monkey/infection_monkey/control.py
@@ -77,12 +77,12 @@ class ControlClient:
             return
         try:
             telemetry = {"monkey_guid": GUID, "log": json.dumps(log)}
-            HTTPIslandAPIClient(self.server_address).send_log(json.dumps(telemetry))
+            HTTPIslandAPIClient.send_log(self.server_address, json.dumps(telemetry))
         except Exception as exc:
             logger.warning(f"Error connecting to control server {self.server_address}: {exc}")
 
     def get_pba_file(self, filename):
         try:
-            HTTPIslandAPIClient(self.server_address).get_pba_file(filename)
+            HTTPIslandAPIClient.get_pba_file(self.server_address, filename)
         except requests.exceptions.RequestException:
             return False

--- a/monkey/infection_monkey/island_api_client/http_island_api_client.py
+++ b/monkey/infection_monkey/island_api_client/http_island_api_client.py
@@ -37,23 +37,24 @@ class HTTPIslandAPIClient(IIslandAPIClient):
             verify=False,
             timeout=MEDIUM_REQUEST_TIMEOUT,
         )
-        self._island_server = island_server
 
     # TODO: set server address as object property when init is called in find_server and pass
     #       object around? won't need to pass island server and create object in every function
+    @staticmethod
     @handle_island_errors
-    def send_log(self, data: str):
+    def send_log(server_address: str, data: str):
         requests.post(  # noqa: DUO123
-            "https://%s/api/log" % (self._island_server,),
+            "https://%s/api/log" % (server_address,),
             json=data,
             verify=False,
             timeout=MEDIUM_REQUEST_TIMEOUT,
         )
 
+    @staticmethod
     @handle_island_errors
-    def get_pba_file(self, filename: str):
+    def get_pba_file(server_address: str, filename: str):
         return requests.get(  # noqa: DUO123
-            "https://%s/api/pba/download/%s" % (self.server_address, filename),
+            "https://%s/api/pba/download/%s" % (server_address, filename),
             verify=False,
             timeout=LONG_REQUEST_TIMEOUT,
         )

--- a/monkey/infection_monkey/island_api_client/http_island_api_client.py
+++ b/monkey/infection_monkey/island_api_client/http_island_api_client.py
@@ -21,9 +21,20 @@ class HTTPIslandAPIClient(IIslandAPIClient):
                 verify=False,
                 timeout=MEDIUM_REQUEST_TIMEOUT,
             )
+            self._island_server = island_server
         except requests.exceptions.ConnectionError as err:
             raise IslandAPIConnectionError(err)
         except TimeoutError as err:
             raise IslandAPITimeoutError(err)
         except Exception as err:
             raise IslandAPIError(err)
+
+        # TODO: set server address as object property when init is called in find_server and pass
+        #       object around? won't need to pass island server and create object in every function
+        def send_log(self, data: str):
+            requests.post(  # noqa: DUO123
+                "https://%s/api/log" % (self._island_server,),
+                json=data,
+                verify=False,
+                timeout=MEDIUM_REQUEST_TIMEOUT,
+            )

--- a/monkey/infection_monkey/island_api_client/http_island_api_client.py
+++ b/monkey/infection_monkey/island_api_client/http_island_api_client.py
@@ -38,12 +38,13 @@ class HTTPIslandAPIClient(IIslandAPIClient):
             timeout=MEDIUM_REQUEST_TIMEOUT,
         )
 
-    @staticmethod
+        self._island_server = island_server
+
     @handle_island_errors
-    def send_log(server_address: str, data: str):
+    def send_log(self, log_contents: str):
         requests.post(  # noqa: DUO123
-            "https://%s/api/log" % (server_address,),
-            json=data,
+            f"https://{self._island_server}/api/log",
+            json=log_contents,
             verify=False,
             timeout=MEDIUM_REQUEST_TIMEOUT,
         )

--- a/monkey/infection_monkey/island_api_client/http_island_api_client.py
+++ b/monkey/infection_monkey/island_api_client/http_island_api_client.py
@@ -24,19 +24,36 @@ def handle_island_errors(fn):
 
     return decorated
 
-        # TODO: set server address as object property when init is called in find_server and pass
-        #       object around? won't need to pass island server and create object in every function
-        def send_log(self, data: str):
-            requests.post(  # noqa: DUO123
-                "https://%s/api/log" % (self._island_server,),
-                json=data,
-                verify=False,
-                timeout=MEDIUM_REQUEST_TIMEOUT,
-            )
 
-        def get_pba_file(self, filename: str):
-            return requests.get(  # noqa: DUO123
-                "https://%s/api/pba/download/%s" % (self.server_address, filename),
-                verify=False,
-                timeout=LONG_REQUEST_TIMEOUT,
-            )
+class HTTPIslandAPIClient(IIslandAPIClient):
+    """
+    A client for the Island's HTTP API
+    """
+
+    @handle_island_errors
+    def __init__(self, island_server: str):
+        requests.get(  # noqa: DUO123
+            f"https://{island_server}/api?action=is-up",
+            verify=False,
+            timeout=MEDIUM_REQUEST_TIMEOUT,
+        )
+        self._island_server = island_server
+
+    # TODO: set server address as object property when init is called in find_server and pass
+    #       object around? won't need to pass island server and create object in every function
+    @handle_island_errors
+    def send_log(self, data: str):
+        requests.post(  # noqa: DUO123
+            "https://%s/api/log" % (self._island_server,),
+            json=data,
+            verify=False,
+            timeout=MEDIUM_REQUEST_TIMEOUT,
+        )
+
+    @handle_island_errors
+    def get_pba_file(self, filename: str):
+        return requests.get(  # noqa: DUO123
+            "https://%s/api/pba/download/%s" % (self.server_address, filename),
+            verify=False,
+            timeout=LONG_REQUEST_TIMEOUT,
+        )

--- a/monkey/infection_monkey/island_api_client/http_island_api_client.py
+++ b/monkey/infection_monkey/island_api_client/http_island_api_client.py
@@ -49,11 +49,12 @@ class HTTPIslandAPIClient(IIslandAPIClient):
             timeout=MEDIUM_REQUEST_TIMEOUT,
         )
 
-    @staticmethod
     @handle_island_errors
-    def get_pba_file(server_address: str, filename: str):
-        return requests.get(  # noqa: DUO123
-            "https://%s/api/pba/download/%s" % (server_address, filename),
+    def get_pba_file(self, filename: str):
+        response = requests.get(  # noqa: DUO123
+            f"https://{self._island_server}/api/pba/download/{filename}",
             verify=False,
             timeout=LONG_REQUEST_TIMEOUT,
         )
+
+        return response.content

--- a/monkey/infection_monkey/island_api_client/http_island_api_client.py
+++ b/monkey/infection_monkey/island_api_client/http_island_api_client.py
@@ -46,23 +46,25 @@ class HTTPIslandAPIClient(IIslandAPIClient):
 
     @handle_island_errors
     def __init__(self, island_server: str):
-        requests.get(  # noqa: DUO123
+        response = requests.get(  # noqa: DUO123
             f"https://{island_server}/api?action=is-up",
             verify=False,
             timeout=MEDIUM_REQUEST_TIMEOUT,
         )
+        response.raise_for_status()
 
         self._island_server = island_server
         self._api_url = f"https://{self._island_server}/api"
 
     @handle_island_errors
     def send_log(self, log_contents: str):
-        requests.post(  # noqa: DUO123
+        response = requests.post(  # noqa: DUO123
             f"{self._api_url}/log",
             json=log_contents,
             verify=False,
             timeout=MEDIUM_REQUEST_TIMEOUT,
         )
+        response.raise_for_status()
 
     @handle_island_errors
     def get_pba_file(self, filename: str):
@@ -71,5 +73,6 @@ class HTTPIslandAPIClient(IIslandAPIClient):
             verify=False,
             timeout=LONG_REQUEST_TIMEOUT,
         )
+        response.raise_for_status()
 
         return response.content

--- a/monkey/infection_monkey/island_api_client/http_island_api_client.py
+++ b/monkey/infection_monkey/island_api_client/http_island_api_client.py
@@ -39,11 +39,12 @@ class HTTPIslandAPIClient(IIslandAPIClient):
         )
 
         self._island_server = island_server
+        self._api_url = f"https://{self._island_server}/api"
 
     @handle_island_errors
     def send_log(self, log_contents: str):
         requests.post(  # noqa: DUO123
-            f"https://{self._island_server}/api/log",
+            f"{self._api_url}/log",
             json=log_contents,
             verify=False,
             timeout=MEDIUM_REQUEST_TIMEOUT,
@@ -52,7 +53,7 @@ class HTTPIslandAPIClient(IIslandAPIClient):
     @handle_island_errors
     def get_pba_file(self, filename: str):
         response = requests.get(  # noqa: DUO123
-            f"https://{self._island_server}/api/pba/download/{filename}",
+            f"{self._api_url}/pba/download/{filename}",
             verify=False,
             timeout=LONG_REQUEST_TIMEOUT,
         )

--- a/monkey/infection_monkey/island_api_client/http_island_api_client.py
+++ b/monkey/infection_monkey/island_api_client/http_island_api_client.py
@@ -2,7 +2,7 @@ import logging
 
 import requests
 
-from common.common_consts.timeouts import MEDIUM_REQUEST_TIMEOUT
+from common.common_consts.timeouts import LONG_REQUEST_TIMEOUT, MEDIUM_REQUEST_TIMEOUT
 
 from . import IIslandAPIClient, IslandAPIConnectionError, IslandAPIError, IslandAPITimeoutError
 
@@ -37,4 +37,11 @@ class HTTPIslandAPIClient(IIslandAPIClient):
                 json=data,
                 verify=False,
                 timeout=MEDIUM_REQUEST_TIMEOUT,
+            )
+
+        def get_pba_file(self, filename: str):
+            return requests.get(  # noqa: DUO123
+                "https://%s/api/pba/download/%s" % (self.server_address, filename),
+                verify=False,
+                timeout=LONG_REQUEST_TIMEOUT,
             )

--- a/monkey/infection_monkey/island_api_client/http_island_api_client.py
+++ b/monkey/infection_monkey/island_api_client/http_island_api_client.py
@@ -38,8 +38,6 @@ class HTTPIslandAPIClient(IIslandAPIClient):
             timeout=MEDIUM_REQUEST_TIMEOUT,
         )
 
-    # TODO: set server address as object property when init is called in find_server and pass
-    #       object around? won't need to pass island server and create object in every function
     @staticmethod
     @handle_island_errors
     def send_log(server_address: str, data: str):

--- a/monkey/infection_monkey/island_api_client/http_island_api_client.py
+++ b/monkey/infection_monkey/island_api_client/http_island_api_client.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 
 import requests
@@ -9,25 +10,19 @@ from . import IIslandAPIClient, IslandAPIConnectionError, IslandAPIError, Island
 logger = logging.getLogger(__name__)
 
 
-class HTTPIslandAPIClient(IIslandAPIClient):
-    """
-    A client for the Island's HTTP API
-    """
-
-    def __init__(self, island_server: str):
+def handle_island_errors(fn):
+    @functools.wraps(fn)
+    def decorated(*args, **kwargs):
         try:
-            requests.get(  # noqa: DUO123
-                f"https://{island_server}/api?action=is-up",
-                verify=False,
-                timeout=MEDIUM_REQUEST_TIMEOUT,
-            )
-            self._island_server = island_server
+            return fn(*args, **kwargs)
         except requests.exceptions.ConnectionError as err:
             raise IslandAPIConnectionError(err)
         except TimeoutError as err:
             raise IslandAPITimeoutError(err)
         except Exception as err:
             raise IslandAPIError(err)
+
+    return decorated
 
         # TODO: set server address as object property when init is called in find_server and pass
         #       object around? won't need to pass island server and create object in every function

--- a/monkey/infection_monkey/island_api_client/i_island_api_client.py
+++ b/monkey/infection_monkey/island_api_client/i_island_api_client.py
@@ -9,10 +9,14 @@ class IIslandAPIClient(ABC):
     @abstractmethod
     def __init__(self, island_server: str):
         """
-        Construct and island API client and connect it to the island
+        Construct an island API client and connect it to the island
 
         :param island_server: The socket address of the API
         :raises IslandAPIConnectionError: If the client cannot successfully connect to the island
+        :raises IslandAPIRequestError: If an error occurs while attempting to connect to the
+                                       island due to an issue in the request sent from the client
+        :raises IslandAPIRequestFailedError: If an error occurs while attempting to connect to the
+                                             island due to an error on the server
         :raises IslandAPITimeoutError: If a timeout occurs while attempting to connect to the island
         :raises IslandAPIError: If an unexpected error occurs while attempting to connect to the
                                 island
@@ -24,10 +28,13 @@ class IIslandAPIClient(ABC):
         Send the contents of the agent's log to the island
 
         :param log_contents: The contents of the agent's log
-        :raises IslandAPIConnectionError: If a connection cannot be made to the island
+        :raises IslandAPIConnectionError: If the client cannot successfully connect to the island
+        :raises IslandAPIRequestError: If an error occurs while attempting to connect to the
+                                       island due to an issue in the request sent from the client
+        :raises IslandAPIRequestFailedError: If an error occurs while attempting to connect to the
+                                             island due to an error on the server
         :raises IslandAPITimeoutError: If a timeout occurs while attempting to connect to the island
-                                       or send the log contents
-        :raises IslandAPIError: If an unexpected error occurred while attempting to send the
+        :raises IslandAPIError: If an unexpected error occurs while attempting to send the
                                 contents of the agent's log to the island
         """
 
@@ -38,9 +45,12 @@ class IIslandAPIClient(ABC):
 
         :param filename: The name of the custom PBA file
         :return: The contents of the custom PBA file in bytes
-        :raises IslandAPIConnectionError: If a connection cannot be made to the island
+        :raises IslandAPIConnectionError: If the client cannot successfully connect to the island
+        :raises IslandAPIRequestError: If an error occurs while attempting to connect to the
+                                       island due to an issue in the request sent from the client
+        :raises IslandAPIRequestFailedError: If an error occurs while attempting to connect to the
+                                             island due to an error on the server
         :raises IslandAPITimeoutError: If a timeout occurs while attempting to connect to the island
-                                       or retrieve the custom PBA file
-        :raises IslandAPIError: If an unexpected error occurred while attempting to retrieve the
+        :raises IslandAPIError: If an unexpected error occurs while attempting to retrieve the
                                 custom PBA file
         """

--- a/monkey/infection_monkey/island_api_client/i_island_api_client.py
+++ b/monkey/infection_monkey/island_api_client/i_island_api_client.py
@@ -17,3 +17,16 @@ class IIslandAPIClient(ABC):
         :raises IslandAPIError: If an unexpected error occurs while attempting to connect to the
                                 island
         """
+
+    @abstractmethod
+    def send_log(self, log_contents: str):
+        """
+        Send the contents of the agent's log to the island
+
+        :param log_contents: The contents of the agent's log
+        :raises IslandAPIConnectionError: If a connection cannot be made to the island
+        :raises IslandAPITimeoutError: If a timeout occurs while attempting to connect to the island
+                                       or send the log contents
+        :raises IslandAPIError: If an unexpected error occurred while attempting to send the
+                                contents of the agent's log to the island
+        """

--- a/monkey/infection_monkey/island_api_client/i_island_api_client.py
+++ b/monkey/infection_monkey/island_api_client/i_island_api_client.py
@@ -30,3 +30,17 @@ class IIslandAPIClient(ABC):
         :raises IslandAPIError: If an unexpected error occurred while attempting to send the
                                 contents of the agent's log to the island
         """
+
+    @abstractmethod
+    def get_pba_file(self, filename: str) -> bytes:
+        """
+        Get a custom PBA file from the island
+
+        :param filename: The name of the custom PBA file
+        :return: The contents of the custom PBA file in bytes
+        :raises IslandAPIConnectionError: If a connection cannot be made to the island
+        :raises IslandAPITimeoutError: If a timeout occurs while attempting to connect to the island
+                                       or retrieve the custom PBA file
+        :raises IslandAPIError: If an unexpected error occurred while attempting to retrieve the
+                                custom PBA file
+        """

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -115,7 +115,9 @@ class InfectionMonkey:
         # TODO: `address_to_port()` should return the port as an integer.
         self._cmd_island_ip, self._cmd_island_port = address_to_ip_port(server)
         self._cmd_island_port = int(self._cmd_island_port)
-        self._control_client = ControlClient(server_address=server)
+        self._control_client = ControlClient(
+            server_address=server, island_api_client=island_api_client
+        )
 
         # TODO Refactor the telemetry messengers to accept control client
         # and remove control_client_object

--- a/monkey/infection_monkey/post_breach/custom_pba/custom_pba.py
+++ b/monkey/infection_monkey/post_breach/custom_pba/custom_pba.py
@@ -76,7 +76,7 @@ class CustomPBA(PBA):
         pba_file_contents = self.control_client.get_pba_file(filename)
 
         status = None
-        if not pba_file_contents or not pba_file_contents.content:
+        if not pba_file_contents:
             logger.error("Island didn't respond with post breach file.")
             status = ScanStatus.SCANNED
 
@@ -97,7 +97,7 @@ class CustomPBA(PBA):
 
         try:
             with open(os.path.join(dst_dir, filename), "wb") as written_PBA_file:
-                written_PBA_file.write(pba_file_contents.content)
+                written_PBA_file.write(pba_file_contents)
             return True
         except IOError as e:
             logger.error("Can not upload post breach file to target machine: %s" % e)

--- a/monkey/tests/unit_tests/infection_monkey/island_api_client/test_http_island_api_client.py
+++ b/monkey/tests/unit_tests/infection_monkey/island_api_client/test_http_island_api_client.py
@@ -6,6 +6,8 @@ from infection_monkey.island_api_client import (
     HTTPIslandAPIClient,
     IslandAPIConnectionError,
     IslandAPIError,
+    IslandAPIRequestError,
+    IslandAPIRequestFailedError,
     IslandAPITimeoutError,
 )
 
@@ -34,6 +36,21 @@ def test_island_api_client(actual_error, expected_error):
 
 
 @pytest.mark.parametrize(
+    "status_code, expected_error",
+    [
+        (401, IslandAPIRequestError),
+        (501, IslandAPIRequestFailedError),
+    ],
+)
+def test_island_api_client__status_code(status_code, expected_error):
+    with requests_mock.Mocker() as m:
+        m.get(ISLAND_URI, status_code=status_code)
+
+        with pytest.raises(expected_error):
+            HTTPIslandAPIClient(SERVER)
+
+
+@pytest.mark.parametrize(
     "actual_error, expected_error",
     [
         (requests.exceptions.ConnectionError, IslandAPIConnectionError),
@@ -52,6 +69,23 @@ def test_island_api_client__send_log(actual_error, expected_error):
 
 
 @pytest.mark.parametrize(
+    "status_code, expected_error",
+    [
+        (401, IslandAPIRequestError),
+        (501, IslandAPIRequestFailedError),
+    ],
+)
+def test_island_api_client_send_log__status_code(status_code, expected_error):
+    with requests_mock.Mocker() as m:
+        m.get(ISLAND_URI)
+        island_api_client = HTTPIslandAPIClient(SERVER)
+
+        with pytest.raises(expected_error):
+            m.post(ISLAND_SEND_LOG_URI, status_code=status_code)
+            island_api_client.send_log(log_contents="some_data")
+
+
+@pytest.mark.parametrize(
     "actual_error, expected_error",
     [
         (requests.exceptions.ConnectionError, IslandAPIConnectionError),
@@ -66,4 +100,21 @@ def test_island_api_client__get_pba_file(actual_error, expected_error):
 
         with pytest.raises(expected_error):
             m.get(ISLAND_GET_PBA_FILE_URI, exc=actual_error)
+            island_api_client.get_pba_file(filename=PBA_FILE)
+
+
+@pytest.mark.parametrize(
+    "status_code, expected_error",
+    [
+        (401, IslandAPIRequestError),
+        (501, IslandAPIRequestFailedError),
+    ],
+)
+def test_island_api_client_get_pba_file__status_code(status_code, expected_error):
+    with requests_mock.Mocker() as m:
+        m.get(ISLAND_URI)
+        island_api_client = HTTPIslandAPIClient(SERVER)
+
+        with pytest.raises(expected_error):
+            m.get(ISLAND_GET_PBA_FILE_URI, status_code=status_code)
             island_api_client.get_pba_file(filename=PBA_FILE)

--- a/monkey/tests/unit_tests/infection_monkey/island_api_client/test_http_island_api_client.py
+++ b/monkey/tests/unit_tests/infection_monkey/island_api_client/test_http_island_api_client.py
@@ -10,8 +10,11 @@ from infection_monkey.island_api_client import (
 )
 
 SERVER = "1.1.1.1:9999"
+PBA_FILE = "dummy.pba"
 
 ISLAND_URI = f"https://{SERVER}/api?action=is-up"
+ISLAND_SEND_LOG_URI = f"https://{SERVER}/api/log"
+ISLAND_GET_PBA_FILE_URI = f"https://{SERVER}/api/pba/download/{PBA_FILE}"
 
 
 @pytest.mark.parametrize(
@@ -28,3 +31,39 @@ def test_island_api_client(actual_error, expected_error):
 
         with pytest.raises(expected_error):
             HTTPIslandAPIClient(SERVER)
+
+
+@pytest.mark.parametrize(
+    "actual_error, expected_error",
+    [
+        (requests.exceptions.ConnectionError, IslandAPIConnectionError),
+        (TimeoutError, IslandAPITimeoutError),
+        (Exception, IslandAPIError),
+    ],
+)
+def test_island_api_client__send_log(actual_error, expected_error):
+    with requests_mock.Mocker() as m:
+        m.get(ISLAND_URI)
+        island_api_client = HTTPIslandAPIClient(SERVER)
+
+        with pytest.raises(expected_error):
+            m.post(ISLAND_SEND_LOG_URI, exc=actual_error)
+            island_api_client.send_log(log_contents="some_data")
+
+
+@pytest.mark.parametrize(
+    "actual_error, expected_error",
+    [
+        (requests.exceptions.ConnectionError, IslandAPIConnectionError),
+        (TimeoutError, IslandAPITimeoutError),
+        (Exception, IslandAPIError),
+    ],
+)
+def test_island_api_client__get_pba_file(actual_error, expected_error):
+    with requests_mock.Mocker() as m:
+        m.get(ISLAND_URI)
+        island_api_client = HTTPIslandAPIClient(SERVER)
+
+        with pytest.raises(expected_error):
+            m.get(ISLAND_GET_PBA_FILE_URI, exc=actual_error)
+            island_api_client.get_pba_file(filename=PBA_FILE)

--- a/vulture_allowlist.py
+++ b/vulture_allowlist.py
@@ -9,12 +9,6 @@ from common.agent_configuration.agent_sub_configurations import (
 )
 from common.credentials import Credentials, LMHash, NTHash
 from infection_monkey.exploit.log4shell_utils.ldap_server import LDAPServerFactory
-from infection_monkey.island_api_client import (
-    HTTPIslandAPIClient,
-    IIslandAPIClient,
-    IslandAPIRequestError,
-    IslandAPIRequestFailedError,
-)
 from monkey_island.cc.event_queue import IslandEventTopic, PyPubSubIslandEventQueue
 from monkey_island.cc.models import Report
 from monkey_island.cc.models.networkmap import Arc, NetworkMap
@@ -334,9 +328,3 @@ CC_TUNNEL
 IslandEventTopic.AGENT_CONNECTED
 IslandEventTopic.CLEAR_SIMULATION_DATA
 IslandEventTopic.RESET_AGENT_CONFIGURATION
-
-# TODO: Remove after #2292 is closed
-IIslandAPIClient
-HTTPIslandAPIClient
-IslandAPIRequestFailedError
-IslandAPIRequestError


### PR DESCRIPTION
# What does this PR do?

Fixes a part of #2292 

Adds a decorator to handle Island API exceptions which can be used for all HTTPIslandAPIClient functions. Alternatively, we could do this [using a metaclass ](https://stackoverflow.com/a/6307917) or using [`inspect` at the end of the class](https://stackoverflow.com/a/3467879).

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing?
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [ ] Have you successfully tested your changes locally? Elaborate:
    > UTs pass
* [ ] ~If applicable, add screenshots or log transcripts of the feature working~
