### PR TITLE
2261 on terminate agents signal

### DIFF
--- a/monkey/monkey_island/cc/services/__init__.py
+++ b/monkey/monkey_island/cc/services/__init__.py
@@ -1,4 +1,4 @@
+from .agent_signals_service import AgentSignalsService
 from .authentication_service import AuthenticationService
 
 from .aws import AWSService
-from .agent_signals_service import AgentSignalsService

--- a/monkey/monkey_island/cc/services/agent_signals_service.py
+++ b/monkey/monkey_island/cc/services/agent_signals_service.py
@@ -1,9 +1,12 @@
+import logging
 from datetime import datetime
 from typing import Optional
 
 from common.types import AgentID
-from monkey_island.cc.models import AgentSignals
+from monkey_island.cc.models import AgentSignals, Simulation
 from monkey_island.cc.repository import IAgentRepository, ISimulationRepository
+
+logger = logging.getLogger(__name__)
 
 
 class AgentSignalsService:
@@ -45,4 +48,7 @@ class AgentSignalsService:
 
         :param timestamp: Timestamp of the terminate signal
         """
-        pass
+        simulation = self._simulation_repository.get_simulation()
+        updated_simulation = Simulation(mode=simulation.mode, terminate_signal_time=timestamp)
+
+        self._simulation_repository.save_simulation(updated_simulation)

--- a/monkey/monkey_island/cc/services/initialize.py
+++ b/monkey/monkey_island/cc/services/initialize.py
@@ -47,7 +47,7 @@ from monkey_island.cc.repository import (
 )
 from monkey_island.cc.server_utils.consts import MONKEY_ISLAND_ABS_PATH
 from monkey_island.cc.server_utils.encryption import ILockableEncryptor, RepositoryEncryptor
-from monkey_island.cc.services import AWSService
+from monkey_island.cc.services import AgentSignalsService, AWSService
 from monkey_island.cc.services.attack.technique_reports.T1003 import T1003, T1003GetReportData
 from monkey_island.cc.services.run_local_monkey import LocalMonkeyRunService
 from monkey_island.cc.setup.mongo.mongo_setup import MONGO_URL
@@ -176,6 +176,7 @@ def _register_services(container: DIContainer):
     container.register_instance(AWSService, container.resolve(AWSService))
     container.register_instance(LocalMonkeyRunService, container.resolve(LocalMonkeyRunService))
     container.register_instance(AuthenticationService, container.resolve(AuthenticationService))
+    container.register_instance(AgentSignalsService, container.resolve(AgentSignalsService))
 
 
 def _dirty_hacks(container: DIContainer):

--- a/monkey/monkey_island/cc/setup/island_event_handlers.py
+++ b/monkey/monkey_island/cc/setup/island_event_handlers.py
@@ -24,7 +24,7 @@ def setup_island_event_handlers(container: DIContainer):
     _subscribe_reset_agent_configuration_events(island_event_queue, container)
     _subscribe_clear_simulation_data_events(island_event_queue, container)
     _subscribe_set_island_mode_events(island_event_queue, container)
-    _subscribe_on_terminate_agents_signal(island_event_queue, container)
+    _subscribe_terminate_agents_events(island_event_queue, container)
 
 
 def _subscribe_reset_agent_configuration_events(
@@ -68,7 +68,7 @@ def _subscribe_set_island_mode_events(
     island_event_queue.subscribe(topic, simulation_repository.set_mode)
 
 
-def _subscribe_on_terminate_agents_signal(
+def _subscribe_terminate_agents_events(
     island_event_queue: IIslandEventQueue, container: DIContainer
 ):
     topic = IslandEventTopic.TERMINATE_AGENTS

--- a/monkey/monkey_island/cc/setup/island_event_handlers.py
+++ b/monkey/monkey_island/cc/setup/island_event_handlers.py
@@ -14,6 +14,7 @@ from monkey_island.cc.repository import (
     INodeRepository,
     ISimulationRepository,
 )
+from monkey_island.cc.services import AgentSignalsService
 from monkey_island.cc.services.database import Database
 
 
@@ -23,6 +24,7 @@ def setup_island_event_handlers(container: DIContainer):
     _subscribe_reset_agent_configuration_events(island_event_queue, container)
     _subscribe_clear_simulation_data_events(island_event_queue, container)
     _subscribe_set_island_mode_events(island_event_queue, container)
+    _subscribe_on_terminate_agents_signal(island_event_queue, container)
 
 
 def _subscribe_reset_agent_configuration_events(
@@ -64,3 +66,13 @@ def _subscribe_set_island_mode_events(
 
     simulation_repository = container.resolve(ISimulationRepository)
     island_event_queue.subscribe(topic, simulation_repository.set_mode)
+
+
+def _subscribe_on_terminate_agents_signal(
+    island_event_queue: IIslandEventQueue, container: DIContainer
+):
+    topic = IslandEventTopic.TERMINATE_AGENTS
+
+    agent_signals_service = container.resolve(AgentSignalsService)
+
+    island_event_queue.subscribe(topic, agent_signals_service.on_terminate_agents_signal)


### PR DESCRIPTION
# What does this PR do?

Fixes part of #2261.

Implements on_terminate_agents_signal, and connects the AgentSignalsService to the event.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~~Was the CHANGELOG.md updated to reflect the changes?~~
* [ ] ~~Was the documentation framework updated to reflect the changes?~~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [ ] Have you successfully tested your changes locally? Elaborate:
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
