### PR TITLE
2325 ipv4address in island

### DIFF
--- a/monkey/monkey_island/cc/resources/ip_addresses.py
+++ b/monkey/monkey_island/cc/resources/ip_addresses.py
@@ -1,3 +1,4 @@
+from ipaddress import IPv4Address
 from typing import Sequence
 
 from monkey_island.cc.resources.AbstractResource import AbstractResource
@@ -11,8 +12,8 @@ class IPAddresses(AbstractResource):
 
     urls = ["/api/island/ip-addresses"]
 
-    def __init__(self, ip_addresses: Sequence[str]):
-        self._ips = ip_addresses
+    def __init__(self, ip_addresses: Sequence[IPv4Address]):
+        self._ips = list(map(str, ip_addresses))
 
     @jwt_required
     def get(self) -> Sequence[str]:

--- a/monkey/monkey_island/cc/server_setup.py
+++ b/monkey/monkey_island/cc/server_setup.py
@@ -127,9 +127,6 @@ def _initialize_di_container(
 ) -> DIContainer:
     container = DIContainer()
 
-    # TODO: Remove the Sequence[str] convention for "ip_addresses" when resources and services are
-    #       refactored.
-    container.register_convention(Sequence[str], "ip_addresses", list(map(str, ip_addresses)))
     container.register_convention(Sequence[IPv4Address], "ip_addresses", ip_addresses)
     container.register_instance(Version, version)
     container.register_convention(Path, "data_dir", data_dir)

--- a/monkey/monkey_island/cc/services/run_local_monkey.py
+++ b/monkey/monkey_island/cc/services/run_local_monkey.py
@@ -2,6 +2,7 @@ import logging
 import platform
 import stat
 import subprocess
+from ipaddress import IPv4Address
 from pathlib import Path
 from shutil import copyfileobj
 from typing import Sequence
@@ -19,7 +20,7 @@ class LocalMonkeyRunService:
         self,
         data_dir: Path,
         agent_binary_repository: IAgentBinaryRepository,
-        ip_addresses: Sequence[str],
+        ip_addresses: Sequence[IPv4Address],
     ):
         self._data_dir = data_dir
         self._agent_binary_repository = agent_binary_repository


### PR DESCRIPTION
# What does this PR do?

Use `IPv4Address` instead of `str` in `server_setup.py`, `resources`, and `services/run_local_monkey.py`

#2325 

Add any further explanations here.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running the island and exercising the affected services and resources
* [ ] If applicable, add screenshots or log transcripts of the feature working
