### PR TITLE
2323 update iislandapiclient with socketaddress

### DIFF
--- a/monkey/common/types.py
+++ b/monkey/common/types.py
@@ -41,5 +41,8 @@ class SocketAddress(InfectionMonkeyBaseModel):
             raise ValueError("SocketAddress requires a port")
         return SocketAddress(ip=IPv4Address(ip), port=int(port))
 
+    def __hash__(self):
+        return hash(str(self))
+
     def __str__(self):
         return f"{self.ip}:{self.port}"

--- a/monkey/infection_monkey/island_api_client/http_island_api_client.py
+++ b/monkey/infection_monkey/island_api_client/http_island_api_client.py
@@ -16,6 +16,7 @@ from common.common_consts.timeouts import (
     SHORT_REQUEST_TIMEOUT,
 )
 from common.credentials import Credentials
+from common.types import SocketAddress
 
 from . import (
     AbstractIslandAPIClientFactory,
@@ -79,7 +80,7 @@ class HTTPIslandAPIClient(IIslandAPIClient):
     @handle_island_errors
     def connect(
         self,
-        island_server: str,
+        island_server: SocketAddress,
     ):
         response = requests.get(  # noqa: DUO123
             f"https://{island_server}/api?action=is-up",
@@ -88,8 +89,7 @@ class HTTPIslandAPIClient(IIslandAPIClient):
         )
         response.raise_for_status()
 
-        self._island_server = island_server
-        self._api_url = f"https://{self._island_server}/api"
+        self._api_url = f"https://{island_server}/api"
 
     @handle_island_errors
     def send_log(self, log_contents: str):

--- a/monkey/infection_monkey/island_api_client/i_island_api_client.py
+++ b/monkey/infection_monkey/island_api_client/i_island_api_client.py
@@ -5,6 +5,7 @@ from common import AgentRegistrationData, AgentSignals, OperatingSystem
 from common.agent_configuration import AgentConfiguration
 from common.agent_events import AbstractAgentEvent
 from common.credentials import Credentials
+from common.types import SocketAddress
 
 
 class IIslandAPIClient(ABC):
@@ -13,7 +14,7 @@ class IIslandAPIClient(ABC):
     """
 
     @abstractmethod
-    def connect(self, island_server: str):
+    def connect(self, island_server: SocketAddress):
         """
         Connect to the island's API
 

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -127,7 +127,7 @@ class InfectionMonkey:
         self._control_client = ControlClient(
             server_address=str(server), island_api_client=self._island_api_client
         )
-        self._control_channel = ControlChannel(server, get_agent_id(), self._island_api_client)
+        self._control_channel = ControlChannel(str(server), get_agent_id(), self._island_api_client)
         self._register_agent(self._island_address)
 
         # TODO Refactor the telemetry messengers to accept control client

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -262,7 +262,7 @@ class InfectionMonkey:
         return agent_event_serializer_registry
 
     def _build_server_list(self, relay_port: int):
-        my_servers = [str(s) for s in self._opts.servers]
+        my_servers = map(str, self._opts.servers)
         relay_servers = [f"{ip}:{relay_port}" for ip in get_my_ip_addresses()]
         return my_servers + relay_servers
 

--- a/monkey/infection_monkey/network/relay/utils.py
+++ b/monkey/infection_monkey/network/relay/utils.py
@@ -80,11 +80,10 @@ def _check_if_island_server(
 
 def send_remove_from_waitlist_control_message_to_relays(servers: Iterable[SocketAddress]):
     for i, server in enumerate(servers, start=1):
-        server_address = SocketAddress.from_string(server)
         t = create_daemon_thread(
             target=notify_disconnect,
             name=f"SendRemoveFromWaitlistControlMessageToRelaysThread-{i:02d}",
-            args=(server_address,),
+            args=(server,),
         )
         t.start()
 

--- a/monkey/infection_monkey/network/relay/utils.py
+++ b/monkey/infection_monkey/network/relay/utils.py
@@ -78,7 +78,7 @@ def _check_if_island_server(
     return None
 
 
-def send_remove_from_waitlist_control_message_to_relays(servers: Iterable[str]):
+def send_remove_from_waitlist_control_message_to_relays(servers: Iterable[SocketAddress]):
     for i, server in enumerate(servers, start=1):
         server_address = SocketAddress.from_string(server)
         t = create_daemon_thread(

--- a/monkey/tests/unit_tests/infection_monkey/island_api_client/test_http_island_api_client.py
+++ b/monkey/tests/unit_tests/infection_monkey/island_api_client/test_http_island_api_client.py
@@ -30,7 +30,7 @@ AGENT_REGISTRATION = AgentRegistrationData(
     machine_hardware_id=1,
     start_time=0,
     parent_id=None,
-    cc_server=str(SERVER),
+    cc_server=SERVER,
     network_interfaces=[],
 )
 

--- a/monkey/tests/unit_tests/infection_monkey/island_api_client/test_http_island_api_client.py
+++ b/monkey/tests/unit_tests/infection_monkey/island_api_client/test_http_island_api_client.py
@@ -30,7 +30,7 @@ AGENT_REGISTRATION = AgentRegistrationData(
     machine_hardware_id=1,
     start_time=0,
     parent_id=None,
-    cc_server=SERVER,
+    cc_server=str(SERVER),
     network_interfaces=[],
 )
 


### PR DESCRIPTION
# What does this PR do?

Fixes part of #2323. Follows [2350](https://github.com/guardicore/monkey/pull/2350).

Add any further explanations here. Updates the IslandAPIClient to use a SocketAddress. One effect of this is that IslandAPISearchResults can no longer be a dict because SocketAddress is not hashable. `find_available_island_apis` was updated to output the results in the same order as the servers that are passed in, in order to make it easier to use.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~~Was the CHANGELOG.md updated to reflect the changes?~~
* [ ] ~~Was the documentation framework updated to reflect the changes?~~
* [ ] ~~Have you checked that you haven't introduced any duplicate code?~~

## Testing Checklist

* [x] Added relevant unit tests?
* [ ] Have you successfully tested your changes locally? Elaborate:
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
