### PR TITLE
2267 island event queue threadsafe

### DIFF
--- a/monkey/common/event_queue/__init__.py
+++ b/monkey/common/event_queue/__init__.py
@@ -2,3 +2,4 @@ from .types import AgentEventSubscriber
 from .pypubsub_publisher_wrapper import PyPubSubPublisherWrapper
 from .i_agent_event_queue import IAgentEventQueue
 from .pypubsub_agent_event_queue import PyPubSubAgentEventQueue
+from .locking_agent_event_queue_decorator import LockingAgentEventQueueDecorator

--- a/monkey/common/event_queue/locking_agent_event_queue_decorator.py
+++ b/monkey/common/event_queue/locking_agent_event_queue_decorator.py
@@ -1,0 +1,31 @@
+from threading import Lock
+from typing import Type
+
+from common.agent_events import AbstractAgentEvent
+
+from . import AgentEventSubscriber, IAgentEventQueue
+
+
+class LockingAgentEventQueueDecorator(IAgentEventQueue):
+    """
+    Makes an IAgentEventQueue thread-safe by locking publish()
+    """
+
+    def __init__(self, agent_event_queue: IAgentEventQueue):
+        self._lock = Lock()
+        self._agent_event_queue = agent_event_queue
+
+    def subscribe_all_events(self, subscriber: AgentEventSubscriber):
+        self._agent_event_queue.subscribe_all_events(subscriber)
+
+    def subscribe_type(
+        self, event_type: Type[AbstractAgentEvent], subscriber: AgentEventSubscriber
+    ):
+        self._agent_event_queue.subscribe_type(event_type, subscriber)
+
+    def subscribe_tag(self, tag: str, subscriber: AgentEventSubscriber):
+        self._agent_event_queue.subscribe_tag(tag, subscriber)
+
+    def publish(self, event: AbstractAgentEvent):
+        with self._lock:
+            self._agent_event_queue.publish(event)

--- a/monkey/common/event_queue/locking_agent_event_queue_decorator.py
+++ b/monkey/common/event_queue/locking_agent_event_queue_decorator.py
@@ -11,8 +11,8 @@ class LockingAgentEventQueueDecorator(IAgentEventQueue):
     Makes an IAgentEventQueue thread-safe by locking publish()
     """
 
-    def __init__(self, agent_event_queue: IAgentEventQueue):
-        self._lock = Lock()
+    def __init__(self, agent_event_queue: IAgentEventQueue, lock: Lock):
+        self._lock = lock
         self._agent_event_queue = agent_event_queue
 
     def subscribe_all_events(self, subscriber: AgentEventSubscriber):

--- a/monkey/monkey_island/cc/event_queue/__init__.py
+++ b/monkey/monkey_island/cc/event_queue/__init__.py
@@ -1,3 +1,4 @@
 from .types import IslandEventSubscriber
 from .i_island_event_queue import IIslandEventQueue, IslandEventTopic
 from .pypubsub_island_event_queue import PyPubSubIslandEventQueue
+from .locking_island_event_queue_decorator import LockingIslandEventQueueDecorator

--- a/monkey/monkey_island/cc/event_queue/locking_island_event_queue_decorator.py
+++ b/monkey/monkey_island/cc/event_queue/locking_island_event_queue_decorator.py
@@ -8,8 +8,8 @@ class LockingIslandEventQueueDecorator(IIslandEventQueue):
     Makes an IIslandEventQueue thread-safe by locking publish()
     """
 
-    def __init__(self, island_event_queue: IIslandEventQueue):
-        self._lock = Lock()
+    def __init__(self, island_event_queue: IIslandEventQueue, lock: Lock):
+        self._lock = lock
         self._island_event_queue = island_event_queue
 
     def subscribe(self, topic: IslandEventTopic, subscriber: IslandEventSubscriber):

--- a/monkey/monkey_island/cc/event_queue/locking_island_event_queue_decorator.py
+++ b/monkey/monkey_island/cc/event_queue/locking_island_event_queue_decorator.py
@@ -1,0 +1,20 @@
+from threading import Lock
+
+from . import IIslandEventQueue, IslandEventSubscriber, IslandEventTopic
+
+
+class LockingIslandEventQueueDecorator(IIslandEventQueue):
+    """
+    Makes an IIslandEventQueue thread-safe by locking publish()
+    """
+
+    def __init__(self, island_event_queue: IIslandEventQueue):
+        self._lock = Lock()
+        self._island_event_queue = island_event_queue
+
+    def subscribe(self, topic: IslandEventTopic, subscriber: IslandEventSubscriber):
+        self._island_event_queue.subscribe(topic, subscriber)
+
+    def publish(self, topic: IslandEventTopic, **kwargs):
+        with self._lock:
+            self._island_event_queue.publish(topic, **kwargs)

--- a/monkey/monkey_island/cc/event_queue/pypubsub_island_event_queue.py
+++ b/monkey/monkey_island/cc/event_queue/pypubsub_island_event_queue.py
@@ -10,6 +10,10 @@ logger = logging.getLogger(__name__)
 
 
 class PyPubSubIslandEventQueue(IIslandEventQueue):
+    """
+    Implements IIslandEventQueue using pypubsub
+    """
+
     def __init__(self, pypubsub_publisher: Publisher):
         self._pypubsub_publisher_wrapper = PyPubSubPublisherWrapper(pypubsub_publisher)
 

--- a/monkey/monkey_island/cc/services/initialize.py
+++ b/monkey/monkey_island/cc/services/initialize.py
@@ -122,11 +122,15 @@ def _register_event_queues(container: DIContainer):
     container.register_instance(IIslandEventQueue, decorated_island_event_queue)
 
 
-def _decorate_agent_event_queue(agent_event_queue: IAgentEventQueue, lock: threading.Lock):
+def _decorate_agent_event_queue(
+    agent_event_queue: IAgentEventQueue, lock: threading.Lock
+) -> IAgentEventQueue:
     return LockingAgentEventQueueDecorator(agent_event_queue, lock)
 
 
-def _decorate_island_event_queue(island_event_queue: IIslandEventQueue, lock: threading.Lock):
+def _decorate_island_event_queue(
+    island_event_queue: IIslandEventQueue, lock: threading.Lock
+) -> IIslandEventQueue:
     return LockingIslandEventQueueDecorator(island_event_queue, lock)
 
 


### PR DESCRIPTION
# What does this PR do?

Makes Island and Agent event queues in the Island thread-safe.

Issue #2267

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing?
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Local smoke test
    > ETE tests
* [ ] ~If applicable, add screenshots or log transcripts of the feature working~
