### PR TITLE
2269 use repositories for get monkey exploited

### DIFF
--- a/monkey/monkey_island/cc/resources/exploitations/monkey_exploitation.py
+++ b/monkey/monkey_island/cc/resources/exploitations/monkey_exploitation.py
@@ -1,3 +1,4 @@
+from monkey_island.cc.repository import IAgentEventRepository, IMachineRepository
 from monkey_island.cc.resources.AbstractResource import AbstractResource
 from monkey_island.cc.resources.request_authentication import jwt_required
 from monkey_island.cc.services.reporting.exploitations.monkey_exploitation import (
@@ -8,7 +9,18 @@ from monkey_island.cc.services.reporting.exploitations.monkey_exploitation impor
 class MonkeyExploitation(AbstractResource):
     urls = ["/api/exploitations/monkey"]
 
+    def __init__(
+        self, event_repository: IAgentEventRepository, machine_repository: IMachineRepository
+    ):
+        self._event_repository = event_repository
+        self._machine_repository = machine_repository
+
     @jwt_required
     def get(self):
-        monkey_exploitations = [exploitation.__dict__ for exploitation in get_monkey_exploited()]
+        monkey_exploitations = [
+            exploitation.__dict__
+            for exploitation in get_monkey_exploited(
+                self._event_repository, self._machine_repository
+            )
+        ]
         return {"monkey_exploitations": monkey_exploitations}

--- a/monkey/monkey_island/cc/resources/exploitations/monkey_exploitation.py
+++ b/monkey/monkey_island/cc/resources/exploitations/monkey_exploitation.py
@@ -1,3 +1,5 @@
+from dataclasses import asdict
+
 from monkey_island.cc.repository import IAgentEventRepository, IMachineRepository
 from monkey_island.cc.resources.AbstractResource import AbstractResource
 from monkey_island.cc.resources.request_authentication import jwt_required
@@ -18,7 +20,7 @@ class MonkeyExploitation(AbstractResource):
     @jwt_required
     def get(self):
         monkey_exploitations = [
-            exploitation.__dict__
+            asdict(exploitation)
             for exploitation in get_monkey_exploited(
                 self._event_repository, self._machine_repository
             )

--- a/monkey/monkey_island/cc/resources/ransomware_report.py
+++ b/monkey/monkey_island/cc/resources/ransomware_report.py
@@ -1,5 +1,6 @@
 from flask import jsonify
 
+from monkey_island.cc.repository import IAgentEventRepository, IMachineRepository
 from monkey_island.cc.resources.AbstractResource import AbstractResource
 from monkey_island.cc.resources.request_authentication import jwt_required
 from monkey_island.cc.services.ransomware import ransomware_report
@@ -8,10 +9,18 @@ from monkey_island.cc.services.ransomware import ransomware_report
 class RansomwareReport(AbstractResource):
     urls = ["/api/report/ransomware"]
 
+    def __init__(
+        self, event_repository: IAgentEventRepository, machine_repository: IMachineRepository
+    ):
+        self._event_repository = event_repository
+        self._machine_repository = machine_repository
+
     @jwt_required
     def get(self):
         return jsonify(
             {
-                "propagation_stats": ransomware_report.get_propagation_stats(),
+                "propagation_stats": ransomware_report.get_propagation_stats(
+                    self._event_repository, self._machine_repository
+                ),
             }
         )

--- a/monkey/monkey_island/cc/services/ransomware/ransomware_report.py
+++ b/monkey/monkey_island/cc/services/ransomware/ransomware_report.py
@@ -1,5 +1,6 @@
 from typing import Dict, List
 
+from monkey_island.cc.repository import IAgentEventRepository, IMachineRepository
 from monkey_island.cc.services.reporting.exploitations.monkey_exploitation import (
     MonkeyExploitation,
     get_monkey_exploited,
@@ -7,9 +8,12 @@ from monkey_island.cc.services.reporting.exploitations.monkey_exploitation impor
 from monkey_island.cc.services.reporting.report import ReportService
 
 
-def get_propagation_stats() -> Dict:
+def get_propagation_stats(
+    event_repository: IAgentEventRepository,
+    machine_repository: IMachineRepository,
+) -> Dict:
     scanned = ReportService.get_scanned()
-    exploited = get_monkey_exploited()
+    exploited = get_monkey_exploited(event_repository, machine_repository)
 
     return {
         "num_scanned_nodes": len(scanned),

--- a/monkey/monkey_island/cc/services/reporting/exploitations/monkey_exploitation.py
+++ b/monkey/monkey_island/cc/services/reporting/exploitations/monkey_exploitation.py
@@ -4,10 +4,10 @@ from typing import List, Sequence
 
 from common.agent_events import ExploitationEvent
 from monkey_island.cc.models import Machine
+from monkey_island.cc.repository import IAgentEventRepository, IMachineRepository
 from monkey_island.cc.services.reporting.issue_processing.exploit_processing.exploiter_descriptor_enum import (  # noqa: E501
     ExploiterDescriptorEnum,
 )
-from monkey_island.cc.repository import IAgentEventRepository, IMachineRepository
 
 logger = logging.getLogger(__name__)
 

--- a/monkey/monkey_island/cc/services/reporting/exploitations/monkey_exploitation.py
+++ b/monkey/monkey_island/cc/services/reporting/exploitations/monkey_exploitation.py
@@ -27,7 +27,9 @@ def get_monkey_exploited(
     exploits = event_repository.get_events_by_type(ExploitationEvent)
     successful_exploits = [e for e in exploits if e.success]
 
-    exploited_machines = (machine_repository.get_machines_by_ip(e)[0] for e in successful_exploits)
+    exploited_machines = {
+        machine_repository.get_machines_by_ip(e.target)[0] for e in successful_exploits
+    }
 
     exploited = [
         MonkeyExploitation(

--- a/monkey/monkey_island/cc/services/reporting/exploitations/monkey_exploitation.py
+++ b/monkey/monkey_island/cc/services/reporting/exploitations/monkey_exploitation.py
@@ -1,12 +1,13 @@
 import logging
 from dataclasses import dataclass
-from typing import List
+from typing import List, Sequence
 
-from monkey_island.cc.database import mongo
-from monkey_island.cc.services.node import NodeService
+from common.agent_events import ExploitationEvent
+from monkey_island.cc.models import Machine
 from monkey_island.cc.services.reporting.issue_processing.exploit_processing.exploiter_descriptor_enum import (  # noqa: E501
     ExploiterDescriptorEnum,
 )
+from monkey_island.cc.repository import IAgentEventRepository, IMachineRepository
 
 logger = logging.getLogger(__name__)
 
@@ -19,30 +20,23 @@ class MonkeyExploitation:
     exploits: List[str]
 
 
-def get_monkey_exploited() -> List[MonkeyExploitation]:
-    exploited_nodes_monkeys_launched = [
-        NodeService.get_displayed_node_by_id(monkey["_id"], True)
-        for monkey in mongo.db.monkey.find({}, {"_id": 1})
-        if not NodeService.get_monkey_manual_run(NodeService.get_monkey_by_id(monkey["_id"]))
-    ]
+def get_monkey_exploited(
+    event_repository: IAgentEventRepository,
+    machine_repository: IMachineRepository,
+) -> List[MonkeyExploitation]:
+    exploits = event_repository.get_events_by_type(ExploitationEvent)
+    successful_exploits = [e for e in exploits if e.success]
 
-    # The node got exploited, but no monkeys got launched.
-    # For example the exploited machine was too old.
-    exploited_nodes_monkeys_failed = [
-        NodeService.get_displayed_node_by_id(node["_id"], True)
-        for node in mongo.db.node.find({"exploited": True}, {"_id": 1})
-    ]
-
-    exploited = exploited_nodes_monkeys_launched + exploited_nodes_monkeys_failed
+    exploited_machines = (machine_repository.get_machines_by_ip(e)[0] for e in successful_exploits)
 
     exploited = [
         MonkeyExploitation(
-            label=exploited_node["label"],
-            ip_addresses=exploited_node["ip_addresses"],
-            domain_name=exploited_node["domain_name"],
-            exploits=get_exploits_used_on_node(exploited_node),
+            label=str(machine.network_interfaces[0].ip),
+            ip_addresses=[str(iface.ip) for iface in machine.network_interfaces],
+            domain_name="",
+            exploits=get_exploits_used_on_node(machine, successful_exploits),
         )
-        for exploited_node in exploited
+        for machine in exploited_machines
     ]
 
     logger.info("Exploited nodes generated for reporting")
@@ -50,13 +44,18 @@ def get_monkey_exploited() -> List[MonkeyExploitation]:
     return exploited
 
 
-def get_exploits_used_on_node(node: dict) -> List[str]:
+def get_exploits_used_on_node(
+    machine: Machine,
+    successful_exploits: Sequence[ExploitationEvent],
+) -> List[str]:
+    machine_ips = [iface.ip for iface in machine.network_interfaces]
+    machine_exploits = (e for e in successful_exploits if e.target in machine_ips)
     return list(
         set(
             [
-                ExploiterDescriptorEnum.get_by_class_name(exploit["exploiter"]).display_name
-                for exploit in node["exploits"]
-                if exploit["exploitation_result"]
+                ExploiterDescriptorEnum.get_by_class_name(exploit.exploiter_name).display_name
+                for exploit in machine_exploits
+                if exploit.success
             ]
         )
     )

--- a/monkey/monkey_island/cc/services/reporting/report.py
+++ b/monkey/monkey_island/cc/services/reporting/report.py
@@ -443,15 +443,22 @@ class ReportService:
         generated_report = mongo.db.report.find_one({})
         return generated_report is not None
 
-    @staticmethod
-    def generate_report():
+    @classmethod
+    def generate_report(cls):
+        if cls._agent_event_repository is None:
+            return RuntimeError("Agent event repository does not exist")
+        if cls._machine_repository is None:
+            return RuntimeError("Machine repository does not exist")
+
         issues = ReportService.get_issues()
         issue_set = ReportService.get_issue_set(issues)
         cross_segment_issues = ReportService.get_cross_segment_issues()
         monkey_latest_modify_time = Monkey.get_latest_modifytime()
 
         scanned_nodes = ReportService.get_scanned()
-        exploited_cnt = len(get_monkey_exploited())
+        exploited_cnt = len(
+            get_monkey_exploited(cls._agent_event_repository, cls._machine_repository)
+        )
         report = {
             "overview": {
                 "manual_monkeys": ReportService.get_manual_monkey_hostnames(),

--- a/monkey/monkey_island/cc/services/reporting/report.py
+++ b/monkey/monkey_island/cc/services/reporting/report.py
@@ -370,7 +370,7 @@ class ReportService:
 
         # For now the feature is limited to 1 group.
         agent_configuration = cls._agent_configuration_repository.get_configuration()
-        subnet_groups = agent_configuration.propagation.network_scan.targets.inaccessible_subnets
+        subnet_groups = [agent_configuration.propagation.network_scan.targets.inaccessible_subnets]
 
         for subnet_group in subnet_groups:
             cross_segment_issues += ReportService.get_cross_segment_issues_per_subnet_group(

--- a/monkey/tests/unit_tests/monkey_island/cc/services/ransomware/test_ransomware_report.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/ransomware/test_ransomware_report.py
@@ -1,10 +1,11 @@
+from unittest.mock import MagicMock
+
 import pytest
 
 from monkey_island.cc.repository import IAgentEventRepository, IMachineRepository
 from monkey_island.cc.services.ransomware import ransomware_report
 from monkey_island.cc.services.reporting.exploitations.monkey_exploitation import MonkeyExploitation
 from monkey_island.cc.services.reporting.report import ReportService
-from unittest.mock import MagicMock
 
 
 @pytest.fixture

--- a/monkey/tests/unit_tests/monkey_island/cc/services/ransomware/test_ransomware_report.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/ransomware/test_ransomware_report.py
@@ -1,8 +1,22 @@
 import pytest
 
+from monkey_island.cc.repository import IAgentEventRepository, IMachineRepository
 from monkey_island.cc.services.ransomware import ransomware_report
 from monkey_island.cc.services.reporting.exploitations.monkey_exploitation import MonkeyExploitation
 from monkey_island.cc.services.reporting.report import ReportService
+from unittest.mock import MagicMock
+
+
+@pytest.fixture
+def event_repository() -> IAgentEventRepository:
+    repository = MagicMock(spec=IAgentEventRepository)
+    return repository
+
+
+@pytest.fixture
+def machine_repository() -> IMachineRepository:
+    repository = MagicMock(spec=IMachineRepository)
+    return repository
 
 
 @pytest.fixture
@@ -15,23 +29,31 @@ def patch_report_service_for_stats(monkeypatch):
     ]
 
     monkeypatch.setattr(ReportService, "get_scanned", lambda: TEST_SCANNED_RESULTS)
-    monkeypatch.setattr(ransomware_report, "get_monkey_exploited", lambda: TEST_EXPLOITED_RESULTS)
+    monkeypatch.setattr(
+        ransomware_report, "get_monkey_exploited", lambda e, m: TEST_EXPLOITED_RESULTS
+    )
 
 
-def test_get_propagation_stats__num_scanned(patch_report_service_for_stats):
-    stats = ransomware_report.get_propagation_stats()
+def test_get_propagation_stats__num_scanned(
+    patch_report_service_for_stats, event_repository, machine_repository
+):
+    stats = ransomware_report.get_propagation_stats(event_repository, machine_repository)
 
     assert stats["num_scanned_nodes"] == 4
 
 
-def test_get_propagation_stats__num_exploited(patch_report_service_for_stats):
-    stats = ransomware_report.get_propagation_stats()
+def test_get_propagation_stats__num_exploited(
+    patch_report_service_for_stats, event_repository, machine_repository
+):
+    stats = ransomware_report.get_propagation_stats(event_repository, machine_repository)
 
     assert stats["num_exploited_nodes"] == 3
 
 
-def test_get_propagation_stats__num_exploited_per_exploit(patch_report_service_for_stats):
-    stats = ransomware_report.get_propagation_stats()
+def test_get_propagation_stats__num_exploited_per_exploit(
+    patch_report_service_for_stats, event_repository, machine_repository
+):
+    stats = ransomware_report.get_propagation_stats(event_repository, machine_repository)
 
     assert stats["num_exploited_per_exploit"]["SSH Exploiter"] == 2
     assert stats["num_exploited_per_exploit"]["SMB Exploiter"] == 1

--- a/monkey/tests/unit_tests/monkey_island/cc/services/reporting/exploitations/test_monkey_exploitation.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/reporting/exploitations/test_monkey_exploitation.py
@@ -1,5 +1,6 @@
 from ipaddress import IPv4Address, IPv4Interface
 from uuid import UUID
+
 from common import OperatingSystem
 from common.agent_events import ExploitationEvent
 from monkey_island.cc.models import Machine

--- a/monkey/tests/unit_tests/monkey_island/cc/services/reporting/exploitations/test_monkey_exploitation.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/reporting/exploitations/test_monkey_exploitation.py
@@ -1,148 +1,60 @@
-import datetime
-from copy import deepcopy
-
-from bson import ObjectId
-
+from ipaddress import IPv4Address, IPv4Interface
+from uuid import UUID
+from common import OperatingSystem
+from common.agent_events import ExploitationEvent
+from monkey_island.cc.models import Machine
 from monkey_island.cc.services.reporting.exploitations.monkey_exploitation import (
     get_exploits_used_on_node,
 )
 
-TELEM_ID = {
-    "exploit_creds": ObjectId(b"123456789000"),
-    "system_info_creds": ObjectId(b"987654321000"),
-    "no_creds": ObjectId(b"112233445566"),
-    "monkey": ObjectId(b"665544332211"),
-}
-MONKEY_GUID = "67890"
-USER = "user-name"
-PWD = "password123"
-LM_HASH = "e52cac67419a9a22664345140a852f61"
-NT_HASH = "a9fdfa038c4b75ebc76dc855dd74f0da"
-VICTIM_IP = "0.0.0.0"
-VICTIM_DOMAIN_NAME = "domain-name"
-HOSTNAME = "name-of-host"
+TARGET_IP_STR = "192.168.1.10"
+OTHER_IP_STR = "192.168.99.99"
+AGENT_ID = UUID("012e7238-7b81-4108-8c7f-0787bc3f3c10")
+TIMESTAMP = 1664371327.4067292
 
-# Below telem constants only contain fields relevant to current tests
+EVENT_1 = ExploitationEvent(
+    source=AGENT_ID,
+    timestamp=TIMESTAMP,
+    target=IPv4Address(TARGET_IP_STR),
+    success=True,
+    exploiter_name="SSHExploiter",
+)
 
-EXPLOIT_TELEMETRY_TELEM = {
-    "_id": TELEM_ID["exploit_creds"],
-    "monkey_guid": MONKEY_GUID,
-    "telem_category": "exploit",
-    "data": {
-        "machine": {
-            "ip_addr": VICTIM_IP,
-            "domain_name": VICTIM_DOMAIN_NAME,
-        },
-        "info": {
-            "credentials": {
-                USER: {
-                    "username": USER,
-                    "lm_hash": LM_HASH,
-                    "ntlm_hash": NT_HASH,
-                }
-            }
-        },
-    },
-}
+EVENT_2 = ExploitationEvent(
+    source=AGENT_ID,
+    timestamp=TIMESTAMP,
+    target=IPv4Address(TARGET_IP_STR),
+    success=True,
+    exploiter_name="Log4ShellExploiter",
+)
 
-SYSTEM_INFO_TELEMETRY_TELEM = {
-    "_id": TELEM_ID["system_info_creds"],
-    "monkey_guid": MONKEY_GUID,
-    "telem_category": "system_info",
-    "timestamp": datetime.datetime(2021, 2, 19, 9, 0, 14, 984000),
-    "command_control_channel": {
-        "src": "192.168.56.1",
-        "dst": "192.168.56.2",
-    },
-    "data": {
-        "credentials": {
-            USER: {
-                "password": PWD,
-                "lm_hash": LM_HASH,
-                "ntlm_hash": NT_HASH,
-            }
-        }
-    },
-}
+EVENT_3 = ExploitationEvent(
+    source=AGENT_ID,
+    timestamp=TIMESTAMP,
+    target=IPv4Address(OTHER_IP_STR),
+    success=True,
+    exploiter_name="ZerologonExploiter",
+)
 
-NO_CREDS_TELEMETRY_TELEM = {
-    "_id": TELEM_ID["no_creds"],
-    "monkey_guid": MONKEY_GUID,
-    "telem_category": "exploit",
-    "timestamp": datetime.datetime(2021, 2, 19, 9, 0, 14, 984000),
-    "command_control_channel": {
-        "src": "192.168.56.1",
-        "dst": "192.168.56.2",
-    },
-    "data": {
-        "machine": {
-            "ip_addr": VICTIM_IP,
-            "domain_name": VICTIM_DOMAIN_NAME,
-        },
-        "info": {"credentials": {}},
-    },
-}
-
-MONKEY_TELEM = {"_id": TELEM_ID["monkey"], "guid": MONKEY_GUID, "hostname": HOSTNAME}
-
-NODE_DICT = {
-    "id": "602f62118e30cf35830ff8e4",
-    "label": "WinDev2010Eval.mshome.net",
-    "group": "monkey_windows",
-    "os": "windows",
-    "dead": True,
-    "exploits": [
-        {
-            "exploitation_result": True,
-            "exploiter": "Log4ShellExploiter",
-            "info": {
-                "display_name": "Log4j",
-                "started": datetime.datetime(2021, 2, 19, 9, 0, 14, 950000),
-                "finished": datetime.datetime(2021, 2, 19, 9, 0, 14, 950000),
-                "vulnerable_urls": [],
-                "vulnerable_ports": [],
-                "executed_cmds": [],
-            },
-            "attempts": [],
-            "timestamp": datetime.datetime(2021, 2, 19, 9, 0, 14, 984000),
-            "origin": "MonkeyIsland : 192.168.56.1",
-        },
-        {
-            "exploitation_result": True,
-            "exploiter": "ZerologonExploiter",
-            "info": {
-                "display_name": "Zerologon",
-                "started": datetime.datetime(2021, 2, 19, 9, 0, 15, 16000),
-                "finished": datetime.datetime(2021, 2, 19, 9, 0, 15, 17000),
-                "vulnerable_urls": [],
-                "vulnerable_ports": [],
-                "executed_cmds": [],
-            },
-            "attempts": [],
-            "timestamp": datetime.datetime(2021, 2, 19, 9, 0, 15, 60000),
-            "origin": "MonkeyIsland : 192.168.56.1",
-        },
-    ],
-}
-
-NODE_DICT_DUPLICATE_EXPLOITS = deepcopy(NODE_DICT)
-NODE_DICT_DUPLICATE_EXPLOITS["exploits"][1] = NODE_DICT_DUPLICATE_EXPLOITS["exploits"][0]
-
-NODE_DICT_FAILED_EXPLOITS = deepcopy(NODE_DICT)
-NODE_DICT_FAILED_EXPLOITS["exploits"][0]["exploitation_result"] = False
-NODE_DICT_FAILED_EXPLOITS["exploits"][1]["exploitation_result"] = False
+MACHINE = Machine(
+    id=1,
+    hardware_id=101,
+    island=True,
+    network_interfaces=[IPv4Interface(TARGET_IP_STR)],
+    operating_system=OperatingSystem.WINDOWS,
+)
 
 
 def test_get_exploits_used_on_node__2_exploits():
-    exploits = get_exploits_used_on_node(NODE_DICT)
-    assert sorted(exploits) == sorted(["Zerologon Exploiter", "Log4Shell Exploiter"])
+    exploits = get_exploits_used_on_node(MACHINE, [EVENT_1, EVENT_2])
+    assert sorted(exploits) == sorted(["SSH Exploiter", "Log4Shell Exploiter"])
 
 
 def test_get_exploits_used_on_node__duplicate_exploits():
-    exploits = get_exploits_used_on_node(NODE_DICT_DUPLICATE_EXPLOITS)
-    assert exploits == ["Log4Shell Exploiter"]
+    exploits = get_exploits_used_on_node(MACHINE, [EVENT_1, EVENT_1])
+    assert exploits == ["SSH Exploiter"]
 
 
-def test_get_exploits_used_on_node__failed():
-    exploits = get_exploits_used_on_node(NODE_DICT_FAILED_EXPLOITS)
-    assert exploits == []
+def test_get_exploits_used_on_node__returns_only_exploits_for_node():
+    exploits = get_exploits_used_on_node(MACHINE, [EVENT_1, EVENT_2, EVENT_3])
+    assert sorted(exploits) == sorted(["SSH Exploiter", "Log4Shell Exploiter"])


### PR DESCRIPTION
# What does this PR do?

Fixes part of #2269.

This addresses the parts of the report that use get_monkey_exploited(). This affects the following:
- The Security report:
    - Which info/warning message is displayed just below Overview
    -  The number of breached machines and the %Exploited in the "The Network from the Monkey's Eyes"
    - The number of breached servers listed above Breached Servers table
- The Ransomware report:
  - The number of breached servers listed in the Lateral Movement section

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing?
* [ ] ~~Was the CHANGELOG.md updated to reflect the changes?~~
* [ ] ~~Was the documentation framework updated to reflect the changes?~~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~~Added relevant unit tests?~~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running in the zoo environment
* [x] If applicable, add screenshots or log transcripts of the feature working
    > ![Screen Shot 2022-10-13 at 12 25 27 PM](https://user-images.githubusercontent.com/11077625/195657302-953f3da7-10b9-4def-a747-02176005010f.jpg)
    > ![Screen Shot 2022-10-13 at 12 21 22 PM](https://user-images.githubusercontent.com/11077625/195657347-bafd8697-2c20-4875-895e-f0455b066c58.jpg)
    > ![Screen Shot 2022-10-13 at 12 25 27 PM](https://user-images.githubusercontent.com/11077625/195657382-3382e748-b91c-44c6-982c-d2cf4010f4de.jpg)
    > ![Screen Shot 2022-10-13 at 12 28 33 PM](https://user-images.githubusercontent.com/11077625/195657409-9cd3739b-c165-43d9-a9cf-fbf6b6f26b66.jpg)



