### PR TITLE
2429 agent event registry

### DIFF
--- a/monkey/common/agent_events/__init__.py
+++ b/monkey/common/agent_events/__init__.py
@@ -1,4 +1,5 @@
 from .abstract_agent_event import AbstractAgentEvent
+from .agent_event_registry import AgentEventRegistry
 from .credentials_stolen_events import CredentialsStolenEvent
 from .ping_scan_event import PingScanEvent
 from .tcp_scan_event import TCPScanEvent

--- a/monkey/common/agent_events/__init__.py
+++ b/monkey/common/agent_events/__init__.py
@@ -7,3 +7,4 @@ from .exploitation_event import ExploitationEvent
 from .propagation_event import PropagationEvent
 from .password_restoration_event import PasswordRestorationEvent
 from .agent_shutdown_event import AgentShutdownEvent
+from .register import register_common_agent_events

--- a/monkey/common/agent_events/agent_event_registry.py
+++ b/monkey/common/agent_events/agent_event_registry.py
@@ -1,0 +1,27 @@
+from typing import Type
+
+from common.agent_events import AbstractAgentEvent
+
+
+class AgentEventRegistry:
+    """
+    Registry that maps event type names to classes
+
+    Example:
+        event_registry = AgentEventSerializerRegistry()
+        event_registry.register(MyEvent)
+
+        event_type = event_registry["MyEvent"]
+    """
+
+    def __init__(self):
+        self._registry = {}
+
+    def register(self, event_type: Type[AbstractAgentEvent]):
+        if not issubclass(event_type, AbstractAgentEvent):
+            raise TypeError(f"Event class must be of type: {AbstractAgentEvent.__name__}")
+
+        self._registry[event_type.__name__] = event_type
+
+    def __getitem__(self, event_type_name: str) -> Type[AbstractAgentEvent]:
+        return self._registry[event_type_name]

--- a/monkey/common/agent_events/register.py
+++ b/monkey/common/agent_events/register.py
@@ -1,0 +1,23 @@
+from common.agent_events import (
+    AgentShutdownEvent,
+    CredentialsStolenEvent,
+    ExploitationEvent,
+    PasswordRestorationEvent,
+    PingScanEvent,
+    PropagationEvent,
+    TCPScanEvent,
+)
+
+from . import AgentEventRegistry
+
+
+def register_common_agent_events(
+    agent_event_registry: AgentEventRegistry,
+):
+    agent_event_registry.register(CredentialsStolenEvent)
+    agent_event_registry.register(PingScanEvent)
+    agent_event_registry.register(TCPScanEvent)
+    agent_event_registry.register(PropagationEvent)
+    agent_event_registry.register(ExploitationEvent)
+    agent_event_registry.register(PasswordRestorationEvent)
+    agent_event_registry.register(AgentShutdownEvent)

--- a/monkey/monkey_island/cc/services/initialize.py
+++ b/monkey/monkey_island/cc/services/initialize.py
@@ -15,6 +15,7 @@ from common.agent_event_serializers import (
     AgentEventSerializerRegistry,
     register_common_agent_event_serializers,
 )
+from common.agent_events import AgentEventRegistry, register_common_agent_events
 from common.aws import AWSInstance
 from common.event_queue import (
     IAgentEventQueue,
@@ -84,6 +85,7 @@ def initialize_services(container: DIContainer, data_dir: Path):
     container.register(Publisher, Publisher)
     _register_event_queues(container)
 
+    _setup_agent_event_registry(container)
     _setup_agent_event_serializers(container)
     _register_repositories(container, data_dir)
     _register_services(container)
@@ -183,6 +185,13 @@ def _build_machine_repository(container: DIContainer) -> IMachineRepository:
     initialize_machine_repository(machine_repository)
 
     return machine_repository
+
+
+def _setup_agent_event_registry(container: DIContainer):
+    agent_event_registry = AgentEventRegistry()
+    register_common_agent_events(agent_event_registry)
+
+    container.register_instance(AgentEventRegistry, agent_event_registry)
 
 
 def _setup_agent_event_serializers(container: DIContainer):

--- a/monkey/tests/unit_tests/common/agent_events/test_agent_event_registry.py
+++ b/monkey/tests/unit_tests/common/agent_events/test_agent_event_registry.py
@@ -1,0 +1,37 @@
+import pytest
+from pydantic import Field
+
+from common.agent_events import AbstractAgentEvent, AgentEventRegistry
+
+
+def test_reject_invalid_classes():
+    class T:
+        pass
+
+    registry = AgentEventRegistry()
+
+    with pytest.raises(TypeError):
+        registry.register(T)
+
+
+def test_registration():
+    class SomeEvent(AbstractAgentEvent):
+        some_param: int = Field(default=435)
+
+    class OtherEvent(AbstractAgentEvent):
+        other_param: float = Field(default=123.456)
+
+    registry = AgentEventRegistry()
+
+    registry.register(SomeEvent)
+    registry.register(OtherEvent)
+
+    assert registry[SomeEvent.__name__] == SomeEvent
+    assert registry[OtherEvent.__name__] == OtherEvent
+
+
+def test_key_error():
+    registry = AgentEventRegistry()
+
+    with pytest.raises(KeyError):
+        registry["Nonexistant"]


### PR DESCRIPTION
# What does this PR do?

This PR supports issue #2429 and may also support #2378.

In order to filter events by type, the endpoint needs to be able to translate from event type name to a Type.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [] ~Was the documentation framework updated to reflect the changes?~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running unit tests
* [ ] ~If applicable, add screenshots or log transcripts of the feature working~
