### PR TITLE
UI: Add MapNode type

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/types/MapNode.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/types/MapNode.tsx
@@ -1,0 +1,34 @@
+export class MapNode {
+    machine_id: number
+    operating_system: string
+    hostname: string
+    network_interfaces: object
+    agent_is_running: boolean
+    island: boolean
+    propagated_to: boolean
+    connections: object
+    agent_id?: string
+    parent_id?: string
+
+    constructor(machine_id: number,
+        operating_system: string,
+        hostname: string,
+        network_interfaces: object,
+        agent_is_running: boolean,
+        island: boolean,
+        propagated_to: boolean,
+        connections: object,
+        agent_id?: string,
+        parent_id?: string) {
+        this.machine_id = machine_id
+        this.operating_system = operating_system
+        this.hostname = hostname
+        this.network_interfaces = network_interfaces
+        this.agent_is_running = agent_is_running
+        this.island = island
+        this.propagated_to = propagated_to
+        this.connections = connections
+        this.agent_id = agent_id
+        this.parent_id = parent_id
+    }
+}

--- a/monkey/monkey_island/cc/ui/src/components/types/MapNode.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/types/MapNode.tsx
@@ -1,34 +1,26 @@
-export class MapNode {
-    machine_id: number
-    operating_system: string
-    hostname: string
-    network_interfaces: object
-    agent_is_running: boolean
-    island: boolean
-    propagated_to: boolean
-    connections: object
-    agent_id?: string
-    parent_id?: string
+export enum OS {
+  unknown="unknown",
+  linux="linux",
+  windows="windows"
+}
 
-    constructor(machine_id: number,
-        operating_system: string,
-        hostname: string,
-        network_interfaces: object,
-        agent_is_running: boolean,
-        island: boolean,
-        propagated_to: boolean,
-        connections: object,
-        agent_id?: string,
-        parent_id?: string) {
-        this.machine_id = machine_id
-        this.operating_system = operating_system
-        this.hostname = hostname
-        this.network_interfaces = network_interfaces
-        this.agent_is_running = agent_is_running
-        this.island = island
-        this.propagated_to = propagated_to
-        this.connections = connections
-        this.agent_id = agent_id
-        this.parent_id = parent_id
-    }
+export enum CommunicationTypes {
+  cc = "cc",
+  scanned = "scanned",
+  exploited = "exploited"
+}
+
+export default class MapNode {
+  constructor(
+    public machine_id: number,
+    public network_interfaces: string[],
+    public agent_is_running: boolean,
+    public connections: Record<string, CommunicationTypes[]>,
+    public operating_system: OS = OS.unknown,
+    public hostname: string = "",
+    public island: boolean = false,
+    public propagated_to: boolean = false,
+    public agent_id: string = null,
+    public parent_id: string = null) {
+  }
 }


### PR DESCRIPTION
# What does this PR do?

Fixes part of #2334 .

MapNode is a class without a constructor which we can easily set the attributes. 

```
class MapNode {
    machine_id!: number
    operating_system!: string
    network_interfaces!: object
    parent_id!: string
}

let map_node = new MapNode();
map_node.machine_id = 2
map_node.operating_system = "Linux"
map_node.network_interfaces = {"bla": "bla"}
console.log(map_node)
```

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing?
* [x] Was the CHANGELOG.md updated to reflect the changes?
* [x] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [x] If applicable, add screenshots or log transcripts of the feature working
