### PR TITLE
Fix send logs on singleton failure

### DIFF
--- a/monkey/infection_monkey/agent_event_handlers/agent_event_forwarder.py
+++ b/monkey/infection_monkey/agent_event_handlers/agent_event_forwarder.py
@@ -29,7 +29,7 @@ class AgentEventForwarder:
         self._batching_agent_event_forwarder = BatchingAgentEventForwarder(island_api_client)
         self._batching_agent_event_forwarder.start()
 
-    def __del__(self):
+    def stop(self):
         self._batching_agent_event_forwarder.stop()
 
     def send_event(self, event: AbstractAgentEvent):

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -508,6 +508,7 @@ class InfectionMonkey:
         notify_disconnect(self._island_address)
 
     def _send_log(self):
+        logger.info("Sending agent logs to the Island")
         monkey_log_path = get_agent_log_path()
         if monkey_log_path.is_file():
             with open(monkey_log_path, "r") as f:

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -473,6 +473,7 @@ class InfectionMonkey:
             if deleted is None:
                 InfectionMonkey._self_delete()
         finally:
+            self._agent_event_forwarder.stop()
             self._singleton.unlock()
 
         logger.info("Monkey is shutting down")

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -137,7 +137,7 @@ class InfectionMonkey:
         self._telemetry_messenger = LegacyTelemetryMessengerAdapter()
         self._current_depth = self._opts.depth
         self._master = None
-        self._relay: TCPRelay
+        self._relay: Optional[TCPRelay] = None
 
     @staticmethod
     def _get_arguments(args):

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -1,4 +1,5 @@
 import argparse
+import contextlib
 import logging
 import os
 import subprocess
@@ -474,7 +475,8 @@ class InfectionMonkey:
                 InfectionMonkey._self_delete()
         finally:
             self._agent_event_forwarder.stop()
-            self._singleton.unlock()
+            with contextlib.suppress(AssertionError):
+                self._singleton.unlock()
 
         logger.info("Monkey is shutting down")
 


### PR DESCRIPTION
# What does this PR do?

Logs are sent to the Island even if the singleton couldn't be acquired. 

Add any further explanations here.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running an agent and ensuring logs get uploaded to the Island.
* [ ] ~If applicable, add screenshots or log transcripts of the feature working~
