### PR TITLE
2464 fix depth 1 bb test

### DIFF
--- a/envs/monkey_zoo/blackbox/test_configurations/depth_1_a.py
+++ b/envs/monkey_zoo/blackbox/test_configurations/depth_1_a.py
@@ -27,7 +27,6 @@ def _add_exploiters(agent_configuration: AgentConfiguration) -> AgentConfigurati
     brute_force = [
         PluginConfiguration(name="MSSQLExploiter", options={}),
         PluginConfiguration(name="SmbExploiter", options={"smb_download_timeout": 30}),
-        PluginConfiguration(name="SSHExploiter", options={}),
     ]
     vulnerability = [
         PluginConfiguration(name="HadoopExploiter", options={}),

--- a/monkey/infection_monkey/exploit/hadoop.py
+++ b/monkey/infection_monkey/exploit/hadoop.py
@@ -74,7 +74,8 @@ class HadoopExploiter(WebRCE):
                     self.exploit_result.propagation_success = True
                     break
         finally:
-            http_thread.join(self.DOWNLOAD_TIMEOUT)
+            if self.exploit_result.exploitation_success:
+                http_thread.join(self.DOWNLOAD_TIMEOUT)
             http_thread.stop()
 
         return self.exploit_result
@@ -98,8 +99,9 @@ class HadoopExploiter(WebRCE):
             # random.SystemRandom can block indefinitely in Linux
             rand_name = ID_STRING + "".join(
                 [
-                    random.choice(string.ascii_lowercase) for _ in range(self.RAN_STR_LEN)
-                ]  # noqa: DUO102
+                    random.choice(string.ascii_lowercase)  # noqa: DUO102
+                    for _ in range(self.RAN_STR_LEN)
+                ]
             )
             payload = self._build_payload(app_id, rand_name, command)
 

--- a/monkey/infection_monkey/exploit/hadoop.py
+++ b/monkey/infection_monkey/exploit/hadoop.py
@@ -86,6 +86,7 @@ class HadoopExploiter(WebRCE):
 
         try:
             # Get the newly created application id
+            timestamp = time()
             resp = requests.post(
                 posixpath.join(url, "ws/v1/cluster/apps/new-application"),
                 timeout=LONG_REQUEST_TIMEOUT,

--- a/monkey/infection_monkey/exploit/hadoop.py
+++ b/monkey/infection_monkey/exploit/hadoop.py
@@ -84,30 +84,39 @@ class HadoopExploiter(WebRCE):
             self._set_interrupted()
             return False
 
-        # Get the newly created application id
-        resp = requests.post(
-            posixpath.join(url, "ws/v1/cluster/apps/new-application"), timeout=LONG_REQUEST_TIMEOUT
-        )
-        resp_dict = json.loads(resp.content)
-        app_id = resp_dict["application-id"]
+        try:
+            # Get the newly created application id
+            resp = requests.post(
+                posixpath.join(url, "ws/v1/cluster/apps/new-application"),
+                timeout=LONG_REQUEST_TIMEOUT,
+            )
+            resp_dict = json.loads(resp.content)
+            app_id = resp_dict["application-id"]
 
-        # Create a random name for our application in YARN
-        # random.SystemRandom can block indefinitely in Linux
-        rand_name = ID_STRING + "".join(
-            [random.choice(string.ascii_lowercase) for _ in range(self.RAN_STR_LEN)]  # noqa: DUO102
-        )
-        payload = self._build_payload(app_id, rand_name, command)
+            # Create a random name for our application in YARN
+            # random.SystemRandom can block indefinitely in Linux
+            rand_name = ID_STRING + "".join(
+                [
+                    random.choice(string.ascii_lowercase) for _ in range(self.RAN_STR_LEN)
+                ]  # noqa: DUO102
+            )
+            payload = self._build_payload(app_id, rand_name, command)
 
-        if self._is_interrupted():
-            self._set_interrupted()
-            return False
+            if self._is_interrupted():
+                self._set_interrupted()
+                return False
 
-        timestamp = time()
-        resp = requests.post(
-            posixpath.join(url, "ws/v1/cluster/apps/"), json=payload, timeout=LONG_REQUEST_TIMEOUT
-        )
+            timestamp = time()
+            resp = requests.post(
+                posixpath.join(url, "ws/v1/cluster/apps/"),
+                json=payload,
+                timeout=LONG_REQUEST_TIMEOUT,
+            )
 
-        success = resp.status_code == 202
+            success = resp.status_code == 202
+        except requests.ConnectionError:
+            success = False
+
         message = "" if success else f"Failed to exploit via {url}"
         self._publish_exploitation_event(timestamp, success, error_message=message)
         self._publish_propagation_event(timestamp, success, error_message=message)


### PR DESCRIPTION
# What does this PR do?

Fixes #2464.

Addresses depth 1 blackbox test failure due to unhandled exception in the Hadoop exploiter. The exception is now handled, and a failed propagation event sent. Note that the depth 1 blackbox test still fails -- it appears that not all of the machines are able to be exploited in the given timeframe.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~~Was the CHANGELOG.md updated to reflect the changes?~~
* [ ] ~~Was the documentation framework updated to reflect the changes?~~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~~Added relevant unit tests?~~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running the depth 1 blackbox test
* [ ] If applicable, add screenshots or log transcripts of the feature working
