### PR TITLE
2506 remove get api local monkey

### DIFF
--- a/monkey/monkey_island/cc/models/monkey.py
+++ b/monkey/monkey_island/cc/models/monkey.py
@@ -73,20 +73,6 @@ class Monkey(Document):
             return Monkey.objects.order_by("-modifytime").first().modifytime
         return None
 
-    def is_dead(self):
-        monkey_is_dead = False
-        if self.dead:
-            monkey_is_dead = True
-        else:
-            try:
-                if MonkeyTtl.objects(id=self.ttl_ref.id).count() == 0:
-                    # No TTLs - monkey has timed out. The monkey is MIA.
-                    monkey_is_dead = True
-            except (DoesNotExist, AttributeError):
-                # Trying to dereference unknown document - the monkey is MIA.
-                monkey_is_dead = True
-        return monkey_is_dead
-
     @ring.lru()
     @staticmethod
     def get_label_by_id(object_id):

--- a/monkey/monkey_island/cc/resources/local_run.py
+++ b/monkey/monkey_island/cc/resources/local_run.py
@@ -2,10 +2,8 @@ import json
 
 from flask import jsonify, make_response, request
 
-from monkey_island.cc.models import Monkey
 from monkey_island.cc.resources.AbstractResource import AbstractResource
 from monkey_island.cc.resources.request_authentication import jwt_required
-from monkey_island.cc.services.node import NodeService
 from monkey_island.cc.services.run_local_monkey import LocalMonkeyRunService
 
 
@@ -14,19 +12,6 @@ class LocalRun(AbstractResource):
 
     def __init__(self, local_monkey_run_service: LocalMonkeyRunService):
         self._local_monkey_run_service = local_monkey_run_service
-
-    # API Spec: Both of these methods should be separated to their own resources
-
-    # API Spec: This should be a REST endpoint, /api/monkeys or something
-    @jwt_required
-    def get(self):
-        island_monkey = NodeService.get_monkey_island_monkey()
-        if island_monkey is not None:
-            is_monkey_running = not Monkey.get_single_monkey_by_id(island_monkey["_id"]).is_dead()
-        else:
-            is_monkey_running = False
-
-        return jsonify(is_running=is_monkey_running)
 
     # API Spec: This should be an RPC-style endpoint
     @jwt_required

--- a/monkey/monkey_island/cc/services/node.py
+++ b/monkey/monkey_island/cc/services/node.py
@@ -92,17 +92,6 @@ class NodeService:
             {"_id": monkey_id}, {"$set": {"modifytime": datetime.now()}}, upsert=False
         )
 
-    # TODO this returns a mock island agent
-    # It's better to just initialize the island machine on reset I think
-    @staticmethod
-    def get_monkey_island_monkey():
-        ip_addresses = get_my_ip_addresses_legacy()
-        for ip_address in ip_addresses:
-            monkey = NodeService.get_monkey_by_ip(ip_address)
-            if monkey is not None:
-                return monkey
-        return None
-
     @staticmethod
     def get_node_or_monkey_by_id(node_id):
         node = NodeService.get_node_by_id(node_id)

--- a/vulture_allowlist.py
+++ b/vulture_allowlist.py
@@ -82,6 +82,8 @@ Deployment.DOCKER
 Edge.meta
 Monkey.guid
 Monkey.launch_time
+Monkey.dead
+Monkey.ttl_ref
 MonkeyTtl.expire_at
 Report.overview
 Report.glance


### PR DESCRIPTION
# What does this PR do?

- Use /api/machines and /api/agents instead of /api/local-monkey to determine if Agents are currently running on the Island.
- Remove `GET /api/local-monkey`

Resolves #2506

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by manipulating stop times in the database and verifying the UI
* [ ] ~If applicable, add screenshots or log transcripts of the feature working~
