### PR TITLE
Fix MapNode group logic

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/types/MapNode.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/types/MapNode.tsx
@@ -65,8 +65,9 @@ export default class MapNode {
       group_components.push('island');
     }
 
-    if (this.agentIds) {
-      if (!this.island && _.isEmpty(this.parentIds)) {
+    if (this.agentIds.length > 0) {
+      if (!this.island &&
+          (_.isEmpty(this.parentIds) || !this.parentIds.some(elem => elem !== null))) {
         group_components.push('manual');
       }
       else {


### PR DESCRIPTION
# What does this PR do?

Fixes #2530 
Previously, if a node was only scanned, the map would still show the wrench icon. This PR fixes that.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing?
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running on GCP and checking the map
* [x] If applicable, add screenshots or log transcripts of the feature working

![image](https://user-images.githubusercontent.com/44770317/200807802-88e5d716-6909-4040-b378-5f59ad16c72f.png)
