### PR TITLE
Add OS discovery agent event

### DIFF
--- a/monkey/common/agent_events/__init__.py
+++ b/monkey/common/agent_events/__init__.py
@@ -8,4 +8,5 @@ from .propagation_event import PropagationEvent
 from .password_restoration_event import PasswordRestorationEvent
 from .agent_shutdown_event import AgentShutdownEvent
 from .file_encryption_event import FileEncryptionEvent
+from .os_discovery_event import OSDiscoveryEvent
 from .register import register_common_agent_events

--- a/monkey/common/agent_events/os_discovery_event.py
+++ b/monkey/common/agent_events/os_discovery_event.py
@@ -1,0 +1,17 @@
+from common.types import OperatingSystem
+
+from . import AbstractAgentEvent
+
+
+class OSDiscoveryEvent(AbstractAgentEvent):
+    """
+    An event that occurs when the Agent identifies the OS of the machine
+    on which it is running.
+
+    Attributes:
+        :param os: Operating system type
+        :param version: OS-specific version string
+    """
+
+    os: OperatingSystem
+    version: str

--- a/monkey/common/agent_events/register.py
+++ b/monkey/common/agent_events/register.py
@@ -3,6 +3,7 @@ from common.agent_events import (
     CredentialsStolenEvent,
     ExploitationEvent,
     FileEncryptionEvent,
+    OSDiscoveryEvent,
     PasswordRestorationEvent,
     PingScanEvent,
     PropagationEvent,
@@ -23,3 +24,4 @@ def register_common_agent_events(
     agent_event_registry.register(PasswordRestorationEvent)
     agent_event_registry.register(AgentShutdownEvent)
     agent_event_registry.register(FileEncryptionEvent)
+    agent_event_registry.register(OSDiscoveryEvent)

--- a/monkey/tests/unit_tests/common/agent_events/test_os_discovery_event.py
+++ b/monkey/tests/unit_tests/common/agent_events/test_os_discovery_event.py
@@ -1,0 +1,70 @@
+from uuid import UUID
+
+import pytest
+
+from common import OperatingSystem
+from common.agent_events import OSDiscoveryEvent
+
+AGENT_ID = UUID("012e7238-7b81-4108-8c7f-0787bc3f3c10")
+TIMESTAMP = 1664371327.4067292
+VERSION = "Ubuntu 22.04"
+
+OS_DISCOVERY_EVENT = OSDiscoveryEvent(
+    source=AGENT_ID, timestamp=TIMESTAMP, os=OperatingSystem.LINUX, version=VERSION
+)
+
+OS_DISCOVERY_OBJECT_DICT = {
+    "source": AGENT_ID,
+    "timestamp": TIMESTAMP,
+    "target": None,
+    "tags": [],
+    "os": OperatingSystem.LINUX,
+    "version": VERSION,
+}
+
+OS_DISCOVERY_SIMPLE_DICT = {
+    "source": str(AGENT_ID),
+    "timestamp": TIMESTAMP,
+    "os": "linux",
+    "target": None,
+    "tags": [],
+    "version": VERSION,
+}
+
+
+@pytest.mark.parametrize(
+    "event_dict",
+    [OS_DISCOVERY_OBJECT_DICT, OS_DISCOVERY_SIMPLE_DICT],
+)
+def test_constructor(event_dict):
+    assert OSDiscoveryEvent(**event_dict) == OS_DISCOVERY_EVENT
+
+
+def test_constructor__extra_fields_forbidden():
+    extra_field_dict = OS_DISCOVERY_SIMPLE_DICT.copy()
+    extra_field_dict["extra_field"] = 99  # red balloons
+
+    with pytest.raises(ValueError):
+        OSDiscoveryEvent(**extra_field_dict)
+
+
+def test_serialization():
+    serialized_event = OS_DISCOVERY_EVENT.dict(simplify=True)
+    assert serialized_event == OS_DISCOVERY_SIMPLE_DICT
+
+
+@pytest.mark.parametrize(
+    "key, value",
+    [
+        ("os", None),
+        ("os", 1),
+        ("os", "FakeOS"),
+        ("version", None),
+    ],
+)
+def test_construct_invalid_field__type_error(key, value):
+    invalid_type_dict = OS_DISCOVERY_SIMPLE_DICT.copy()
+    invalid_type_dict[key] = value
+
+    with pytest.raises(TypeError):
+        OSDiscoveryEvent(**invalid_type_dict)


### PR DESCRIPTION
# What does this PR do?

Fixes part of #2562.

Adds `OSDiscoveryEvent`, an agent event for OS information.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing?
* [ ] ~~Was the CHANGELOG.md updated to reflect the changes?~~
* [ ] ~~Was the documentation framework updated to reflect the changes?~~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~~Added relevant unit tests?~~
* [ ] ~~Have you successfully tested your changes locally? Elaborate:~~
* [ ] ~~If applicable, add screenshots or log transcripts of the feature working~~
