### PR TITLE
2562 handle agent os event

### DIFF
--- a/monkey/monkey_island/cc/agent_event_handlers/__init__.py
+++ b/monkey/monkey_island/cc/agent_event_handlers/__init__.py
@@ -2,4 +2,5 @@ from .save_event_to_event_repository import save_event_to_event_repository
 from .save_stolen_credentials_to_repository import save_stolen_credentials_to_repository
 from .scan_event_handler import ScanEventHandler
 from .update_agent_shutdown_status import update_agent_shutdown_status
+from .update_machine_os import update_machine_os
 from .update_nodes_on_exploitation import update_nodes_on_exploitation

--- a/monkey/monkey_island/cc/agent_event_handlers/update_machine_os.py
+++ b/monkey/monkey_island/cc/agent_event_handlers/update_machine_os.py
@@ -1,13 +1,10 @@
 from common.agent_events import OSDiscoveryEvent
-from monkey_island.cc.repository import AgentMachineFacade, IMachineRepository
+from monkey_island.cc.repository import AgentMachineFacade
 
 
 class update_machine_os:
-    def __init__(
-        self, agent_machine_facade: AgentMachineFacade, machine_repository: IMachineRepository
-    ):
+    def __init__(self, agent_machine_facade: AgentMachineFacade):
         self._agent_machine_facade = agent_machine_facade
-        self._machine_repository = machine_repository
 
     def __call__(self, event: OSDiscoveryEvent):
         # Get the agent machine
@@ -16,4 +13,4 @@ class update_machine_os:
         # Update the machine
         machine.operating_system = event.os
         machine.operating_system_version = event.version
-        self._machine_repository.upsert_machine(machine)
+        self._agent_machine_facade.update_agent_machine(event.source, machine)

--- a/monkey/monkey_island/cc/agent_event_handlers/update_machine_os.py
+++ b/monkey/monkey_island/cc/agent_event_handlers/update_machine_os.py
@@ -1,0 +1,18 @@
+from common.agent_events import OSDiscoveryEvent
+from monkey_island.cc.repository import IAgentRepository, IMachineRepository
+
+
+class update_machine_os:
+    def __init__(self, agent_repository: IAgentRepository, machine_repository: IMachineRepository):
+        self._agent_repository = agent_repository
+        self._machine_repository = machine_repository
+
+    def __call__(self, event: OSDiscoveryEvent):
+        # Get the agent machine
+        agent = self._agent_repository.get_agent_by_id(event.source)
+        machine = self._machine_repository.get_machine_by_id(agent.machine_id)
+
+        # Update the machine
+        machine.operating_system = event.os
+        machine.operating_system_version = event.version
+        self._machine_repository.upsert_machine(machine)

--- a/monkey/monkey_island/cc/agent_event_handlers/update_machine_os.py
+++ b/monkey/monkey_island/cc/agent_event_handlers/update_machine_os.py
@@ -13,4 +13,4 @@ class update_machine_os:
         # Update the machine
         machine.operating_system = event.os
         machine.operating_system_version = event.version
-        self._agent_machine_facade.update_agent_machine(event.source, machine)
+        self._agent_machine_facade.upsert_machine(machine)

--- a/monkey/monkey_island/cc/agent_event_handlers/update_machine_os.py
+++ b/monkey/monkey_island/cc/agent_event_handlers/update_machine_os.py
@@ -1,16 +1,17 @@
 from common.agent_events import OSDiscoveryEvent
-from monkey_island.cc.repository import IAgentRepository, IMachineRepository
+from monkey_island.cc.repository import AgentMachineFacade, IMachineRepository
 
 
 class update_machine_os:
-    def __init__(self, agent_repository: IAgentRepository, machine_repository: IMachineRepository):
-        self._agent_repository = agent_repository
+    def __init__(
+        self, agent_machine_facade: AgentMachineFacade, machine_repository: IMachineRepository
+    ):
+        self._agent_machine_facade = agent_machine_facade
         self._machine_repository = machine_repository
 
     def __call__(self, event: OSDiscoveryEvent):
         # Get the agent machine
-        agent = self._agent_repository.get_agent_by_id(event.source)
-        machine = self._machine_repository.get_machine_by_id(agent.machine_id)
+        machine = self._agent_machine_facade.get_agent_machine(event.source)
 
         # Update the machine
         machine.operating_system = event.os

--- a/monkey/monkey_island/cc/repository/__init__.py
+++ b/monkey/monkey_island/cc/repository/__init__.py
@@ -31,4 +31,5 @@ from .mongo_agent_event_repository import MongoAgentEventRepository
 from .file_agent_log_repository import FileAgentLogRepository
 
 from .utils import initialize_machine_repository
+from .agent_machine_facade import AgentMachineFacade
 from .network_model_update_facade import NetworkModelUpdateFacade

--- a/monkey/monkey_island/cc/repository/agent_machine_facade.py
+++ b/monkey/monkey_island/cc/repository/agent_machine_facade.py
@@ -21,7 +21,7 @@ class AgentMachineFacade:
 
         :param agent_id: An AgentID
         :return: The MachineID of the Machine that the Agent ran on
-        :raises UnknownRecordError: If no `Agent` with the specified `agent_id` could be found.
+        :raises UnknownRecordError: If no `Agent` with the specified `agent_id` could be found
         :raises RetrievalError: If an error occurs while attempting to retrieve the `Agent`
         """
         return self._agent_repository.get_agent_by_id(agent_id).machine_id
@@ -32,13 +32,28 @@ class AgentMachineFacade:
 
         :param agent_id: AgentID of the Agent
         :return: Machine that the Agent ran on
-        :raises UnknownRecordError: If no `Machine` for the specified `agent_id` could be found.
+        :raises UnknownRecordError: If no `Machine` for the specified `agent_id` could be found
         :raises RetrievalError: If an error occurs while attempting to retrieve the `Machine`
         """
         machine_id = self.get_machine_id_from_agent_id(agent_id)
         return self._machine_repository.get_machine_by_id(machine_id)
 
-    # Should I also add an update method?
+    def update_agent_machine(self, agent_id: AgentID, machine: Machine):
+        """
+        Update the machine for a given Agent
+
+        :param agent_id: The AgentID of the Agent
+        :param machine: The updated Machine
+        :raises UnknownRecordError: If no `Machine` for the specified `agent_id` could be found
+        :raises RetrievalError: If an error occurs while attempting to retrieve the `Machine`
+        :raises ValueError: If `machine`'s ID does not match the Agent's machine ID
+        :raises StorageError: If a problem occurred while attempting to store the `Machine`
+        """
+        machine_id = self.get_machine_id_from_agent_id(agent_id)
+        if machine.id != machine_id:
+            raise ValueError("Machine's ID does not match the agent's machine ID")
+
+        self._machine_repository.upsert_machine(machine)
 
     def reset_cache(self):
         self.get_machine_id_from_agent_id.cache_clear()

--- a/monkey/monkey_island/cc/repository/agent_machine_facade.py
+++ b/monkey/monkey_island/cc/repository/agent_machine_facade.py
@@ -1,0 +1,44 @@
+from functools import lru_cache
+
+from common.types import AgentID, MachineID
+from monkey_island.cc.models import Machine
+from monkey_island.cc.repository import IAgentRepository, IMachineRepository
+
+
+class AgentMachineFacade:
+    """
+    A simple facade for getting the Machine for an Agent
+    """
+
+    def __init__(self, agent_repository: IAgentRepository, machine_repository: IMachineRepository):
+        self._agent_repository = agent_repository
+        self._machine_repository = machine_repository
+
+    @lru_cache(maxsize=8192)
+    def get_machine_id_from_agent_id(self, agent_id: AgentID) -> MachineID:
+        """
+        Given an AgentID, get the MachineID of the machine the Agent ran on
+
+        :param agent_id: An AgentID
+        :return: The MachineID of the Machine that the Agent ran on
+        :raises UnknownRecordError: If no `Agent` with the specified `agent_id` could be found.
+        :raises RetrievalError: If an error occurs while attempting to retrieve the `Agent`
+        """
+        return self._agent_repository.get_agent_by_id(agent_id).machine_id
+
+    def get_agent_machine(self, agent_id: AgentID) -> Machine:
+        """
+        Get the Machine for a given Agent, by AgentID
+
+        :param agent_id: AgentID of the Agent
+        :return: Machine that the Agent ran on
+        :raises UnknownRecordError: If no `Machine` for the specified `agent_id` could be found.
+        :raises RetrievalError: If an error occurs while attempting to retrieve the `Machine`
+        """
+        machine_id = self.get_machine_id_from_agent_id(agent_id)
+        return self._machine_repository.get_machine_by_id(machine_id)
+
+    # Should I also add an update method?
+
+    def reset_cache(self):
+        self.get_machine_id_from_agent_id.cache_clear()

--- a/monkey/monkey_island/cc/repository/agent_machine_facade.py
+++ b/monkey/monkey_island/cc/repository/agent_machine_facade.py
@@ -38,21 +38,12 @@ class AgentMachineFacade:
         machine_id = self.get_machine_id_from_agent_id(agent_id)
         return self._machine_repository.get_machine_by_id(machine_id)
 
-    def update_agent_machine(self, agent_id: AgentID, machine: Machine):
+    def upsert_machine(self, machine: Machine):
         """
-        Update the machine for a given Agent
+        Upsert (insert or update) a `Machine`
 
-        :param agent_id: The AgentID of the Agent
-        :param machine: The updated Machine
-        :raises UnknownRecordError: If no `Machine` for the specified `agent_id` could be found
-        :raises RetrievalError: If an error occurs while attempting to retrieve the `Machine`
-        :raises ValueError: If `machine`'s ID does not match the Agent's machine ID
-        :raises StorageError: If a problem occurred while attempting to store the `Machine`
+        See :meth:`monkey_island.cc.models.Machine.upsert_machine`
         """
-        machine_id = self.get_machine_id_from_agent_id(agent_id)
-        if machine.id != machine_id:
-            raise ValueError("Machine's ID does not match the agent's machine ID")
-
         self._machine_repository.upsert_machine(machine)
 
     def reset_cache(self):

--- a/monkey/monkey_island/cc/repository/network_model_update_facade.py
+++ b/monkey/monkey_island/cc/repository/network_model_update_facade.py
@@ -6,7 +6,6 @@ from common.types import AgentID, MachineID
 from monkey_island.cc.models import CommunicationType, Machine
 from monkey_island.cc.repository import (
     AgentMachineFacade,
-    IAgentRepository,
     IMachineRepository,
     INodeRepository,
     UnknownRecordError,
@@ -21,12 +20,10 @@ class NetworkModelUpdateFacade:
     def __init__(
         self,
         agent_machine_facade: AgentMachineFacade,
-        agent_repository: IAgentRepository,
         machine_repository: IMachineRepository,
         node_repository: INodeRepository,
     ):
         self._agent_machine_facade = agent_machine_facade
-        self._agent_repository = agent_repository
         self._machine_repository = machine_repository
         self._node_repository = node_repository
 
@@ -57,7 +54,6 @@ class NetworkModelUpdateFacade:
         # For now, assume that IPs are unique
         return machines[0].id
 
-    @lru_cache(maxsize=8192)
     def get_machine_id_from_agent_id(self, agent_id: AgentID) -> MachineID:
         """
         Given an AgentID, get the MachineID of the machine the Agent ran on
@@ -65,7 +61,7 @@ class NetworkModelUpdateFacade:
         :param agent_id: An AgentID
         :return: The Machine that the Agent ran on
         """
-        return self._agent_repository.get_agent_by_id(agent_id).machine_id
+        return self._agent_machine_facade.get_machine_id_from_agent_id(agent_id)
 
     def upsert_communication_from_event(
         self, event: AbstractAgentEvent, communication_type: CommunicationType
@@ -94,4 +90,3 @@ class NetworkModelUpdateFacade:
 
     def reset_cache(self):
         self._get_machine_id_by_ip.cache_clear()
-        self.get_machine_id_from_agent_id.cache_clear()

--- a/monkey/monkey_island/cc/repository/network_model_update_facade.py
+++ b/monkey/monkey_island/cc/repository/network_model_update_facade.py
@@ -5,6 +5,7 @@ from common.agent_events import AbstractAgentEvent
 from common.types import AgentID, MachineID
 from monkey_island.cc.models import CommunicationType, Machine
 from monkey_island.cc.repository import (
+    AgentMachineFacade,
     IAgentRepository,
     IMachineRepository,
     INodeRepository,
@@ -19,10 +20,12 @@ class NetworkModelUpdateFacade:
 
     def __init__(
         self,
+        agent_machine_facade: AgentMachineFacade,
         agent_repository: IAgentRepository,
         machine_repository: IMachineRepository,
         node_repository: INodeRepository,
     ):
+        self._agent_machine_facade = agent_machine_facade
         self._agent_repository = agent_repository
         self._machine_repository = machine_repository
         self._node_repository = node_repository
@@ -82,7 +85,7 @@ class NetworkModelUpdateFacade:
         if not isinstance(event.target, IPv4Address):
             raise TypeError("Event targets must be of type IPv4Address")
 
-        source_machine_id = self.get_machine_id_from_agent_id(event.source)
+        source_machine_id = self._agent_machine_facade.get_machine_id_from_agent_id(event.source)
         target_machine = self.get_or_create_target_machine(event.target)
 
         self._node_repository.upsert_communication(

--- a/monkey/monkey_island/cc/services/initialize.py
+++ b/monkey/monkey_island/cc/services/initialize.py
@@ -30,6 +30,7 @@ from monkey_island.cc.event_queue import (
 )
 from monkey_island.cc.repository import (
     AgentBinaryRepository,
+    AgentMachineFacade,
     FileAgentConfigurationRepository,
     FileAgentLogRepository,
     FileRepositoryCachingDecorator,
@@ -156,6 +157,7 @@ def _register_repositories(container: DIContainer, data_dir: Path):
     container.register_instance(IMachineRepository, _build_machine_repository(container))
     container.register_instance(IAgentRepository, container.resolve(MongoAgentRepository))
     container.register_instance(IAgentLogRepository, container.resolve(FileAgentLogRepository))
+    container.register_instance(AgentMachineFacade, container.resolve(AgentMachineFacade))
     container.register_instance(
         NetworkModelUpdateFacade, container.resolve(NetworkModelUpdateFacade)
     )

--- a/monkey/monkey_island/cc/setup/agent_event_handlers.py
+++ b/monkey/monkey_island/cc/setup/agent_event_handlers.py
@@ -3,6 +3,7 @@ from common.agent_events import (
     AgentShutdownEvent,
     CredentialsStolenEvent,
     ExploitationEvent,
+    OSDiscoveryEvent,
     PingScanEvent,
     TCPScanEvent,
 )
@@ -12,6 +13,7 @@ from monkey_island.cc.agent_event_handlers import (
     save_event_to_event_repository,
     save_stolen_credentials_to_repository,
     update_agent_shutdown_status,
+    update_machine_os,
     update_nodes_on_exploitation,
 )
 
@@ -22,6 +24,7 @@ def setup_agent_event_handlers(container: DIContainer):
     _subscribe_and_store_to_event_repository(container, agent_event_queue)
     _subscribe_scan_events(container, agent_event_queue)
     _subscribe_exploitation_events(container, agent_event_queue)
+    _subscribe_os_discovery_events(container, agent_event_queue)
 
 
 def _subscribe_and_store_to_event_repository(
@@ -48,3 +51,8 @@ def _subscribe_exploitation_events(container: DIContainer, agent_event_queue: IA
     agent_event_queue.subscribe_type(
         ExploitationEvent, container.resolve(update_nodes_on_exploitation)
     )
+
+
+def _subscribe_os_discovery_events(container: DIContainer, agent_event_queue: IAgentEventQueue):
+    os_discovery_event_handler = container.resolve(update_machine_os)
+    agent_event_queue.subscribe_type(OSDiscoveryEvent, os_discovery_event_handler)

--- a/monkey/monkey_island/cc/setup/island_event_handlers.py
+++ b/monkey/monkey_island/cc/setup/island_event_handlers.py
@@ -7,6 +7,7 @@ from monkey_island.cc.island_event_handlers import (
     set_agent_configuration_per_island_mode,
 )
 from monkey_island.cc.repository import (
+    AgentMachineFacade,
     IAgentEventRepository,
     IAgentLogRepository,
     IAgentRepository,
@@ -56,6 +57,9 @@ def _subscribe_clear_simulation_data_events(
 
     network_model_update_facade = container.resolve(NetworkModelUpdateFacade)
     island_event_queue.subscribe(topic, network_model_update_facade.reset_cache)
+
+    agent_machine_facade = container.resolve(AgentMachineFacade)
+    island_event_queue.subscribe(topic, agent_machine_facade.reset_cache)
 
     for i_repository in [
         IAgentEventRepository,

--- a/monkey/tests/unit_tests/monkey_island/cc/agent_event_handlers/test_scan_event_handler.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/agent_event_handlers/test_scan_event_handler.py
@@ -13,6 +13,7 @@ from common.types import NetworkService, PortStatus, SocketAddress
 from monkey_island.cc.agent_event_handlers import ScanEventHandler
 from monkey_island.cc.models import Agent, CommunicationType, Machine, Node
 from monkey_island.cc.repository import (
+    AgentMachineFacade,
     IAgentRepository,
     IMachineRepository,
     INodeRepository,
@@ -129,8 +130,13 @@ def node_repository() -> INodeRepository:
 
 
 @pytest.fixture
-def network_model_update_facade(agent_repository, machine_repository, node_repository):
-    return NetworkModelUpdateFacade(agent_repository, machine_repository, node_repository)
+def agent_machine_facade(agent_repository, machine_repository):
+    return AgentMachineFacade(agent_repository, machine_repository)
+
+
+@pytest.fixture
+def network_model_update_facade(agent_machine_facade, machine_repository, node_repository):
+    return NetworkModelUpdateFacade(agent_machine_facade, machine_repository, node_repository)
 
 
 @pytest.fixture
@@ -168,12 +174,13 @@ def handler(scan_event_handler, request):
 
 
 def test_ping_scan_event_target_machine_not_exists(
+    agent_machine_facade: AgentMachineFacade,
     agent_repository: IAgentRepository,
     in_memory_machine_repository: IMachineRepository,
     node_repository,
 ):
     network_model_update_facade = NetworkModelUpdateFacade(
-        agent_repository, in_memory_machine_repository, node_repository
+        agent_machine_facade, in_memory_machine_repository, node_repository
     )
     scan_event_handler = ScanEventHandler(
         network_model_update_facade, in_memory_machine_repository, node_repository

--- a/monkey/tests/unit_tests/monkey_island/cc/agent_event_handlers/test_update_machine_os.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/agent_event_handlers/test_update_machine_os.py
@@ -9,7 +9,12 @@ from common.agent_events import OSDiscoveryEvent
 from common.types import SocketAddress
 from monkey_island.cc.agent_event_handlers import update_machine_os
 from monkey_island.cc.models import Agent, Machine
-from monkey_island.cc.repository import IAgentRepository, IMachineRepository, UnknownRecordError
+from monkey_island.cc.repository import (
+    AgentMachineFacade,
+    IAgentRepository,
+    IMachineRepository,
+    UnknownRecordError,
+)
 
 # The machine
 MACHINE_ID = 99
@@ -48,8 +53,13 @@ def machine_repository() -> IMachineRepository:
 
 
 @pytest.fixture
-def updater(agent_repository, machine_repository) -> update_machine_os:
-    return update_machine_os(agent_repository, machine_repository)
+def agent_machine_facade(agent_repository, machine_repository) -> AgentMachineFacade:
+    return AgentMachineFacade(agent_repository, machine_repository)
+
+
+@pytest.fixture
+def updater(agent_machine_facade, machine_repository) -> update_machine_os:
+    return update_machine_os(agent_machine_facade, machine_repository)
 
 
 def test_machine_updated(updater, machine_repository):

--- a/monkey/tests/unit_tests/monkey_island/cc/agent_event_handlers/test_update_machine_os.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/agent_event_handlers/test_update_machine_os.py
@@ -1,0 +1,75 @@
+from ipaddress import IPv4Interface
+from unittest.mock import MagicMock
+from uuid import UUID
+
+import pytest
+
+from common import OperatingSystem
+from common.agent_events import OSDiscoveryEvent
+from common.types import SocketAddress
+from monkey_island.cc.agent_event_handlers import update_machine_os
+from monkey_island.cc.models import Agent, Machine
+from monkey_island.cc.repository import IAgentRepository, IMachineRepository, UnknownRecordError
+
+# The machine
+MACHINE_ID = 99
+MACHINE = Machine(
+    id=MACHINE_ID, hardware_id=33, network_interfaces=[IPv4Interface("10.10.10.55/24")]
+)
+
+# The agent
+AGENT_ID = UUID("72a64013-b3ab-4be9-9f05-0ffaccf01950")
+CC_SERVER = SocketAddress(ip="10.10.10.100", port="5000")
+AGENT = Agent(id=AGENT_ID, machine_id=MACHINE_ID, start_time=0, cc_server=CC_SERVER)
+
+# The event
+EVENT = OSDiscoveryEvent(source=AGENT_ID, os=OperatingSystem.LINUX, version="blah")
+
+
+@pytest.fixture
+def agent_repository() -> IAgentRepository:
+    repository = MagicMock(spec=IAgentRepository)
+    repository.get_agent_by_id = MagicMock(return_value=AGENT)
+    return repository
+
+
+MACHINES_BY_ID = {MACHINE_ID: MACHINE}
+
+
+def machine_from_id(id):
+    return MACHINES_BY_ID[id]
+
+
+@pytest.fixture
+def machine_repository() -> IMachineRepository:
+    repository = MagicMock(spec=IMachineRepository)
+    repository.get_machine_by_id = MagicMock(side_effect=machine_from_id)
+    return repository
+
+
+@pytest.fixture
+def updater(agent_repository, machine_repository) -> update_machine_os:
+    return update_machine_os(agent_repository, machine_repository)
+
+
+def test_machine_updated(updater, machine_repository):
+    updater(EVENT)
+    assert machine_repository.upsert_machine.called
+
+
+def test_machine_not_updated_if_no_agent(updater, agent_repository, machine_repository):
+    agent_repository.get_agent_by_id = MagicMock(side_effect=UnknownRecordError)
+
+    with pytest.raises(UnknownRecordError):
+        updater(EVENT)
+
+    assert not machine_repository.upsert_machine.called
+
+
+def test_machine_not_updated_if_no_machine(updater, machine_repository):
+    machine_repository.get_machine_by_id = MagicMock(side_effect=UnknownRecordError)
+
+    with pytest.raises(UnknownRecordError):
+        updater(EVENT)
+
+    assert not machine_repository.upsert_machine.called

--- a/monkey/tests/unit_tests/monkey_island/cc/agent_event_handlers/test_update_machine_os.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/agent_event_handlers/test_update_machine_os.py
@@ -58,8 +58,8 @@ def agent_machine_facade(agent_repository, machine_repository) -> AgentMachineFa
 
 
 @pytest.fixture
-def updater(agent_machine_facade, machine_repository) -> update_machine_os:
-    return update_machine_os(agent_machine_facade, machine_repository)
+def updater(agent_machine_facade) -> update_machine_os:
+    return update_machine_os(agent_machine_facade)
 
 
 def test_machine_updated(updater, machine_repository):

--- a/monkey/tests/unit_tests/monkey_island/cc/repository/test_agent_machine_facade.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/repository/test_agent_machine_facade.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from ipaddress import IPv4Address, IPv4Interface
 from uuid import UUID
 
@@ -84,8 +85,11 @@ def test_get_agent_machine(agent_machine_facade):
     assert agent_machine_facade.get_agent_machine(AGENT_ID) == SOURCE_MACHINE
 
 
-def test_update_agent_machine__throws_error_if_machine_id_differs(agent_machine_facade):
-    updated_machine = Machine(id=SOURCE_MACHINE.id + 100)
+def test_upsert_machine(agent_machine_facade, machine_repository):
+    new_machine = deepcopy(SOURCE_MACHINE)
+    new_machine.hostname = "blah"
 
-    with pytest.raises(ValueError):
-        agent_machine_facade.update_agent_machine(AGENT_ID, updated_machine)
+    agent_machine_facade.upsert_machine(new_machine)
+
+    machines = machine_repository.get_machines()
+    assert list(machines) == [new_machine]

--- a/monkey/tests/unit_tests/monkey_island/cc/repository/test_agent_machine_facade.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/repository/test_agent_machine_facade.py
@@ -1,0 +1,84 @@
+from ipaddress import IPv4Address, IPv4Interface
+from uuid import UUID
+
+import pytest
+from tests.monkey_island import InMemoryAgentRepository, InMemoryMachineRepository
+
+from common.types import SocketAddress
+from monkey_island.cc.models import Agent, Machine
+from monkey_island.cc.repository import AgentMachineFacade, IAgentRepository, IMachineRepository
+
+SEED_ID = 99
+SOURCE_IP_ADDRESS = IPv4Address("10.10.10.99")
+
+SOURCE_MACHINE_ID = 1
+SOURCE_MACHINE = Machine(
+    id=SOURCE_MACHINE_ID,
+    hardware_id=5,
+    network_interfaces=[IPv4Interface(SOURCE_IP_ADDRESS)],
+)
+
+AGENT_ID = UUID("655fd01c-5eec-4e42-b6e3-1fb738c2978d")
+AGENT = Agent(
+    id=AGENT_ID,
+    machine_id=SOURCE_MACHINE_ID,
+    start_time=0,
+    parent_id=None,
+    cc_server=(SocketAddress(ip="10.10.10.10", port=5000)),
+)
+
+
+@pytest.fixture
+def agent_repository() -> IAgentRepository:
+    agent_repository = InMemoryAgentRepository()
+    agent_repository.upsert_agent(AGENT)
+
+    return agent_repository
+
+
+@pytest.fixture
+def machine_repository() -> IMachineRepository:
+    machine_repository = InMemoryMachineRepository(SEED_ID)
+    machine_repository.upsert_machine(SOURCE_MACHINE)
+
+    return machine_repository
+
+
+@pytest.fixture
+def agent_machine_facade(agent_repository, machine_repository) -> AgentMachineFacade:
+    return AgentMachineFacade(agent_repository, machine_repository)
+
+
+def test_get_machine_id_from_agent_id(agent_machine_facade):
+    assert agent_machine_facade.get_machine_id_from_agent_id(AGENT_ID) == SOURCE_MACHINE_ID
+
+
+def test_cache_reset__get_machine_id_from_agent_id(
+    agent_machine_facade, agent_repository, machine_repository
+):
+    original_machine_id = agent_machine_facade.get_machine_id_from_agent_id(AGENT_ID)
+    new_machine_id = original_machine_id + 100
+    new_machine = Machine(
+        id=new_machine_id,
+        hardware_id=5,
+        network_interfaces=[IPv4Interface(SOURCE_IP_ADDRESS)],
+    )
+    machine_repository.upsert_machine(new_machine)
+    new_agent = Agent(
+        id=AGENT_ID,
+        machine_id=new_machine_id,
+        start_time=0,
+        parent_id=None,
+        cc_server=(SocketAddress(ip="10.10.10.10", port=5000)),
+    )
+
+    agent_repository.reset()
+    agent_repository.upsert_agent(new_agent)
+    agent_machine_facade.reset_cache()
+    new_machine_id = agent_machine_facade.get_machine_id_from_agent_id(AGENT_ID)
+
+    assert original_machine_id != new_machine_id
+
+
+def test_get_agent_machine(agent_machine_facade):
+    assert agent_machine_facade.get_agent_machine(AGENT_ID) == SOURCE_MACHINE

--- a/monkey/tests/unit_tests/monkey_island/cc/repository/test_agent_machine_facade.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/repository/test_agent_machine_facade.py
@@ -82,3 +82,10 @@ def test_cache_reset__get_machine_id_from_agent_id(
 
 def test_get_agent_machine(agent_machine_facade):
     assert agent_machine_facade.get_agent_machine(AGENT_ID) == SOURCE_MACHINE
+
+
+def test_update_agent_machine__throws_error_if_machine_id_differs(agent_machine_facade):
+    updated_machine = Machine(id=SOURCE_MACHINE.id + 100)
+
+    with pytest.raises(ValueError):
+        agent_machine_facade.update_agent_machine(AGENT_ID, updated_machine)

--- a/monkey/tests/unit_tests/monkey_island/cc/repository/test_network_model_update_facade.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/repository/test_network_model_update_facade.py
@@ -9,6 +9,7 @@ from common.agent_events import AbstractAgentEvent
 from common.types import SocketAddress
 from monkey_island.cc.models import Agent, CommunicationType, Machine
 from monkey_island.cc.repository import (
+    AgentMachineFacade,
     IAgentRepository,
     IMachineRepository,
     INodeRepository,
@@ -79,12 +80,22 @@ def node_repository() -> INodeRepository:
 
 
 @pytest.fixture
+def agent_machine_facade(
+    agent_repository: IAgentRepository, machine_repository: IMachineRepository
+) -> AgentMachineFacade:
+    return AgentMachineFacade(agent_repository, machine_repository)
+
+
+@pytest.fixture
 def network_model_update_facade(
+    agent_machine_facade: AgentMachineFacade,
     agent_repository: IAgentRepository,
     machine_repository: IMachineRepository,
     node_repository: INodeRepository,
 ) -> NetworkModelUpdateFacade:
-    return NetworkModelUpdateFacade(agent_repository, machine_repository, node_repository)
+    return NetworkModelUpdateFacade(
+        agent_machine_facade, agent_repository, machine_repository, node_repository
+    )
 
 
 def test_return_existing_machine(network_model_update_facade, machine_repository):

--- a/monkey/tests/unit_tests/monkey_island/cc/repository/test_network_model_update_facade.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/repository/test_network_model_update_facade.py
@@ -89,13 +89,10 @@ def agent_machine_facade(
 @pytest.fixture
 def network_model_update_facade(
     agent_machine_facade: AgentMachineFacade,
-    agent_repository: IAgentRepository,
     machine_repository: IMachineRepository,
     node_repository: INodeRepository,
 ) -> NetworkModelUpdateFacade:
-    return NetworkModelUpdateFacade(
-        agent_machine_facade, agent_repository, machine_repository, node_repository
-    )
+    return NetworkModelUpdateFacade(agent_machine_facade, machine_repository, node_repository)
 
 
 def test_return_existing_machine(network_model_update_facade, machine_repository):
@@ -113,13 +110,6 @@ def test_create_new_machine(network_model_update_facade, machine_repository):
 
     assert target_machine == EXPECTED_CREATED_MACHINE
     assert machine_repository.get_machine_by_id(target_machine.id) == target_machine
-
-
-def test_get_machine_id_from_agent_id(network_model_update_facade):
-    assert (
-        network_model_update_facade.get_machine_id_from_agent_id(SOURCE_AGENT_ID)
-        == SOURCE_MACHINE_ID
-    )
 
 
 def test_upsert_communication_from_event(network_model_update_facade, node_repository):
@@ -151,30 +141,3 @@ def test_cache_reset__get_or_create_target_machine(network_model_update_facade, 
     new_target = network_model_update_facade.get_or_create_target_machine(TARGET_IP_ADDRESS)
 
     assert original_target.id != new_target.id
-
-
-def test_cache_reset__get_machine_id_from_agent_id(
-    network_model_update_facade, agent_repository, machine_repository
-):
-    original_machine_id = network_model_update_facade.get_machine_id_from_agent_id(SOURCE_AGENT_ID)
-    new_machine_id = original_machine_id + 100
-    new_machine = Machine(
-        id=new_machine_id,
-        hardware_id=5,
-        network_interfaces=[IPv4Interface(SOURCE_IP_ADDRESS)],
-    )
-    machine_repository.upsert_machine(new_machine)
-    new_agent = Agent(
-        id=SOURCE_AGENT_ID,
-        machine_id=new_machine_id,
-        start_time=0,
-        parent_id=None,
-        cc_server=(SocketAddress(ip="10.10.10.10", port=5000)),
-    )
-
-    agent_repository.reset()
-    agent_repository.upsert_agent(new_agent)
-    network_model_update_facade.reset_cache()
-    new_machine_id = network_model_update_facade.get_machine_id_from_agent_id(SOURCE_AGENT_ID)
-
-    assert original_machine_id != new_machine_id


### PR DESCRIPTION
# What does this PR do?

Fixes part of #2562.
Should be merged after #2572.

Update the Island to handle `OSDiscoveryEvent`s.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~~Was the CHANGELOG.md updated to reflect the changes?~~
* [ ] ~~Was the documentation framework updated to reflect the changes?~~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running in the zoo environment
* [x] If applicable, add screenshots or log transcripts of the feature working

    > ![Screen Shot 2022-11-11 at 4 04 13 PM](https://user-images.githubusercontent.com/11077625/201430596-0f420f9f-1805-40c1-917d-51a4088e1fca.jpg)
