### PR TITLE
BB: Make credentials reuse the first test

### DIFF
--- a/envs/monkey_zoo/blackbox/test_blackbox.py
+++ b/envs/monkey_zoo/blackbox/test_blackbox.py
@@ -77,6 +77,8 @@ def island_client(island):
     yield island_client_object
 
 
+# NOTE: These test methods are ordered to give time for the slower zoo machines
+# to boot up and finish starting services.
 @pytest.mark.usefixtures("island_client")
 # noinspection PyUnresolvedReferences
 class TestMonkeyBlackbox:
@@ -107,8 +109,11 @@ class TestMonkeyBlackbox:
     def get_log_dir_path():
         return os.path.abspath(LOG_DIR_PATH)
 
-    # If test_depth_1_a() is run first, some test will fail because machines are not yet fully
-    # booted. Running test_depth_2_a() first gives slow VMs extra time to boot.
+    def test_credentials_reuse_ssh_key(self, island_client):
+        TestMonkeyBlackbox.run_exploitation_test(
+            island_client, credentials_reuse_ssh_key_test_configuration, "Credentials_Reuse_SSH_Key"
+        )
+
     def test_depth_2_a(self, island_client):
         TestMonkeyBlackbox.run_exploitation_test(
             island_client, depth_2_a_test_configuration, "Depth2A test suite"
@@ -153,11 +158,6 @@ class TestMonkeyBlackbox:
             timeout=DEFAULT_TIMEOUT_SECONDS + 30,
             log_handler=log_handler,
         ).run()
-
-    def test_credentials_reuse_ssh_key(self, island_client):
-        TestMonkeyBlackbox.run_exploitation_test(
-            island_client, credentials_reuse_ssh_key_test_configuration, "Credentials_Reuse_SSH_Key"
-        )
 
     # Not grouped because conflicts with SMB.
     # Consider grouping when more depth 1 exploiters collide with group depth_1_a


### PR DESCRIPTION
# What does this PR do?

Fixes #2601.

Arranges the blackbox tests so that the credentials reuse test happens first.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing?
* [ ] ~~Was the CHANGELOG.md updated to reflect the changes?~~
* [ ] ~~Was the documentation framework updated to reflect the changes?~~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~~Added relevant unit tests?~~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running the blackbox tests in the zoo
* [x] If applicable, add screenshots or log transcripts of the feature working
    Observe that the credentials reuse test runs first:
    ```
    20:19:49 [INFO] gcp_machine_handlers.start_machines.49: GCP machines successfully started.
    20:20:19 [INFO] test_blackbox.delete_logs.58: Deleting monkey logs before new tests.
    ----------------------------------------------------------------------------------- live log call -----------------------------------------------------------------------------------
    20:20:20 [INFO] monkey_island_client._set_island_mode.47: Setting island mode to Custom.
    20:20:20 [INFO] monkey_island_client._import_config.59: Configuration is imported.
    20:20:20 [INFO] monkey_island_client._import_credentials.74: Credentials are imported.
    20:20:20 [INFO] exploitation.print_test_starting_info.38: Started Credentials_Reuse_SSH_Key test
    20:20:20 [INFO] exploitation.print_test_starting_info.40: Machines participating in test: 10.2.3.14, 10.2.4.15, 10.2.5.16

    20:20:20 [INFO] monkey_island_client.run_monkey_local.83: Running the monkey.
    20:20:48 [INFO] exploitation.log_success.57:
    CommunicationAnalyzer:
    Agent from 10.2.3.14 communicated back
    Agent from 10.2.4.15 communicated back
    Agent from 10.2.5.16 communicated back

    20:20:48 [INFO] exploitation.log_success.59: Credentials_Reuse_SSH_Key test passed, time taken: 28.4 seconds.
    ```
