### PR TITLE
Common: Move PluginType enum from types.py to plugin/plugin_type.py

### DIFF
--- a/monkey/common/agent_plugins/__init__.py
+++ b/monkey/common/agent_plugins/__init__.py
@@ -1,0 +1,1 @@
+from .agent_plugin_type import AgentPluginType

--- a/monkey/common/agent_plugins/agent_plugin_type.py
+++ b/monkey/common/agent_plugins/agent_plugin_type.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class PluginType(Enum):
+class AgentPluginType(Enum):
     CREDENTIAL_COLLECTOR = "CredentialCollector"
     EXPLOITER = "Exploiter"
     FINGERPRINTER = "Fingerprinter"

--- a/monkey/common/plugins/plugin_type.py
+++ b/monkey/common/plugins/plugin_type.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class PluginType(Enum):
+    CREDENTIAL_COLLECTOR = "CredentialCollector"
+    EXPLOITER = "Exploiter"
+    FINGERPRINTER = "Fingerprinter"
+    PAYLOAD = "Payload"

--- a/monkey/common/types.py
+++ b/monkey/common/types.py
@@ -92,10 +92,3 @@ class SocketAddress(InfectionMonkeyBaseModel):
 
     def __str__(self):
         return f"{self.ip}:{self.port}"
-
-
-class PluginType(Enum):
-    CREDENTIAL_COLLECTOR = "CredentialCollector"
-    EXPLOITER = "Exploiter"
-    FINGERPRINTER = "Fingerprinter"
-    PAYLOAD = "Payload"

--- a/monkey/infection_monkey/i_puppet/i_puppet.py
+++ b/monkey/infection_monkey/i_puppet/i_puppet.py
@@ -4,8 +4,8 @@ from collections import namedtuple
 from dataclasses import dataclass
 from typing import Dict, Mapping, Optional, Sequence
 
+from common.agent_plugins import AgentPluginType
 from common.credentials import Credentials
-from common.plugins.plugin_type import PluginType
 from common.types import PingScanData
 from infection_monkey.model import VictimHost
 
@@ -29,13 +29,13 @@ FingerprintData = namedtuple("FingerprintData", ["os_type", "os_version", "servi
 
 class IPuppet(metaclass=abc.ABCMeta):
     @abc.abstractmethod
-    def load_plugin(self, plugin_name: str, plugin: object, plugin_type: PluginType) -> None:
+    def load_plugin(self, plugin_name: str, plugin: object, plugin_type: AgentPluginType) -> None:
         """
         Loads a plugin into the puppet
 
         :param str plugin_name: The plugin class name
         :param object plugin: The plugin object to load
-        :param PluginType plugin_type: The type of plugin being loaded
+        :param AgentPluginType plugin_type: The type of plugin being loaded
         """
 
     @abc.abstractmethod

--- a/monkey/infection_monkey/i_puppet/i_puppet.py
+++ b/monkey/infection_monkey/i_puppet/i_puppet.py
@@ -5,7 +5,8 @@ from dataclasses import dataclass
 from typing import Dict, Mapping, Optional, Sequence
 
 from common.credentials import Credentials
-from common.types import PingScanData, PluginType
+from common.plugins.plugin_type import PluginType
+from common.types import PingScanData
 from infection_monkey.model import VictimHost
 
 

--- a/monkey/infection_monkey/island_api_client/http_island_api_client.py
+++ b/monkey/infection_monkey/island_api_client/http_island_api_client.py
@@ -10,9 +10,9 @@ from common import AgentHeartbeat, AgentRegistrationData, AgentSignals, Operatin
 from common.agent_configuration import AgentConfiguration
 from common.agent_event_serializers import AgentEventSerializerRegistry
 from common.agent_events import AbstractAgentEvent
+from common.agent_plugins import AgentPluginType
 from common.common_consts.timeouts import SHORT_REQUEST_TIMEOUT
 from common.credentials import Credentials
-from common.plugins.plugin_type import PluginType
 from common.types import AgentID, JSONSerializable, SocketAddress
 
 from . import AbstractIslandAPIClientFactory, IIslandAPIClient, IslandAPIRequestError
@@ -60,7 +60,7 @@ class HTTPIslandAPIClient(IIslandAPIClient):
         response = self.http_client.get(f"agent-binaries/{os_name}")
         return response.content
 
-    def get_agent_plugin(self, plugin_type: PluginType, plugin_name: str) -> bytes:
+    def get_agent_plugin(self, plugin_type: AgentPluginType, plugin_name: str) -> bytes:
         response = self.http_client.get(f"/api/agent-plugins/{plugin_type.value}/{plugin_name}")
 
         return response.content

--- a/monkey/infection_monkey/island_api_client/http_island_api_client.py
+++ b/monkey/infection_monkey/island_api_client/http_island_api_client.py
@@ -12,7 +12,8 @@ from common.agent_event_serializers import AgentEventSerializerRegistry
 from common.agent_events import AbstractAgentEvent
 from common.common_consts.timeouts import SHORT_REQUEST_TIMEOUT
 from common.credentials import Credentials
-from common.types import AgentID, JSONSerializable, PluginType, SocketAddress
+from common.plugins.plugin_type import PluginType
+from common.types import AgentID, JSONSerializable, SocketAddress
 
 from . import AbstractIslandAPIClientFactory, IIslandAPIClient, IslandAPIRequestError
 from .http_client import HTTPClient

--- a/monkey/infection_monkey/island_api_client/i_island_api_client.py
+++ b/monkey/infection_monkey/island_api_client/i_island_api_client.py
@@ -5,7 +5,8 @@ from common import AgentRegistrationData, AgentSignals, OperatingSystem
 from common.agent_configuration import AgentConfiguration
 from common.agent_events import AbstractAgentEvent
 from common.credentials import Credentials
-from common.types import AgentID, PluginType, SocketAddress
+from common.plugins.plugin_type import PluginType
+from common.types import AgentID, SocketAddress
 
 
 class IIslandAPIClient(ABC):

--- a/monkey/infection_monkey/island_api_client/i_island_api_client.py
+++ b/monkey/infection_monkey/island_api_client/i_island_api_client.py
@@ -4,8 +4,8 @@ from typing import Sequence
 from common import AgentRegistrationData, AgentSignals, OperatingSystem
 from common.agent_configuration import AgentConfiguration
 from common.agent_events import AbstractAgentEvent
+from common.agent_plugins import AgentPluginType
 from common.credentials import Credentials
-from common.plugins.plugin_type import PluginType
 from common.types import AgentID, SocketAddress
 
 
@@ -48,7 +48,7 @@ class IIslandAPIClient(ABC):
         """
 
     @abstractmethod
-    def get_agent_plugin(self, plugin_type: PluginType, plugin_name: str) -> bytes:
+    def get_agent_plugin(self, plugin_type: AgentPluginType, plugin_name: str) -> bytes:
         """
         Gets plugin from the Island based on plugin type and name
 

--- a/monkey/infection_monkey/master/plugin_registry.py
+++ b/monkey/infection_monkey/master/plugin_registry.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any
 
-from common.types import PluginType
+from common.plugins.plugin_type import PluginType
 from infection_monkey.i_puppet import UnknownPluginError
 from infection_monkey.island_api_client import IIslandAPIClient
 

--- a/monkey/infection_monkey/master/plugin_registry.py
+++ b/monkey/infection_monkey/master/plugin_registry.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any
 
-from common.plugins.plugin_type import PluginType
+from common.agent_plugins import AgentPluginType
 from infection_monkey.i_puppet import UnknownPluginError
 from infection_monkey.island_api_client import IIslandAPIClient
 
@@ -22,13 +22,13 @@ class PluginRegistry:
         self._registry = {}
         self._island_api_client = island_api_client
 
-    def load_plugin(self, plugin_name: str, plugin: object, plugin_type: PluginType) -> None:
+    def load_plugin(self, plugin_name: str, plugin: object, plugin_type: AgentPluginType) -> None:
         self._registry.setdefault(plugin_type, {})
         self._registry[plugin_type][plugin_name] = plugin
 
         logger.debug(f"Plugin '{plugin_name}' loaded")
 
-    def get_plugin(self, plugin_name: str, plugin_type: PluginType) -> Any:
+    def get_plugin(self, plugin_name: str, plugin_type: AgentPluginType) -> Any:
         try:
             plugin = self._registry[plugin_type][plugin_name]
         except KeyError:

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -23,10 +23,10 @@ from common.agent_events import (
     OSDiscoveryEvent,
     PropagationEvent,
 )
+from common.agent_plugins import AgentPluginType
 from common.agent_registration_data import AgentRegistrationData
 from common.event_queue import IAgentEventQueue, PyPubSubAgentEventQueue
 from common.network.network_utils import get_my_ip_addresses, get_network_interfaces
-from common.plugins.plugin_type import PluginType
 from common.tags.attack import T1082_ATTACK_TECHNIQUE_TAG
 from common.types import SocketAddress
 from common.utils.argparse_types import positive_int
@@ -306,19 +306,19 @@ class InfectionMonkey:
         puppet.load_plugin(
             "MimikatzCollector",
             MimikatzCredentialCollector(self._agent_event_queue),
-            PluginType.CREDENTIAL_COLLECTOR,
+            AgentPluginType.CREDENTIAL_COLLECTOR,
         )
         puppet.load_plugin(
             "SSHCollector",
             SSHCredentialCollector(self._agent_event_queue),
-            PluginType.CREDENTIAL_COLLECTOR,
+            AgentPluginType.CREDENTIAL_COLLECTOR,
         )
 
-        puppet.load_plugin("elastic", ElasticSearchFingerprinter(), PluginType.FINGERPRINTER)
-        puppet.load_plugin("http", HTTPFingerprinter(), PluginType.FINGERPRINTER)
-        puppet.load_plugin("mssql", MSSQLFingerprinter(), PluginType.FINGERPRINTER)
-        puppet.load_plugin("smb", SMBFingerprinter(), PluginType.FINGERPRINTER)
-        puppet.load_plugin("ssh", SSHFingerprinter(), PluginType.FINGERPRINTER)
+        puppet.load_plugin("elastic", ElasticSearchFingerprinter(), AgentPluginType.FINGERPRINTER)
+        puppet.load_plugin("http", HTTPFingerprinter(), AgentPluginType.FINGERPRINTER)
+        puppet.load_plugin("mssql", MSSQLFingerprinter(), AgentPluginType.FINGERPRINTER)
+        puppet.load_plugin("smb", SMBFingerprinter(), AgentPluginType.FINGERPRINTER)
+        puppet.load_plugin("ssh", SSHFingerprinter(), AgentPluginType.FINGERPRINTER)
 
         agent_binary_repository = CachingAgentBinaryRepository(
             island_api_client=self._island_api_client,
@@ -326,31 +326,41 @@ class InfectionMonkey:
         exploit_wrapper = ExploiterWrapper(self._agent_event_queue, agent_binary_repository)
 
         puppet.load_plugin(
-            "HadoopExploiter", exploit_wrapper.wrap(HadoopExploiter), PluginType.EXPLOITER
+            "HadoopExploiter", exploit_wrapper.wrap(HadoopExploiter), AgentPluginType.EXPLOITER
         )
         puppet.load_plugin(
-            "Log4ShellExploiter", exploit_wrapper.wrap(Log4ShellExploiter), PluginType.EXPLOITER
+            "Log4ShellExploiter",
+            exploit_wrapper.wrap(Log4ShellExploiter),
+            AgentPluginType.EXPLOITER,
         )
         puppet.load_plugin(
-            "PowerShellExploiter", exploit_wrapper.wrap(PowerShellExploiter), PluginType.EXPLOITER
+            "PowerShellExploiter",
+            exploit_wrapper.wrap(PowerShellExploiter),
+            AgentPluginType.EXPLOITER,
         )
-        puppet.load_plugin("SMBExploiter", exploit_wrapper.wrap(SMBExploiter), PluginType.EXPLOITER)
-        puppet.load_plugin("SSHExploiter", exploit_wrapper.wrap(SSHExploiter), PluginType.EXPLOITER)
-        puppet.load_plugin("WmiExploiter", exploit_wrapper.wrap(WmiExploiter), PluginType.EXPLOITER)
         puppet.load_plugin(
-            "MSSQLExploiter", exploit_wrapper.wrap(MSSQLExploiter), PluginType.EXPLOITER
+            "SMBExploiter", exploit_wrapper.wrap(SMBExploiter), AgentPluginType.EXPLOITER
+        )
+        puppet.load_plugin(
+            "SSHExploiter", exploit_wrapper.wrap(SSHExploiter), AgentPluginType.EXPLOITER
+        )
+        puppet.load_plugin(
+            "WmiExploiter", exploit_wrapper.wrap(WmiExploiter), AgentPluginType.EXPLOITER
+        )
+        puppet.load_plugin(
+            "MSSQLExploiter", exploit_wrapper.wrap(MSSQLExploiter), AgentPluginType.EXPLOITER
         )
 
         puppet.load_plugin(
             "ZerologonExploiter",
             exploit_wrapper.wrap(ZerologonExploiter),
-            PluginType.EXPLOITER,
+            AgentPluginType.EXPLOITER,
         )
 
         puppet.load_plugin(
             "ransomware",
             RansomwarePayload(self._agent_event_queue),
-            PluginType.PAYLOAD,
+            AgentPluginType.PAYLOAD,
         )
 
         return puppet

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -26,8 +26,9 @@ from common.agent_events import (
 from common.agent_registration_data import AgentRegistrationData
 from common.event_queue import IAgentEventQueue, PyPubSubAgentEventQueue
 from common.network.network_utils import get_my_ip_addresses, get_network_interfaces
+from common.plugins.plugin_type import PluginType
 from common.tags.attack import T1082_ATTACK_TECHNIQUE_TAG
-from common.types import PluginType, SocketAddress
+from common.types import SocketAddress
 from common.utils.argparse_types import positive_int
 from infection_monkey.agent_event_handlers import (
     AgentEventForwarder,

--- a/monkey/infection_monkey/puppet/puppet.py
+++ b/monkey/infection_monkey/puppet/puppet.py
@@ -5,7 +5,8 @@ from typing import Dict, Sequence
 from common.common_consts.timeouts import CONNECTION_TIMEOUT
 from common.credentials import Credentials
 from common.event_queue import IAgentEventQueue
-from common.types import PingScanData, PluginType
+from common.plugins.plugin_type import PluginType
+from common.types import PingScanData
 from infection_monkey import network_scanning
 from infection_monkey.i_puppet import ExploiterResultData, FingerprintData, IPuppet, PortScanData
 from infection_monkey.master.plugin_registry import PluginRegistry

--- a/monkey/infection_monkey/puppet/puppet.py
+++ b/monkey/infection_monkey/puppet/puppet.py
@@ -2,10 +2,10 @@ import logging
 import threading
 from typing import Dict, Sequence
 
+from common.agent_plugins import AgentPluginType
 from common.common_consts.timeouts import CONNECTION_TIMEOUT
 from common.credentials import Credentials
 from common.event_queue import IAgentEventQueue
-from common.plugins.plugin_type import PluginType
 from common.types import PingScanData
 from infection_monkey import network_scanning
 from infection_monkey.i_puppet import ExploiterResultData, FingerprintData, IPuppet, PortScanData
@@ -24,12 +24,12 @@ class Puppet(IPuppet):
         self._plugin_registry = plugin_registry
         self._agent_event_queue = agent_event_queue
 
-    def load_plugin(self, plugin_name: str, plugin: object, plugin_type: PluginType) -> None:
+    def load_plugin(self, plugin_name: str, plugin: object, plugin_type: AgentPluginType) -> None:
         self._plugin_registry.load_plugin(plugin_name, plugin, plugin_type)
 
     def run_credential_collector(self, name: str, options: Dict) -> Sequence[Credentials]:
         credential_collector = self._plugin_registry.get_plugin(
-            name, PluginType.CREDENTIAL_COLLECTOR
+            name, AgentPluginType.CREDENTIAL_COLLECTOR
         )
         return credential_collector.collect_credentials(options)
 
@@ -50,7 +50,7 @@ class Puppet(IPuppet):
         options: Dict,
     ) -> FingerprintData:
         try:
-            fingerprinter = self._plugin_registry.get_plugin(name, PluginType.FINGERPRINTER)
+            fingerprinter = self._plugin_registry.get_plugin(name, AgentPluginType.FINGERPRINTER)
             return fingerprinter.get_host_fingerprint(host, ping_scan_data, port_scan_data, options)
         except Exception:
             logger.exception(
@@ -67,11 +67,11 @@ class Puppet(IPuppet):
         options: Dict,
         interrupt: threading.Event,
     ) -> ExploiterResultData:
-        exploiter = self._plugin_registry.get_plugin(name, PluginType.EXPLOITER)
+        exploiter = self._plugin_registry.get_plugin(name, AgentPluginType.EXPLOITER)
         return exploiter.exploit_host(host, servers, current_depth, options, interrupt)
 
     def run_payload(self, name: str, options: Dict, interrupt: threading.Event):
-        payload = self._plugin_registry.get_plugin(name, PluginType.PAYLOAD)
+        payload = self._plugin_registry.get_plugin(name, AgentPluginType.PAYLOAD)
         payload.run(options, interrupt)
 
     def cleanup(self) -> None:

--- a/monkey/tests/unit_tests/infection_monkey/master/mock_puppet.py
+++ b/monkey/tests/unit_tests/infection_monkey/master/mock_puppet.py
@@ -3,8 +3,8 @@ import threading
 from typing import Dict, Sequence
 
 from common import OperatingSystem
+from common.agent_plugins import AgentPluginType
 from common.credentials import Credentials, LMHash, Password, SSHKeypair, Username
-from common.plugins.plugin_type import PluginType
 from common.types import PingScanData, PortStatus
 from infection_monkey.i_puppet import ExploiterResultData, FingerprintData, IPuppet, PortScanData
 from infection_monkey.model import VictimHost
@@ -18,7 +18,7 @@ logger = logging.getLogger()
 
 
 class MockPuppet(IPuppet):
-    def load_plugin(self, plugin_name: str, plugin: object, plugin_type: PluginType) -> None:
+    def load_plugin(self, plugin_name: str, plugin: object, plugin_type: AgentPluginType) -> None:
         logger.debug(f"load_plugin({plugin}, {plugin_type})")
 
     def run_credential_collector(self, name: str, options: Dict) -> Sequence[Credentials]:

--- a/monkey/tests/unit_tests/infection_monkey/master/mock_puppet.py
+++ b/monkey/tests/unit_tests/infection_monkey/master/mock_puppet.py
@@ -4,7 +4,8 @@ from typing import Dict, Sequence
 
 from common import OperatingSystem
 from common.credentials import Credentials, LMHash, Password, SSHKeypair, Username
-from common.types import PingScanData, PluginType, PortStatus
+from common.plugins.plugin_type import PluginType
+from common.types import PingScanData, PortStatus
 from infection_monkey.i_puppet import ExploiterResultData, FingerprintData, IPuppet, PortScanData
 from infection_monkey.model import VictimHost
 

--- a/monkey/tests/unit_tests/infection_monkey/master/test_plugin_registry.py
+++ b/monkey/tests/unit_tests/infection_monkey/master/test_plugin_registry.py
@@ -1,7 +1,7 @@
 import pytest
 from flask import Response
 
-from common.plugins.plugin_type import PluginType
+from common.agent_plugins import AgentPluginType
 from infection_monkey.i_puppet import UnknownPluginError
 from infection_monkey.master.plugin_registry import PluginRegistry
 
@@ -18,7 +18,7 @@ def test_get_plugin_not_found():
     plugin_registry = PluginRegistry(StubIslandAPIClient(status=404))
 
     with pytest.raises(UnknownPluginError):
-        plugin_registry.get_plugin("Ghost", PluginType.PAYLOAD)
+        plugin_registry.get_plugin("Ghost", AgentPluginType.PAYLOAD)
 
 
 # modify when plugin architecture is fully implemented
@@ -26,11 +26,11 @@ def test_get_plugin_not_implemented():
     plugin_registry = PluginRegistry(StubIslandAPIClient(status=200))
 
     with pytest.raises(NotImplementedError):
-        plugin_registry.get_plugin("Ghost", PluginType.PAYLOAD)
+        plugin_registry.get_plugin("Ghost", AgentPluginType.PAYLOAD)
 
 
 def test_get_plugin_unexpected_response():
     plugin_registry = PluginRegistry(StubIslandAPIClient(status=100))
 
     with pytest.raises(Exception):
-        plugin_registry.get_plugin("Ghost", PluginType.PAYLOAD)
+        plugin_registry.get_plugin("Ghost", AgentPluginType.PAYLOAD)

--- a/monkey/tests/unit_tests/infection_monkey/master/test_plugin_registry.py
+++ b/monkey/tests/unit_tests/infection_monkey/master/test_plugin_registry.py
@@ -1,7 +1,7 @@
 import pytest
 from flask import Response
 
-from common.types import PluginType
+from common.plugins.plugin_type import PluginType
 from infection_monkey.i_puppet import UnknownPluginError
 from infection_monkey.master.plugin_registry import PluginRegistry
 

--- a/monkey/tests/unit_tests/infection_monkey/puppet/test_puppet.py
+++ b/monkey/tests/unit_tests/infection_monkey/puppet/test_puppet.py
@@ -1,8 +1,8 @@
 import threading
 from unittest.mock import MagicMock
 
+from common.agent_plugins import AgentPluginType
 from common.event_queue import IAgentEventQueue
-from common.plugins.plugin_type import PluginType
 from common.types import PingScanData
 from infection_monkey.master.plugin_registry import PluginRegistry
 from infection_monkey.puppet.puppet import EMPTY_FINGERPRINT, Puppet
@@ -17,7 +17,7 @@ def test_puppet_run_payload_success():
     payload = MagicMock()
     payload_name = "PayloadOne"
 
-    p.load_plugin(payload_name, payload, PluginType.PAYLOAD)
+    p.load_plugin(payload_name, payload, AgentPluginType.PAYLOAD)
     p.run_payload(payload_name, {}, threading.Event())
 
     payload.run.assert_called_once()
@@ -38,9 +38,9 @@ def test_puppet_run_multiple_payloads():
     payload_3 = MagicMock()
     payload3_name = "PayloadThree"
 
-    p.load_plugin(payload1_name, payload_1, PluginType.PAYLOAD)
-    p.load_plugin(payload2_name, payload_2, PluginType.PAYLOAD)
-    p.load_plugin(payload3_name, payload_3, PluginType.PAYLOAD)
+    p.load_plugin(payload1_name, payload_1, AgentPluginType.PAYLOAD)
+    p.load_plugin(payload2_name, payload_2, AgentPluginType.PAYLOAD)
+    p.load_plugin(payload3_name, payload_3, AgentPluginType.PAYLOAD)
 
     p.run_payload(payload1_name, {}, threading.Event())
     payload_1.run.assert_called_once()

--- a/monkey/tests/unit_tests/infection_monkey/puppet/test_puppet.py
+++ b/monkey/tests/unit_tests/infection_monkey/puppet/test_puppet.py
@@ -2,7 +2,8 @@ import threading
 from unittest.mock import MagicMock
 
 from common.event_queue import IAgentEventQueue
-from common.types import PingScanData, PluginType
+from common.plugins.plugin_type import PluginType
+from common.types import PingScanData
 from infection_monkey.master.plugin_registry import PluginRegistry
 from infection_monkey.puppet.puppet import EMPTY_FINGERPRINT, Puppet
 


### PR DESCRIPTION
# What does this PR do?

Moves PluginType enum. `types.py` has an unclear purpose. I think it's better to define plugin types close to other, related plugin infrastructure (currently being developed)


## Testing Checklist

* [ ] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running UT's
