### PR TITLE
Agent: Fix unsent events getting dropped on exception

### DIFF
--- a/monkey/infection_monkey/agent_event_handlers/agent_event_forwarder.py
+++ b/monkey/infection_monkey/agent_event_handlers/agent_event_forwarder.py
@@ -93,3 +93,7 @@ class BatchingAgentEventForwarder:
                 self._island_api_client.send_events(events)
             except Exception:
                 logger.exception("Exception caught when connecting to the Island")
+
+                # Put all unsent events back on the queue so we can attempt to resend them later
+                for event in events:
+                    self._queue.put(event)

--- a/monkey/tests/unit_tests/infection_monkey/agent_event_handlers/test_agent_event_forwarder.py
+++ b/monkey/tests/unit_tests/infection_monkey/agent_event_handlers/test_agent_event_forwarder.py
@@ -31,3 +31,19 @@ def test_api_not_called_if_no_events(event_sender, mock_island_api_client):
     event_sender.flush()
 
     assert mock_island_api_client.send_events.call_count == 0
+
+
+def test_resend_events_on_failure(event_sender, mock_island_api_client):
+    mock_island_api_client.send_events = MagicMock(side_effect=Exception)
+    events = [{"value": 1}, {"value": 2}, {"value": 3}]
+    for e in events:
+        event_sender.add_event_to_queue(e)
+
+    event_sender.flush()
+    event_sender.flush()
+
+    assert mock_island_api_client.send_events.call_count == 2
+    assert (
+        mock_island_api_client.send_events.call_args_list[0]
+        == mock_island_api_client.send_events.call_args_list[1]
+    )


### PR DESCRIPTION
# What does this PR do?

Prevents events from being dropped if the island is temporarily not able to be contacted.

Merge after #2649 

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running unit tests
* [ ] ~If applicable, add screenshots or log transcripts of the feature working~