### PR TITLE
2534 fix machine id serialization

### DIFF
--- a/monkey/common/agent_events/abstract_agent_event.py
+++ b/monkey/common/agent_events/abstract_agent_event.py
@@ -5,7 +5,7 @@ from typing import FrozenSet, Union
 
 from pydantic import Field
 
-from common.base_models import InfectionMonkeyBaseModel
+from common.base_models import InfectionMonkeyBaseModel, InfectionMonkeyModelConfig
 from common.types import AgentID, MachineID
 
 
@@ -25,6 +25,9 @@ class AbstractAgentEvent(InfectionMonkeyBaseModel, ABC):
     """
 
     source: AgentID
-    target: Union[IPv4Address, MachineID, None] = Field(default=None)
+    target: Union[MachineID, IPv4Address, None] = Field(default=None)
     timestamp: float = Field(default_factory=time.time)
     tags: FrozenSet[str] = Field(default_factory=frozenset)
+
+    class Config(InfectionMonkeyModelConfig):
+        smart_union = True

--- a/monkey/tests/unit_tests/common/agent_events/test_file_encryption_event.py
+++ b/monkey/tests/unit_tests/common/agent_events/test_file_encryption_event.py
@@ -3,6 +3,7 @@ from pathlib import PurePosixPath, PureWindowsPath
 from uuid import UUID
 
 import pytest
+from pydantic.errors import IntegerError
 
 from common import OperatingSystem
 from common.agent_events import FileEncryptionEvent
@@ -85,7 +86,6 @@ def test_construct_invalid_field__type_error(key, value):
     "key, value",
     [
         ("file_path", {"bogus_field": "bogus"}),
-        ("target", "not-an-ip"),
         ("file_path", {"path": str(LINUX_FILE_ENCRYPTED_PATH), "os": "FakeOS"}),
     ],
 )
@@ -94,6 +94,14 @@ def test_construct_invalid_field__value_error(key, value):
     invalid_value_dict[key] = value
 
     with pytest.raises(ValueError):
+        FileEncryptionEvent(**invalid_value_dict)
+
+
+def test_construct_invalid_field__integer_error():
+    invalid_value_dict = LINUX_FILE_ENCRYPTION_SIMPLE_DICT.copy()
+    invalid_value_dict["target"] = "not-an-ip-or-integer"
+
+    with pytest.raises(IntegerError):
         FileEncryptionEvent(**invalid_value_dict)
 
 

--- a/monkey/tests/unit_tests/monkey_island/cc/resources/test_agent_events.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/resources/test_agent_events.py
@@ -1,4 +1,5 @@
 from http import HTTPStatus
+from ipaddress import IPv4Address
 from unittest.mock import MagicMock
 from uuid import UUID
 
@@ -33,7 +34,7 @@ SERIALIZED_EVENT_1 = {
     "type": SomeAgentEvent.__name__,
     "some_field": 1,
     "source": "f811ad00-5a68-4437-bd51-7b5cc1768ad5",
-    "target": None,
+    "target": 1,
     "timestamp": 0.0,
     "tags": ["some-event"],
 }
@@ -41,7 +42,7 @@ SERIALIZED_EVENT_1 = {
 EXPECTED_EVENT_1 = SomeAgentEvent(
     some_field=1,
     source=UUID("f811ad00-5a68-4437-bd51-7b5cc1768ad5"),
-    target=None,
+    target=1,
     timestamp=0.0,
     tags=frozenset({"some-event"}),
 )
@@ -50,7 +51,7 @@ SERIALIZED_EVENT_2 = {
     "type": OtherAgentEvent.__name__,
     "other_field": 2.0,
     "source": "012e7238-7b81-4108-8c7f-0787bc3f3c10",
-    "target": None,
+    "target": "127.0.0.1",
     "timestamp": 1.0,
     "tags": [],
 }
@@ -58,7 +59,7 @@ SERIALIZED_EVENT_2 = {
 EXPECTED_EVENT_2 = OtherAgentEvent(
     other_field=2.0,
     source=UUID("012e7238-7b81-4108-8c7f-0787bc3f3c10"),
-    target=None,
+    target=IPv4Address("127.0.0.1"),
     timestamp=1.0,
     tags=frozenset(),
 )
@@ -95,13 +96,13 @@ class PassFailAgentEvent_type2(AbstractAgentEvent):
 
 
 PFAE1_1 = PassFailAgentEvent_type1(
-    source=UUID("f811ad00-5a68-4437-bd51-7b5cc1768ad5"), timestamp=42, success=False
+    source=UUID("f811ad00-5a68-4437-bd51-7b5cc1768ad5"), timestamp=42, success=False, target=1
 )
 SERIALIZED_PFAE1_1 = {
     "type": PassFailAgentEvent_type1.__name__,
     "success": False,
     "source": "f811ad00-5a68-4437-bd51-7b5cc1768ad5",
-    "target": None,
+    "target": 1,
     "timestamp": 42.0,
     "tags": [],
 }
@@ -117,13 +118,16 @@ SERIALIZED_PFAE1_2 = {
     "tags": [],
 }
 PFAE2_1 = PassFailAgentEvent_type2(
-    source=UUID("f811ad00-5a68-4437-bd51-7b5cc1768ad5"), timestamp=42, success=True
+    source=UUID("f811ad00-5a68-4437-bd51-7b5cc1768ad5"),
+    timestamp=42,
+    success=True,
+    target=IPv4Address("127.0.0.1"),
 )
 SERIALIZED_PFAE2_1 = {
     "type": PassFailAgentEvent_type2.__name__,
     "success": True,
     "source": "f811ad00-5a68-4437-bd51-7b5cc1768ad5",
-    "target": None,
+    "target": "127.0.0.1",
     "timestamp": 42.0,
     "tags": [],
 }

--- a/vulture_allowlist.py
+++ b/vulture_allowlist.py
@@ -1,6 +1,6 @@
 from common import DIContainer
 from common.agent_configuration import ScanTargetConfiguration
-from common.agent_events import FileEncryptedEvent
+from common.agent_events import AbstractAgentEvent, FileEncryptedEvent
 from common.agent_plugins import AgentPlugin, AgentPluginManifest
 from common.base_models import InfectionMonkeyModelConfig, MutableInfectionMonkeyModelConfig
 from common.credentials import LMHash, NTHash, SecretEncodingConfig
@@ -14,8 +14,8 @@ from infection_monkey.transport.http import FileServHTTPRequestHandler
 from monkey_island.cc.deployment import Deployment
 from monkey_island.cc.models import IslandMode, Machine
 from monkey_island.cc.repositories import (
-    AgentPluginRepositoryLoggingDecorator,
     AgentPluginRepositoryCachingDecorator,
+    AgentPluginRepositoryLoggingDecorator,
     IAgentEventRepository,
     MongoAgentEventRepository,
 )
@@ -49,6 +49,8 @@ NetworkPort.le
 
 FileEncryptedEvent.arbitrary_types_allowed
 FileEncryptedEvent._file_path_to_pure_path
+
+AbstractAgentEvent.smart_union
 
 # Unused, but kept for future potential
 DIContainer.release_convention


### PR DESCRIPTION
# What does this PR do?

Fixes #2534 .

Adding `smart_union` to the config of AbstractAgentEvent validates the order of types. Changing the order of the target field and adding smart_union fixes this thing.

Why did we need to change the order? IPv4Address can use strings and integers to parse it.
Example:
IPv4Address(1) will be IPv4Addres("0.0.0.1")

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [x] Was the CHANGELOG.md updated to reflect the changes?
* [x] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by unit tests
* [x] If applicable, add screenshots or log transcripts of the feature working
