### PR TITLE
UI: Overlay the map legend on the map

### DIFF
--- a/monkey/monkey_island/cc/ui/src/styles/components/Map.scss
+++ b/monkey/monkey_island/cc/ui/src/styles/components/Map.scss
@@ -1,5 +1,7 @@
 .map-legend {
   font-size: 18px;
+  position: absolute;
+  z-index: 1;
 }
 
 .map-window {


### PR DESCRIPTION
# What does this PR do?

Fixes part of #2590.

Overlays the legend on the map.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~~Was the CHANGELOG.md updated to reflect the changes?~~
* [ ] ~~Was the documentation framework updated to reflect the changes?~~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~~Added relevant unit tests?~~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Ran the island and viewed the webpage
* [x] If applicable, add screenshots or log transcripts of the feature working
    Observe that the legend is displayed over the map
     > ![Screen Shot 2022-12-13 at 11 11 44 AM](https://user-images.githubusercontent.com/11077625/207385112-17dd0b36-f387-47f8-a68a-c13101dd3728.jpg)
