### PR TITLE
UI: Overlay preview pane on top of the map

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/map/MapOptions.js
+++ b/monkey/monkey_island/cc/ui/src/components/map/MapOptions.js
@@ -17,7 +17,8 @@ let getGroupsOptions = (stateList) => {
 export const basic_options = {
   autoResize: true,
   layout: {
-    improvedLayout: false
+    improvedLayout: false,
+    randomSeed: 1
   },
   edges: {
     width: 2,

--- a/monkey/monkey_island/cc/ui/src/components/map/MapOptions.js
+++ b/monkey/monkey_island/cc/ui/src/components/map/MapOptions.js
@@ -38,6 +38,11 @@ export const basic_options = {
   }
 };
 
+// Move the camera to the right
+// to compensate for the side panel on the right
+export const startingPosition = {'position': {'x': 130, 'y': 0}}
+
+
 const nodeStates = Object.keys(NodeGroup);
 const groupsOptions = getGroupsOptions(nodeStates);
 

--- a/monkey/monkey_island/cc/ui/src/components/pages/MapPage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/MapPage.js
@@ -85,8 +85,8 @@ class MapPageComponent extends AuthComponent {
         className={'main'}>
         <Row>
           {this.renderKillDialogModal()}
-          <Col xs={12} lg={8}>
-            <h1 className="page-title">2. Infection Map</h1>
+          <Col xs={12} >
+            <h1 className="page-title map-page-title">2. Infection Map</h1>
           </Col>
           <Col xs={8} id="map-column">
             <div className="map-legend">

--- a/monkey/monkey_island/cc/ui/src/components/pages/MapPage.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/MapPage.js
@@ -88,7 +88,7 @@ class MapPageComponent extends AuthComponent {
           <Col xs={12} lg={8}>
             <h1 className="page-title">2. Infection Map</h1>
           </Col>
-          <Col xs={8}>
+          <Col xs={8} id="map-column">
             <div className="map-legend">
               <b>Legend: </b>
               <span>Exploit <FontAwesomeIcon icon={faMinus} size="lg" style={{ color: '#cc0200' }} /></span>
@@ -103,26 +103,28 @@ class MapPageComponent extends AuthComponent {
               <ReactiveGraph graph={this.props.graph} events={this.events} />
             </div>
           </Col>
-          <Col xs={4}>
-            <div style={{ 'overflow': 'auto', 'marginBottom': '1em' }}>
-              <Link to="/infection/events" className="btn btn-light pull-left" style={{ 'width': '48%' }}>Monkey
-                Events</Link>
-              <button onClick={() => this.setState({ showKillDialog: true })} className="btn btn-danger pull-right"
-                style={{ 'width': '48%' }}>
-                <FontAwesomeIcon icon={faStopCircle} style={{ 'marginRight': '0.5em' }} />
-                Kill All Monkeys
-              </button>
-            </div>
-            {this.state.killPressed ?
-              <div className="alert alert-info">
-                <FontAwesomeIcon icon={faInfoCircle} style={{ 'marginRight': '5px' }} />
-                Kill command sent to all monkeys
+          <div>
+            <Col xs={4} id="map-preview-column">
+              <div style={{ 'overflow': 'auto', 'marginBottom': '1em' }}>
+                <Link to="/infection/events" className="btn btn-light pull-left" style={{ 'width': '48%' }}>Monkey
+                  Events</Link>
+                <button onClick={() => this.setState({ showKillDialog: true })} className="btn btn-danger pull-right"
+                  style={{ 'width': '48%' }}>
+                  <FontAwesomeIcon icon={faStopCircle} style={{ 'marginRight': '0.5em' }} />
+                  Kill All Monkeys
+                </button>
               </div>
-              : ''}
+              {this.state.killPressed ?
+                <div className="alert alert-info">
+                  <FontAwesomeIcon icon={faInfoCircle} style={{ 'marginRight': '5px' }} />
+                  Kill command sent to all monkeys
+                </div>
+                : ''}
 
-            <NodePreviewPane item={this.state.selected} type={this.state.selectedType}
-            allNodes={this.props.mapNodes} />
-          </Col>
+              <NodePreviewPane item={this.state.selected} type={this.state.selectedType}
+              allNodes={this.props.mapNodes} />
+            </Col>
+          </div>
         </Row>
       </Col>
     );

--- a/monkey/monkey_island/cc/ui/src/components/reactive-graph/ReactiveGraph.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/reactive-graph/ReactiveGraph.tsx
@@ -8,7 +8,12 @@ const GraphWrapper = (props: { graph: Graph, events: any }) => {
   let options = getOptions();
   return (
     <div className={'net-graph-wrapper'}>
-      <Graph graph={props.graph} options={options} events={props.events}/>
+      <Graph graph={props.graph} options={options} events={props.events}
+      getNetwork={network => {
+        // Move the center of the camera to the right
+        // to compensate for the side panel on the right
+        network.moveTo({'position': {'x': 100, 'y': 0}})
+      }}/>
     </div>
   )
 }

--- a/monkey/monkey_island/cc/ui/src/components/reactive-graph/ReactiveGraph.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/reactive-graph/ReactiveGraph.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Graph from 'react-graph-vis';
-import {getOptions} from '../map/MapOptions';
+import {getOptions, startingPosition} from '../map/MapOptions';
 
 
 const GraphWrapper = (props: { graph: Graph, events: any }) => {
@@ -10,9 +10,7 @@ const GraphWrapper = (props: { graph: Graph, events: any }) => {
     <div className={'net-graph-wrapper'}>
       <Graph graph={props.graph} options={options} events={props.events}
       getNetwork={network => {
-        // Move the center of the camera to the right
-        // to compensate for the side panel on the right
-        network.moveTo({'position': {'x': 130, 'y': 0}})
+        network.moveTo(startingPosition);
       }}/>
     </div>
   )

--- a/monkey/monkey_island/cc/ui/src/components/reactive-graph/ReactiveGraph.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/reactive-graph/ReactiveGraph.tsx
@@ -12,7 +12,7 @@ const GraphWrapper = (props: { graph: Graph, events: any }) => {
       getNetwork={network => {
         // Move the center of the camera to the right
         // to compensate for the side panel on the right
-        network.moveTo({'position': {'x': 100, 'y': 0}})
+        network.moveTo({'position': {'x': 130, 'y': 0}})
       }}/>
     </div>
   )

--- a/monkey/monkey_island/cc/ui/src/styles/App.css
+++ b/monkey/monkey_island/cc/ui/src/styles/App.css
@@ -154,6 +154,10 @@ body {
   font-family: 'Alegreya', serif;
 }
 
+.map-page-title {
+  margin-bottom: 10px;
+}
+
 @media (min-width: 768px) {
   .main {
     padding-right: 40px;

--- a/monkey/monkey_island/cc/ui/src/styles/components/Map.scss
+++ b/monkey/monkey_island/cc/ui/src/styles/components/Map.scss
@@ -14,7 +14,7 @@
 }
 
 .net-graph-wrapper {
-  height: calc(100% - 130px);
+  height: 89vh;
   width: 100%;
   padding-bottom: 10px;
 }

--- a/monkey/monkey_island/cc/ui/src/styles/components/Map.scss
+++ b/monkey/monkey_island/cc/ui/src/styles/components/Map.scss
@@ -8,6 +8,11 @@
   position: relative;
 }
 
+#map-column {
+  flex: auto;
+  max-width: 100%;
+}
+
 .net-graph-wrapper {
   height: calc(100% - 130px);
   width: 100%;

--- a/monkey/monkey_island/cc/ui/src/styles/components/PreviewPane.scss
+++ b/monkey/monkey_island/cc/ui/src/styles/components/PreviewPane.scss
@@ -1,3 +1,9 @@
-.preview-pane a>svg{
-  color: $monkey-yellow !important;
+.preview-pane a>svg {
+  color: $monkey-yellow  !important;
+}
+
+#map-preview-column {
+  position: absolute;
+  right: 0;
+  z-index: 1;
 }


### PR DESCRIPTION
# What does this PR do?

Fixes #2590.

Expands the map width and overlays the preview pane on top of the map.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~~Was the CHANGELOG.md updated to reflect the changes?~~
* [ ] ~~Was the documentation framework updated to reflect the changes?~~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~~Added relevant unit tests?~~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running the island and viewing the webpage (Chrome, Firefox, Safari)
* [x] If applicable, add screenshots or log transcripts of the feature working
    > https://user-images.githubusercontent.com/11077625/207447471-b8f92776-9d2b-43c3-8e4c-555059fca372.mov

