### PR TITLE
UI: Hide the configuration page error summary

### DIFF
--- a/monkey/monkey_island/cc/ui/src/styles/pages/ConfigurationPage.scss
+++ b/monkey/monkey_island/cc/ui/src/styles/pages/ConfigurationPage.scss
@@ -32,7 +32,7 @@
   margin-left: 2em;
 }
 
-.config-form div.card.errors {
+.config-form div.card {
   display: none;
 }
 


### PR DESCRIPTION
# What does this PR do?

Fixes part of #2694.

Hides the error summary on the configuration page.

Note: It appears that the errors have been placed in the `card` class. I'm not sure if this card is being reused for other messages. We could hide the `danger-border` class instead.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~~Was the CHANGELOG.md updated to reflect the changes?~~
* [ ] ~~Was the documentation framework updated to reflect the changes?~~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~~Added relevant unit tests?~~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running the island and viewing the webpage
* [ ] If applicable, add screenshots or log transcripts of the feature working
    Observe that the error list is not being displayed when field(s) have invalid inputs
    > ![Screen Shot 2022-12-15 at 10 46 21 AM](https://user-images.githubusercontent.com/11077625/207904913-4f6a2a49-8c57-454b-ad1e-015b05a92920.jpg)
