### PR TITLE
2710 implement get all file names test doubles

### DIFF
--- a/monkey/tests/monkey_island/in_memory_file_repository.py
+++ b/monkey/tests/monkey_island/in_memory_file_repository.py
@@ -11,7 +11,7 @@ class InMemoryFileRepository(IFileRepository):
         self._files: Dict[str, bytes] = {}
 
     def get_all_file_names(self) -> Sequence[str]:
-        raise NotImplementedError()
+        return list(self._files.keys())
 
     def save_file(self, unsafe_file_name: str, file_contents: BinaryIO):
         self._files[unsafe_file_name] = file_contents.read()

--- a/monkey/tests/monkey_island/mock_file_repository.py
+++ b/monkey/tests/monkey_island/mock_file_repository.py
@@ -14,7 +14,7 @@ class MockFileRepository(IFileRepository):
         self._file = io.BytesIO(FILE_CONTENTS)
 
     def get_all_file_names(self) -> Sequence[str]:
-        raise NotImplementedError()
+        return [FILE_NAME]
 
     def save_file(self, unsafe_file_name: str, file_contents: BinaryIO):
         pass

--- a/monkey/tests/monkey_island/single_file_repository.py
+++ b/monkey/tests/monkey_island/single_file_repository.py
@@ -12,7 +12,10 @@ class SingleFileRepository(IFileRepository):
         self._file_name = ""
 
     def get_all_file_names(self) -> Sequence[str]:
-        raise NotImplementedError()
+        if self._file is None:
+            return []
+
+        return [self._file_name]
 
     def save_file(self, unsafe_file_name: str, file_contents: BinaryIO):
         self._file = io.BytesIO(file_contents.read())


### PR DESCRIPTION
# What does this PR do?

Issue #2710
Implements `get_all_file_names()` for test doubles

Add any further explanations here.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running unit tests
* [ ] ~If applicable, add screenshots or log transcripts of the feature working~