### PR TITLE
2710 config schema service

### DIFF
--- a/monkey/monkey_island/cc/services/__init__.py
+++ b/monkey/monkey_island/cc/services/__init__.py
@@ -2,3 +2,5 @@ from .agent_signals_service import AgentSignalsService
 from .authentication_service import AuthenticationService
 
 from .aws import AWSService
+
+from .config_schema_service import ConfigSchemaService

--- a/monkey/monkey_island/cc/services/__init__.py
+++ b/monkey/monkey_island/cc/services/__init__.py
@@ -3,4 +3,4 @@ from .authentication_service import AuthenticationService
 
 from .aws import AWSService
 
-from .config_schema_service import ConfigSchemaService
+from .config_schema_service import AgentConfigSchemaService

--- a/monkey/monkey_island/cc/services/config_schema_service.py
+++ b/monkey/monkey_island/cc/services/config_schema_service.py
@@ -71,8 +71,9 @@ class ConfigSchemaService:
                 # Add exploiter reference to brute_force
                 # TODO: Remove distinction in exploiter and change the reference
                 exploitation = schema["definitions"]["ExploitationConfiguration"]
-                brute_force = exploitation["properties"]["brute_force"]
-                brute_force["items"] = {"$ref": f"#/definitions/{plugin_type_name}"}
+                exploitation["properties"]["brute_force"] = {
+                    "$ref": f"#/definitions/{plugin_type_name}"
+                }
             else:
                 raise Exception(
                     "Error occurred while setting schema for {plugin_type} plugin type."

--- a/monkey/monkey_island/cc/services/config_schema_service.py
+++ b/monkey/monkey_island/cc/services/config_schema_service.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict
 
-from common.agent_configuration import AgentConfiguration
+from common.agent_configuration import AgentConfiguration, PluginConfiguration
+from common.agent_plugins import AgentPlugin, AgentPluginType
 from monkey_island.cc.repositories import IAgentPluginRepository
 
 
@@ -15,6 +16,36 @@ class ConfigSchemaService:
     ):
         self._agent_plugin_repository = agent_plugin_repository
 
+    def _create_plugin_schema(self, plugin: AgentPlugin) -> Dict[str, Any]:
+        schema = PluginConfiguration.schema()
+        schema["properties"]["name"]["enum"] = [plugin.plugin_manifest.name]
+        schema["properties"]["options"]["properties"] = plugin.config_schema
+
+        return schema
+
+    def _add_plugins_to_schema(self, schema: Dict[str, Any]):
+        # Note: Can throw RetrievalError, UnknownRecordError
+        plugins = self._agent_plugin_repository.get_plugin_catalog()
+        if plugins:
+            schema["plugins"] = {}
+
+        for (plugin_type, name) in plugins:
+            plugin = self._agent_plugin_repository.get_plugin(plugin_type, name)
+            plugin_schema = self._create_plugin_schema(plugin)
+
+            plugin_type_name = str(plugin_type.name).lower()
+            if plugin_type_name not in schema["plugins"]:
+                schema["plugins"][plugin_type_name] = {"anyOf": []}
+            schema["plugins"][plugin_type_name]["anyOf"].append(plugin_schema)
+
+            # Add reference, based on type
+            # TODO: It would actually probably be easier to forego the
+            # reference and just add the schema here
+            if plugin_type == AgentPluginType.EXPLOITER:
+                exploitation = schema["definitions"]["ExploitationConfiguration"]
+                brute_force = exploitation["properties"]["brute_force"]
+                brute_force["items"] = {"$ref": "#/plugins/exploiter"}
+
     def get_schema(self) -> Dict[str, Any]:
         """
         Get the schema.
@@ -23,6 +54,9 @@ class ConfigSchemaService:
         """
         try:
             agent_config_schema = AgentConfiguration.schema()
+
+            self._add_plugins_to_schema(agent_config_schema)
+
             return agent_config_schema
         except Exception as err:
             raise RuntimeError(err)

--- a/monkey/monkey_island/cc/services/config_schema_service.py
+++ b/monkey/monkey_island/cc/services/config_schema_service.py
@@ -73,7 +73,6 @@ class ConfigSchemaService:
 
     def _create_plugin_schema(self, plugin: AgentPlugin) -> Dict[str, Any]:
         schema = deepcopy(PluginConfiguration.schema())
-        schema["properties"]["name"]["enum"] = [plugin.plugin_manifest.name]
+        schema["properties"]["name"]["title"] = [plugin.plugin_manifest.name]
         schema["properties"]["options"]["properties"] = plugin.config_schema
-
         return schema

--- a/monkey/monkey_island/cc/services/config_schema_service.py
+++ b/monkey/monkey_island/cc/services/config_schema_service.py
@@ -33,13 +33,21 @@ class ConfigSchemaService:
             raise RuntimeError(err)
 
     def _add_plugins_to_schema(self, schema: Dict[str, Any]):
-        plugins = self._agent_plugin_repository.get_plugin_catalog()
-        if plugins:
+        plugin_catalog = self._agent_plugin_repository.get_plugin_catalog()
+        if plugin_catalog:
             schema["definitions"].setdefault("AgentPluginsConfiguration", {})
+            schema["definitions"]["AgentPluginsConfiguration"][
+                "title"
+            ] = "AgentPluginsConfiguration"
+            schema["definitions"]["AgentPluginsConfiguration"]["type"] = "object"
+            schema["definitions"]["AgentPluginsConfiguration"]["description"] = (
+                "A configuration for agent plugins.\n It provides a full"
+                " set of available plugins that can be used by the agent.\n"
+            )
 
-        self._set_exploiters_reference(schema, plugins)
+        self._set_exploiters_reference(schema, plugin_catalog)
 
-        for (plugin_type, name) in plugins:
+        for (plugin_type, name) in plugin_catalog:
             plugin = self._agent_plugin_repository.get_plugin(plugin_type, name)
             plugin_schema = self._create_plugin_schema(plugin)
 

--- a/monkey/monkey_island/cc/services/config_schema_service.py
+++ b/monkey/monkey_island/cc/services/config_schema_service.py
@@ -32,7 +32,6 @@ class ConfigSchemaService:
             raise RuntimeError(err)
 
     def _add_plugins_to_schema(self, schema: Dict[str, Any]):
-        # Note: Can throw RetrievalError, UnknownRecordError
         plugins = self._agent_plugin_repository.get_plugin_catalog()
         if plugins:
             schema["plugins"] = {}
@@ -41,14 +40,12 @@ class ConfigSchemaService:
             plugin = self._agent_plugin_repository.get_plugin(plugin_type, name)
             plugin_schema = self._create_plugin_schema(plugin)
 
-            plugin_type_name = str(plugin_type.name).lower()
+            plugin_type_name = plugin_type.name.lower()
             if plugin_type_name not in schema["plugins"]:
                 schema["plugins"][plugin_type_name] = {"anyOf": []}
             schema["plugins"][plugin_type_name]["anyOf"].append(plugin_schema)
 
             # Add reference, based on type
-            # TODO: It would actually probably be easier to forego the
-            # reference and just add the schema here
             if plugin_type == AgentPluginType.EXPLOITER:
                 exploitation = schema["definitions"]["ExploitationConfiguration"]
                 brute_force = exploitation["properties"]["brute_force"]

--- a/monkey/monkey_island/cc/services/config_schema_service.py
+++ b/monkey/monkey_island/cc/services/config_schema_service.py
@@ -1,0 +1,28 @@
+from typing import Any, Dict
+
+from common.agent_configuration import AgentConfiguration
+from monkey_island.cc.repositories import IAgentPluginRepository
+
+
+class ConfigSchemaService:
+    """
+    A service for retrieving the agent configuration schema.
+    """
+
+    def __init__(
+        self,
+        agent_plugin_repository: IAgentPluginRepository,
+    ):
+        self._agent_plugin_repository = agent_plugin_repository
+
+    def get_schema(self) -> Dict[str, Any]:
+        """
+        Get the schema.
+
+        :raises RuntimeError: If the schema could not be retrieved
+        """
+        try:
+            agent_config_schema = AgentConfiguration.schema()
+            return agent_config_schema
+        except Exception as err:
+            raise RuntimeError(err)

--- a/monkey/monkey_island/cc/services/config_schema_service.py
+++ b/monkey/monkey_island/cc/services/config_schema_service.py
@@ -35,7 +35,7 @@ class ConfigSchemaService:
     def _add_plugins_to_schema(self, schema: Dict[str, Any]):
         plugins = self._agent_plugin_repository.get_plugin_catalog()
         if plugins:
-            schema["plugins"] = {}
+            schema["definitions"].setdefault("AgentPluginsConfiguration", {})
 
         self._set_exploiters_reference(schema, plugins)
 
@@ -44,7 +44,9 @@ class ConfigSchemaService:
             plugin_schema = self._create_plugin_schema(plugin)
 
             plugin_type_name = plugin_type.name.lower()
-            plugin_type_schema = schema["plugins"].setdefault(plugin_type_name, {})
+            plugin_type_schema = schema["definitions"]["AgentPluginsConfiguration"].setdefault(
+                plugin_type_name, {}
+            )
             plugin_type_schema.setdefault("anyOf", []).append(plugin_schema)
 
     def _set_exploiters_reference(
@@ -57,7 +59,7 @@ class ConfigSchemaService:
             if plugin_type == AgentPluginType.EXPLOITER:
                 exploitation = schema["definitions"]["ExploitationConfiguration"]
                 brute_force = exploitation["properties"]["brute_force"]
-                brute_force["items"] = {"$ref": "#/plugins/exploiter"}
+                brute_force["items"] = {"$ref": "#/definitions/AgentPluginsConfiguration/exploiter"}
             else:
                 raise Exception("Error occurred while getting configuration schema")
 

--- a/monkey/monkey_island/cc/services/config_schema_service.py
+++ b/monkey/monkey_island/cc/services/config_schema_service.py
@@ -1,9 +1,20 @@
 from copy import deepcopy
-from typing import Any, Dict, Sequence, Tuple
+from typing import Any, Dict
 
-from common.agent_configuration import AgentConfiguration, PluginConfiguration
+from common.agent_configuration import AgentConfiguration
 from common.agent_plugins import AgentPlugin, AgentPluginType
 from monkey_island.cc.repositories import IAgentPluginRepository
+
+PLUGIN_SCHEMAS = {
+    AgentPluginType.EXPLOITER: {
+        "title": "Exploiter Plugins",
+        "type": "object",
+        "description": "A configuration for agent exploiter plugins.\n It provides a full"
+        " set of available exploiter plugins"
+        " that can be used by the agent.\n",
+        "properties": {},
+    }
+}
 
 
 class ConfigSchemaService:
@@ -19,7 +30,7 @@ class ConfigSchemaService:
 
     def get_schema(self) -> Dict[str, Any]:
         """
-        Get the schema.
+        Get the Agent configuration schema.
 
         :raises RuntimeError: If the schema could not be retrieved
         """
@@ -32,76 +43,57 @@ class ConfigSchemaService:
         except Exception as err:
             raise RuntimeError(err)
 
-    def _add_plugins_to_schema(self, schema: Dict[str, Any]):
-        """
-        Add all plugins to the schema provided,
-
-        :param schema: The schema which will be modified
-        """
+    def _add_plugins_to_schema(self, schema: Dict[str, Any]) -> Dict[str, Any]:
         plugin_catalog = self._agent_plugin_repository.get_plugin_catalog()
 
-        self._set_plugin_type_schema(schema, plugin_catalog)
-
         for (plugin_type, name) in plugin_catalog:
+            schema = self._inject_plugin_references_to_schema(plugin_type, schema)
             plugin = self._agent_plugin_repository.get_plugin(plugin_type, name)
+            schema = self._add_plugin_to_schema(schema, plugin_type, plugin)
 
-            plugin_type_name = plugin_type.name.lower()
-            schema["definitions"][plugin_type_name]["properties"].setdefault(
-                name, self._create_plugin_schema(plugin)
+        return schema
+
+    def _inject_plugin_references_to_schema(
+        self, plugin_type: AgentPluginType, schema: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        if plugin_type == AgentPluginType.EXPLOITER:
+            schema = self._set_exploiter_definition(schema, plugin_type)
+
+            exploitation = schema["definitions"]["ExploitationConfiguration"]
+            exploitation["properties"]["brute_force"] = {
+                "$ref": f"#/definitions/{self._get_plugin_type_string(plugin_type)}"
+            }
+        else:
+            raise NotImplementedError(
+                f"Only plugins of type {AgentPluginType.EXPLOITER} are "
+                f"supported. Type provided {plugin_type}"
             )
 
-    def _set_plugin_type_schema(
-        self, schema: Dict[str, Any], plugin_catalog: Sequence[Tuple[AgentPluginType, str]]
-    ):
-        """
-        Modifies main schema with plugin schema and reference based on plugin type.
-
-        :param schema: The schema which will be modified
-        :param plugin_catalog: The catalog with all available plugin types and name
-        :raises Exception: When unsupported plugin type is provided
-        """
-        plugin_types = set([plugin_type for (plugin_type, _) in plugin_catalog])
-
-        for plugin_type in plugin_types:
-            if plugin_type == AgentPluginType.EXPLOITER:
-                plugin_type_name = plugin_type.name.lower()
-                # Add exploiter definition
-                self._set_exploiter_definition(schema, plugin_type_name)
-
-                # Add exploiter reference to brute_force
-                # TODO: Remove distinction in exploiter and change the reference
-                exploitation = schema["definitions"]["ExploitationConfiguration"]
-                exploitation["properties"]["brute_force"] = {
-                    "$ref": f"#/definitions/{plugin_type_name}"
-                }
-            else:
-                raise Exception(
-                    "Error occurred while setting schema for {plugin_type} plugin type."
-                )
-
-    def _set_exploiter_definition(self, schema: Dict[str, Any], plugin_type_name: str):
-        """
-        Construct exploiter plugins schema.
-
-        :param schema: The schema which will be modified
-        :param plugin_type_name: The plugin type name used in the schema
-        """
-        plugin_type_schema = schema["definitions"].setdefault(plugin_type_name, {})
-        plugin_type_schema["title"] = "Exploiter Plugins"
-        plugin_type_schema["type"] = "object"
-        plugin_type_schema["description"] = (
-            "A configuration for agent exploiter plugins.\n It provides a full"
-            " set of available exploiter plugins that can be used by the agent.\n"
-        )
-        plugin_type_schema.setdefault("properties", {})
-
-    def _create_plugin_schema(self, plugin: AgentPlugin) -> Dict[str, Any]:
-        """
-        Generate plugin configuration schema.
-
-        :param plugin: The AgentPlugin for which we generate the schema
-        """
-        schema = deepcopy(PluginConfiguration.schema())
-        schema["properties"]["name"]["title"] = plugin.plugin_manifest.title
-        schema["properties"]["options"]["properties"] = plugin.config_schema
         return schema
+
+    def _add_plugin_to_schema(
+        self, schema: Dict[str, Any], plugin_type: AgentPluginType, plugin: AgentPlugin
+    ):
+        plugin_type_string = self._get_plugin_type_string(plugin_type)
+        schema["definitions"][plugin_type_string]["properties"][
+            plugin.plugin_manifest.name
+        ] = plugin.config_schema
+        return schema
+
+    def _set_exploiter_definition(
+        self, schema: Dict[str, Any], plugin_type: AgentPluginType
+    ) -> Dict[str, Any]:
+        plugin_type_string = self._get_plugin_type_string(plugin_type)
+        if plugin_type_string not in schema["definitions"]:
+            try:
+                schema["definitions"][plugin_type_string] = PLUGIN_SCHEMAS[plugin_type]
+            except KeyError:
+                raise NotImplementedError(
+                    f"Only plugins of type {AgentPluginType.EXPLOITER} are "
+                    f"supported. Type provided {plugin_type}"
+                )
+        return schema
+
+    @staticmethod
+    def _get_plugin_type_string(plugin_type: AgentPluginType):
+        return plugin_type.name.lower()

--- a/monkey/monkey_island/cc/services/config_schema_service.py
+++ b/monkey/monkey_island/cc/services/config_schema_service.py
@@ -21,7 +21,7 @@ SUPPORTED_PLUGINS = {
 }
 
 
-class ConfigSchemaService:
+class AgentConfigSchemaService:
     """
     A service for retrieving the agent configuration schema.
     """

--- a/monkey/monkey_island/cc/services/config_schema_service.py
+++ b/monkey/monkey_island/cc/services/config_schema_service.py
@@ -1,18 +1,22 @@
-from copy import deepcopy
 from typing import Any, Dict
+
+import dpath.util
 
 from common.agent_configuration import AgentConfiguration
 from common.agent_plugins import AgentPlugin, AgentPluginType
 from monkey_island.cc.repositories import IAgentPluginRepository
 
-PLUGIN_SCHEMAS = {
+SUPPORTED_PLUGINS = {
     AgentPluginType.EXPLOITER: {
-        "title": "Exploiter Plugins",
-        "type": "object",
-        "description": "A configuration for agent exploiter plugins.\n It provides a full"
-        " set of available exploiter plugins"
-        " that can be used by the agent.\n",
-        "properties": {},
+        "subschema": {
+            "title": "Exploiter Plugins",
+            "type": "object",
+            "description": "A configuration for agent exploiter plugins.\n It provides a full"
+            " set of available exploiter plugins"
+            " that can be used by the agent.\n",
+            "properties": {},
+        },
+        "path_in_schema": "definitions.ExploitationConfiguration.properties.brute_force",
     }
 }
 
@@ -35,54 +39,35 @@ class ConfigSchemaService:
         :raises RuntimeError: If the schema could not be retrieved
         """
         try:
-            agent_config_schema = deepcopy(AgentConfiguration.schema())
-
-            self._add_plugins_to_schema(agent_config_schema)
+            agent_config_schema = AgentConfiguration.schema()
+            agent_config_schema = self._add_plugin_defs(agent_config_schema)
+            agent_config_schema = self._add_references_to_plugin_defs(agent_config_schema)
+            agent_config_schema = self._add_plugins(agent_config_schema)
 
             return agent_config_schema
         except Exception as err:
             raise RuntimeError(err)
 
-    def _add_plugins_to_schema(self, schema: Dict[str, Any]) -> Dict[str, Any]:
+    def _add_plugin_defs(self, schema: Dict[str, Any]) -> Dict[str, Any]:
+        for plugin_type, subschema_info in SUPPORTED_PLUGINS.items():
+            plugin_type_string = self._get_plugin_type_string(plugin_type)
+            schema["definitions"][plugin_type_string] = SUPPORTED_PLUGINS[plugin_type]["subschema"]
+        return schema
+
+    def _add_references_to_plugin_defs(self, schema: Dict[str, Any]) -> Dict[str, Any]:
+        for plugin_type, subschema_info in SUPPORTED_PLUGINS.items():
+            reference = {"$ref": f"#/definitions/{self._get_plugin_type_string(plugin_type)}"}
+            dpath.util.set(schema, subschema_info["path_in_schema"], reference)
+
+        return schema
+
+    def _add_plugins(self, schema: Dict[str, Any]) -> Dict[str, Any]:
         plugin_catalog = self._agent_plugin_repository.get_plugin_catalog()
 
         for (plugin_type, name) in plugin_catalog:
-            schema = self._inject_plugin_references_to_schema(plugin_type, schema)
             plugin = self._agent_plugin_repository.get_plugin(plugin_type, name)
             schema = self._add_plugin_to_schema(schema, plugin_type, plugin)
 
-        return schema
-
-    def _inject_plugin_references_to_schema(
-        self, plugin_type: AgentPluginType, schema: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        if plugin_type == AgentPluginType.EXPLOITER:
-            schema = self._set_exploiter_definition(schema, plugin_type)
-
-            exploitation = schema["definitions"]["ExploitationConfiguration"]
-            exploitation["properties"]["brute_force"] = {
-                "$ref": f"#/definitions/{self._get_plugin_type_string(plugin_type)}"
-            }
-        else:
-            raise NotImplementedError(
-                f"Only plugins of type {AgentPluginType.EXPLOITER} are "
-                f"supported. Type provided {plugin_type}"
-            )
-
-        return schema
-
-    def _set_exploiter_definition(
-        self, schema: Dict[str, Any], plugin_type: AgentPluginType
-    ) -> Dict[str, Any]:
-        plugin_type_string = self._get_plugin_type_string(plugin_type)
-        if plugin_type_string not in schema["definitions"]:
-            try:
-                schema["definitions"][plugin_type_string] = PLUGIN_SCHEMAS[plugin_type]
-            except KeyError:
-                raise NotImplementedError(
-                    f"Only plugins of type {AgentPluginType.EXPLOITER} are "
-                    f"supported. Type provided {plugin_type}"
-                )
         return schema
 
     @staticmethod

--- a/monkey/monkey_island/cc/services/config_schema_service.py
+++ b/monkey/monkey_island/cc/services/config_schema_service.py
@@ -16,12 +16,20 @@ class ConfigSchemaService:
     ):
         self._agent_plugin_repository = agent_plugin_repository
 
-    def _create_plugin_schema(self, plugin: AgentPlugin) -> Dict[str, Any]:
-        schema = PluginConfiguration.schema()
-        schema["properties"]["name"]["enum"] = [plugin.plugin_manifest.name]
-        schema["properties"]["options"]["properties"] = plugin.config_schema
+    def get_schema(self) -> Dict[str, Any]:
+        """
+        Get the schema.
 
-        return schema
+        :raises RuntimeError: If the schema could not be retrieved
+        """
+        try:
+            agent_config_schema = AgentConfiguration.schema()
+
+            self._add_plugins_to_schema(agent_config_schema)
+
+            return agent_config_schema
+        except Exception as err:
+            raise RuntimeError(err)
 
     def _add_plugins_to_schema(self, schema: Dict[str, Any]):
         # Note: Can throw RetrievalError, UnknownRecordError
@@ -46,17 +54,9 @@ class ConfigSchemaService:
                 brute_force = exploitation["properties"]["brute_force"]
                 brute_force["items"] = {"$ref": "#/plugins/exploiter"}
 
-    def get_schema(self) -> Dict[str, Any]:
-        """
-        Get the schema.
+    def _create_plugin_schema(self, plugin: AgentPlugin) -> Dict[str, Any]:
+        schema = PluginConfiguration.schema()
+        schema["properties"]["name"]["enum"] = [plugin.plugin_manifest.name]
+        schema["properties"]["options"]["properties"] = plugin.config_schema
 
-        :raises RuntimeError: If the schema could not be retrieved
-        """
-        try:
-            agent_config_schema = AgentConfiguration.schema()
-
-            self._add_plugins_to_schema(agent_config_schema)
-
-            return agent_config_schema
-        except Exception as err:
-            raise RuntimeError(err)
+        return schema

--- a/monkey/monkey_island/cc/services/config_schema_service.py
+++ b/monkey/monkey_island/cc/services/config_schema_service.py
@@ -71,15 +71,6 @@ class ConfigSchemaService:
 
         return schema
 
-    def _add_plugin_to_schema(
-        self, schema: Dict[str, Any], plugin_type: AgentPluginType, plugin: AgentPlugin
-    ):
-        plugin_type_string = self._get_plugin_type_string(plugin_type)
-        schema["definitions"][plugin_type_string]["properties"][
-            plugin.plugin_manifest.name
-        ] = plugin.config_schema
-        return schema
-
     def _set_exploiter_definition(
         self, schema: Dict[str, Any], plugin_type: AgentPluginType
     ) -> Dict[str, Any]:
@@ -97,3 +88,12 @@ class ConfigSchemaService:
     @staticmethod
     def _get_plugin_type_string(plugin_type: AgentPluginType):
         return plugin_type.name.lower()
+
+    def _add_plugin_to_schema(
+        self, schema: Dict[str, Any], plugin_type: AgentPluginType, plugin: AgentPlugin
+    ):
+        plugin_type_string = self._get_plugin_type_string(plugin_type)
+        schema["definitions"][plugin_type_string]["properties"][
+            plugin.plugin_manifest.name
+        ] = plugin.config_schema
+        return schema

--- a/monkey/monkey_island/cc/services/initialize.py
+++ b/monkey/monkey_island/cc/services/initialize.py
@@ -66,7 +66,7 @@ from monkey_island.cc.repositories import (
 )
 from monkey_island.cc.server_utils.consts import MONKEY_ISLAND_ABS_PATH
 from monkey_island.cc.server_utils.encryption import ILockableEncryptor, RepositoryEncryptor
-from monkey_island.cc.services import AgentSignalsService, AWSService
+from monkey_island.cc.services import AgentSignalsService, AWSService, ConfigSchemaService
 from monkey_island.cc.services.run_local_monkey import LocalMonkeyRunService
 from monkey_island.cc.setup.mongo.mongo_setup import MONGO_URL
 
@@ -252,3 +252,4 @@ def _register_services(container: DIContainer):
     container.register_instance(LocalMonkeyRunService, container.resolve(LocalMonkeyRunService))
     container.register_instance(AuthenticationService, container.resolve(AuthenticationService))
     container.register_instance(AgentSignalsService, container.resolve(AgentSignalsService))
+    container.register_instance(ConfigSchemaService, container.resolve(ConfigSchemaService))

--- a/monkey/monkey_island/cc/services/initialize.py
+++ b/monkey/monkey_island/cc/services/initialize.py
@@ -66,7 +66,7 @@ from monkey_island.cc.repositories import (
 )
 from monkey_island.cc.server_utils.consts import MONKEY_ISLAND_ABS_PATH
 from monkey_island.cc.server_utils.encryption import ILockableEncryptor, RepositoryEncryptor
-from monkey_island.cc.services import AgentSignalsService, AWSService, ConfigSchemaService
+from monkey_island.cc.services import AgentConfigSchemaService, AgentSignalsService, AWSService
 from monkey_island.cc.services.run_local_monkey import LocalMonkeyRunService
 from monkey_island.cc.setup.mongo.mongo_setup import MONGO_URL
 
@@ -252,4 +252,6 @@ def _register_services(container: DIContainer):
     container.register_instance(LocalMonkeyRunService, container.resolve(LocalMonkeyRunService))
     container.register_instance(AuthenticationService, container.resolve(AuthenticationService))
     container.register_instance(AgentSignalsService, container.resolve(AgentSignalsService))
-    container.register_instance(ConfigSchemaService, container.resolve(ConfigSchemaService))
+    container.register_instance(
+        AgentConfigSchemaService, container.resolve(AgentConfigSchemaService)
+    )

--- a/monkey/tests/unit_tests/common/agent_plugins/test_agent_plugin_manifest.py
+++ b/monkey/tests/unit_tests/common/agent_plugins/test_agent_plugin_manifest.py
@@ -6,6 +6,7 @@ from common.agent_plugins.agent_plugin_manifest import AgentPluginManifest
 from common.agent_plugins.agent_plugin_type import AgentPluginType
 
 FAKE_NAME = "rdp_exploiter"
+FAKE_NAME2 = "ssh_exploiter"
 FAKE_TYPE = "Exploiter"
 FAKE_OPERATING_SYSTEMS = ["linux"]
 FAKE_TITLE = "Remote Desktop Protocol exploiter"

--- a/monkey/tests/unit_tests/monkey_island/cc/fake_agent_plugin_data.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/fake_agent_plugin_data.py
@@ -1,8 +1,34 @@
-from tests.unit_tests.common.agent_plugins.test_agent_plugin_manifest import FAKE_MANIFEST_OBJECT
+from tests.unit_tests.common.agent_plugins.test_agent_plugin_manifest import (
+    FAKE_MANIFEST_OBJECT,
+    FAKE_NAME2,
+)
 
-from common.agent_plugins import AgentPlugin
+from common.agent_plugins import AgentPlugin, AgentPluginManifest
 
-FAKE_PLUGIN_CONFIG_SCHEMA_1 = {"plugin_options": {"some_option": "some_value"}}
+FAKE_PLUGIN_CONFIG_SCHEMA_1 = {
+    "title": "Mock exploiter",
+    "description": "Configuration settings for Mock exploiter.",
+    "type": "object",
+    "required": ["exploitation_success_rate", "propagation_success_rate"],
+    "properties": {
+        "exploitation_success_rate": {
+            "title": "Exploitation success rate",
+            "description": "The rate of successful exploitation in percentage",
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100,
+            "default": 50,
+        },
+        "propagation_success_rate": {
+            "title": "Propagation success rate",
+            "description": "The rate of successful propagation in percentage",
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100,
+            "default": 50,
+        },
+    },
+}
 
 FAKE_PLUGIN_ARCHIVE_1 = b"random bytes"
 
@@ -13,12 +39,30 @@ FAKE_AGENT_PLUGIN_1 = AgentPlugin(
 )
 
 
-FAKE_PLUGIN_CONFIG_SCHEMA_2 = {"plugin_options": {"other_option": "other_value"}}
+FAKE_PLUGIN_CONFIG_SCHEMA_2 = {
+    "title": "Mock exploiter",
+    "description": "Configuration settings for Mock exploiter.",
+    "type": "object",
+    "required": ["timeout"],
+    "properties": {
+        "timeout": {
+            "title": "Timeout",
+            "description": "How long the exploiter should run for",
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100,
+            "default": 50,
+        }
+    },
+}
 
 FAKE_PLUGIN_ARCHIVE_2 = b"other random bytes"
 
+_manifest_params = FAKE_MANIFEST_OBJECT.dict(simplify=True)
+_manifest_params["name"] = FAKE_NAME2
+
 FAKE_AGENT_PLUGIN_2 = AgentPlugin(
-    plugin_manifest=FAKE_MANIFEST_OBJECT,
+    plugin_manifest=AgentPluginManifest(**_manifest_params),
     config_schema=FAKE_PLUGIN_CONFIG_SCHEMA_2,
     source_archive=FAKE_PLUGIN_ARCHIVE_2,
 )

--- a/monkey/tests/unit_tests/monkey_island/cc/resources/test_agent_plugins.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/resources/test_agent_plugins.py
@@ -4,7 +4,10 @@ import pytest
 from tests.common import StubDIContainer
 from tests.monkey_island import InMemoryAgentPluginRepository
 from tests.unit_tests.common.agent_plugins.test_agent_plugin_manifest import FAKE_TYPE
-from tests.unit_tests.monkey_island.cc.fake_agent_plugin_data import FAKE_AGENT_PLUGIN_1
+from tests.unit_tests.monkey_island.cc.fake_agent_plugin_data import (
+    FAKE_AGENT_PLUGIN_1,
+    FAKE_PLUGIN_CONFIG_SCHEMA_1,
+)
 from tests.unit_tests.monkey_island.conftest import get_url_for_resource
 
 from monkey_island.cc.repositories import IAgentPluginRepository, RetrievalError
@@ -31,7 +34,7 @@ def test_get_plugin(flask_client, agent_plugin_repository):
     agent_plugin_repository.save_plugin(FAKE_AGENT_PLUGIN_1)
 
     expected_response = {
-        "config_schema": {"plugin_options": {"some_option": "some_value"}},
+        "config_schema": FAKE_PLUGIN_CONFIG_SCHEMA_1,
         "plugin_manifest": {
             "description": None,
             "link_to_documentation": "www.beefface.com",

--- a/monkey/tests/unit_tests/monkey_island/cc/services/test_config_schema_service.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/test_config_schema_service.py
@@ -28,8 +28,7 @@ def expected_config_schema() -> Dict[str, Any]:
         },
     }
     expected_exploitation = expected_schema["definitions"]["ExploitationConfiguration"]
-    expected_brute_force = expected_exploitation["properties"]["brute_force"]
-    expected_brute_force["items"] = {"$ref": "#/definitions/exploiter"}
+    expected_exploitation["properties"]["brute_force"] = {"$ref": "#/definitions/exploiter"}
 
     return expected_schema
 

--- a/monkey/tests/unit_tests/monkey_island/cc/services/test_config_schema_service.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/test_config_schema_service.py
@@ -12,7 +12,7 @@ from common.agent_configuration import PluginConfiguration
 from common.agent_plugins import AgentPlugin, AgentPluginType
 from monkey_island.cc.repositories import IAgentPluginRepository
 from monkey_island.cc.services import ConfigSchemaService
-from monkey_island.cc.services.config_schema_service import PLUGIN_SCHEMAS
+from monkey_island.cc.services.config_schema_service import SUPPORTED_PLUGINS
 
 
 @pytest.fixture
@@ -37,8 +37,8 @@ def expected_plugin_schema(plugin: AgentPlugin):
     return schema
 
 
-EXPECTED_PLUGIN_SCHEMA = PLUGIN_SCHEMAS[AgentPluginType.EXPLOITER]
-EXPECTED_PLUGIN_SCHEMA["properties"] = {
+EXPECTED_PLUGIN_SCHEMA = SUPPORTED_PLUGINS[AgentPluginType.EXPLOITER]["subschema"]
+EXPECTED_PLUGIN_SCHEMA["properties"] = {  # type: ignore[index]
     FAKE_NAME: FAKE_AGENT_PLUGIN_1,
     FAKE_NAME2: FAKE_AGENT_PLUGIN_2,
 }

--- a/monkey/tests/unit_tests/monkey_island/cc/services/test_config_schema_service.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/test_config_schema_service.py
@@ -11,7 +11,7 @@ from tests.unit_tests.monkey_island.cc.fake_agent_plugin_data import (
 from common.agent_configuration import PluginConfiguration
 from common.agent_plugins import AgentPlugin, AgentPluginType
 from monkey_island.cc.repositories import IAgentPluginRepository
-from monkey_island.cc.services import ConfigSchemaService
+from monkey_island.cc.services import AgentConfigSchemaService
 from monkey_island.cc.services.config_schema_service import SUPPORTED_PLUGINS
 
 
@@ -23,8 +23,8 @@ def agent_plugin_repository() -> IAgentPluginRepository:
 @pytest.fixture
 def config_schema_service(
     agent_plugin_repository: IAgentPluginRepository,
-) -> ConfigSchemaService:
-    return ConfigSchemaService(agent_plugin_repository)
+) -> AgentConfigSchemaService:
+    return AgentConfigSchemaService(agent_plugin_repository)
 
 
 def expected_plugin_schema(plugin: AgentPlugin):

--- a/monkey/tests/unit_tests/monkey_island/cc/services/test_config_schema_service.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/test_config_schema_service.py
@@ -18,6 +18,10 @@ from monkey_island.cc.services import ConfigSchemaService
 def expected_config_schema() -> Dict[str, Any]:
     expected_schema = deepcopy(AgentConfiguration.schema())
     expected_schema["definitions"]["AgentPluginsConfiguration"] = {
+        "title": "AgentPluginsConfiguration",
+        "type": "object",
+        "description": "A configuration for agent plugins.\n It provides a full"
+        + " set of available plugins that can be used by the agent.\n",
         "exploiter": {
             "anyOf": [
                 expected_plugin_schema(FAKE_AGENT_PLUGIN_1),

--- a/monkey/tests/unit_tests/monkey_island/cc/services/test_config_schema_service.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/test_config_schema_service.py
@@ -17,21 +17,19 @@ from monkey_island.cc.services import ConfigSchemaService
 @pytest.fixture
 def expected_config_schema() -> Dict[str, Any]:
     expected_schema = deepcopy(AgentConfiguration.schema())
-    expected_schema["definitions"]["AgentPluginsConfiguration"] = {
-        "title": "AgentPluginsConfiguration",
+    expected_schema["definitions"]["exploiter"] = {
+        "title": "Exploiter Plugins",
         "type": "object",
-        "description": "A configuration for agent plugins.\n It provides a full"
-        + " set of available plugins that can be used by the agent.\n",
-        "exploiter": {
-            "anyOf": [
-                expected_plugin_schema(FAKE_AGENT_PLUGIN_1),
-                expected_plugin_schema(FAKE_AGENT_PLUGIN_2),
-            ]
+        "description": "A configuration for agent exploiter plugins.\n "
+        + "It provides a full set of available exploiter plugins that can be used by the agent.\n",
+        "properties": {
+            "ssh_exploiter": expected_plugin_schema(FAKE_AGENT_PLUGIN_1),
+            "wmi_exploiter": expected_plugin_schema(FAKE_AGENT_PLUGIN_2),
         },
     }
     expected_exploitation = expected_schema["definitions"]["ExploitationConfiguration"]
     expected_brute_force = expected_exploitation["properties"]["brute_force"]
-    expected_brute_force["items"] = {"$ref": "#/definitions/AgentPluginsConfiguration/exploiter"}
+    expected_brute_force["items"] = {"$ref": "#/definitions/exploiter"}
 
     return expected_schema
 
@@ -52,7 +50,7 @@ def expected_plugin_schema(plugin: AgentPlugin):
     schema = deepcopy(PluginConfiguration.schema())
     # Need to specify the name here, otherwise the options can be matched with
     # any plugin's configuration
-    schema["properties"]["name"]["title"] = [plugin.plugin_manifest.name]
+    schema["properties"]["name"]["title"] = plugin.plugin_manifest.title
     schema["properties"]["options"]["properties"] = plugin.config_schema
 
     return schema

--- a/monkey/tests/unit_tests/monkey_island/cc/services/test_config_schema_service.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/test_config_schema_service.py
@@ -1,0 +1,62 @@
+from copy import copy
+
+import pytest
+from tests.monkey_island import InMemoryAgentPluginRepository
+from tests.unit_tests.monkey_island.cc.fake_agent_plugin_data import (
+    FAKE_AGENT_PLUGIN_1,
+    FAKE_AGENT_PLUGIN_2,
+)
+
+from common.agent_configuration import AgentConfiguration, PluginConfiguration
+from common.agent_plugins import AgentPlugin
+from monkey_island.cc.repositories import IAgentPluginRepository
+from monkey_island.cc.services import ConfigSchemaService
+
+
+@pytest.fixture
+def agent_plugin_repository() -> IAgentPluginRepository:
+    return InMemoryAgentPluginRepository()
+
+
+@pytest.fixture
+def config_schema_service(
+    agent_plugin_repository: IAgentPluginRepository,
+) -> ConfigSchemaService:
+    return ConfigSchemaService(agent_plugin_repository)
+
+
+def expected_plugin_schema(plugin: AgentPlugin):
+    schema = PluginConfiguration.schema()
+    # Need to specify the name here, otherwise the options can be matched with
+    # any plugin's configuration
+    schema["properties"]["name"]["enum"] = [plugin.plugin_manifest.name]
+    schema["properties"]["options"]["properties"] = plugin.config_schema
+
+    return schema
+
+
+def test_get_schema__returns_config_schema(config_schema_service):
+    schema = config_schema_service.get_schema()
+    assert schema == copy(AgentConfiguration.schema())
+
+
+def test_get_schema__adds_plugins_to_schema(config_schema_service, agent_plugin_repository):
+    agent_plugin_repository.save_plugin("ssh_exploiter", FAKE_AGENT_PLUGIN_1)
+    agent_plugin_repository.save_plugin("wmi_exploiter", FAKE_AGENT_PLUGIN_2)
+    expected_schema = copy(AgentConfiguration.schema())
+    expected_schema["plugins"] = {
+        "exploiter": {
+            "anyOf": [
+                expected_plugin_schema(FAKE_AGENT_PLUGIN_1),
+                expected_plugin_schema(FAKE_AGENT_PLUGIN_2),
+            ]
+        }
+    }
+    expected_exploitation = expected_schema["definitions"]["ExploitationConfiguration"]
+    # TODO: We add to brute_force, because we don't have a subcategory for plugins
+    expected_brute_force = expected_exploitation["properties"]["brute_force"]
+    expected_brute_force["items"] = {"$ref": "#/plugins/exploiter"}
+
+    actual_schema = config_schema_service.get_schema()
+
+    assert actual_schema == expected_schema

--- a/monkey/tests/unit_tests/monkey_island/cc/services/test_config_schema_service.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/test_config_schema_service.py
@@ -52,7 +52,7 @@ def expected_plugin_schema(plugin: AgentPlugin):
     schema = deepcopy(PluginConfiguration.schema())
     # Need to specify the name here, otherwise the options can be matched with
     # any plugin's configuration
-    schema["properties"]["name"]["enum"] = [plugin.plugin_manifest.name]
+    schema["properties"]["name"]["title"] = [plugin.plugin_manifest.name]
     schema["properties"]["options"]["properties"] = plugin.config_schema
 
     return schema
@@ -70,4 +70,5 @@ def test_get_schema__adds_exploiter_plugins_to_schema(
     agent_plugin_repository.save_plugin("wmi_exploiter", FAKE_AGENT_PLUGIN_2)
 
     actual_config_schema = config_schema_service.get_schema()
+
     assert actual_config_schema == expected_config_schema

--- a/monkey/tests/unit_tests/monkey_island/cc/services/test_config_schema_service.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/test_config_schema_service.py
@@ -1,4 +1,4 @@
-from copy import copy
+from copy import deepcopy
 from typing import Any, Dict
 
 import pytest
@@ -16,7 +16,7 @@ from monkey_island.cc.services import ConfigSchemaService
 
 @pytest.fixture
 def expected_config_schema() -> Dict[str, Any]:
-    expected_schema = copy(AgentConfiguration.schema())
+    expected_schema = deepcopy(AgentConfiguration.schema())
     expected_schema["plugins"] = {
         "exploiter": {
             "anyOf": [
@@ -45,7 +45,7 @@ def config_schema_service(
 
 
 def expected_plugin_schema(plugin: AgentPlugin):
-    schema = PluginConfiguration.schema()
+    schema = deepcopy(PluginConfiguration.schema())
     # Need to specify the name here, otherwise the options can be matched with
     # any plugin's configuration
     schema["properties"]["name"]["enum"] = [plugin.plugin_manifest.name]
@@ -56,7 +56,7 @@ def expected_plugin_schema(plugin: AgentPlugin):
 
 def test_get_schema__returns_config_schema(config_schema_service):
     schema = config_schema_service.get_schema()
-    assert schema == copy(AgentConfiguration.schema())
+    assert schema == deepcopy(AgentConfiguration.schema())
 
 
 def test_get_schema__adds_exploiter_plugins_to_schema(

--- a/monkey/tests/unit_tests/monkey_island/cc/services/test_config_schema_service.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/test_config_schema_service.py
@@ -47,8 +47,8 @@ EXPECTED_PLUGIN_SCHEMA["properties"] = {
 def test_get_schema__adds_exploiter_plugins_to_schema(
     config_schema_service, agent_plugin_repository
 ):
-    agent_plugin_repository.save_plugin(FAKE_NAME, FAKE_AGENT_PLUGIN_1)
-    agent_plugin_repository.save_plugin(FAKE_NAME2, FAKE_AGENT_PLUGIN_2)
+    agent_plugin_repository.save_plugin(FAKE_AGENT_PLUGIN_1)
+    agent_plugin_repository.save_plugin(FAKE_AGENT_PLUGIN_2)
 
     actual_config_schema = config_schema_service.get_schema()
     assert actual_config_schema["definitions"]["exploiter"] == EXPECTED_PLUGIN_SCHEMA

--- a/monkey/tests/unit_tests/monkey_island/cc/services/test_config_schema_service.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/test_config_schema_service.py
@@ -17,7 +17,7 @@ from monkey_island.cc.services import ConfigSchemaService
 @pytest.fixture
 def expected_config_schema() -> Dict[str, Any]:
     expected_schema = deepcopy(AgentConfiguration.schema())
-    expected_schema["plugins"] = {
+    expected_schema["definitions"]["AgentPluginsConfiguration"] = {
         "exploiter": {
             "anyOf": [
                 expected_plugin_schema(FAKE_AGENT_PLUGIN_1),
@@ -27,7 +27,7 @@ def expected_config_schema() -> Dict[str, Any]:
     }
     expected_exploitation = expected_schema["definitions"]["ExploitationConfiguration"]
     expected_brute_force = expected_exploitation["properties"]["brute_force"]
-    expected_brute_force["items"] = {"$ref": "#/plugins/exploiter"}
+    expected_brute_force["items"] = {"$ref": "#/definitions/AgentPluginsConfiguration/exploiter"}
 
     return expected_schema
 

--- a/vulture_allowlist.py
+++ b/vulture_allowlist.py
@@ -13,12 +13,10 @@ from infection_monkey.island_api_client import HTTPIslandAPIClient
 from infection_monkey.transport.http import FileServHTTPRequestHandler
 from monkey_island.cc.deployment import Deployment
 from monkey_island.cc.models import IslandMode, Machine
-from monkey_island.cc.repositories import (
-    IAgentEventRepository,
-    MongoAgentEventRepository,
-)
+from monkey_island.cc.repositories import IAgentEventRepository, MongoAgentEventRepository
 from monkey_island.cc.repositories.i_agent_plugin_repository import IAgentPluginRepository
 from monkey_island.cc.resources.agent_heartbeat import AgentHeartbeat
+from monkey_island.cc.services import ConfigSchemaService
 from monkey_island.cc.services.reporting.exploitations.monkey_exploitation import MonkeyExploitation
 from monkey_island.cc.services.reporting.issue_processing.exploit_processing.exploiter_descriptor_enum import (
     ExploiterDescriptorEnum,
@@ -45,8 +43,8 @@ NTHash.validate_hash_format
 NetworkPort.ge
 NetworkPort.le
 
-FileEncryptedEvent.arbitrary_types_allowed
-FileEncryptedEvent._file_path_to_pure_path
+FileEncryptionEvent.arbitrary_types_allowed
+FileEncryptionEvent._file_path_to_pure_path
 
 AbstractAgentEvent.smart_union
 
@@ -151,3 +149,6 @@ IAgentPluginRepository
 
 # Remove after #2710
 IAgentPluginRepository.get_plugin_catalog
+
+# Remove after plugins are fetched from back end
+ConfigSchemaService.get_schema

--- a/vulture_allowlist.py
+++ b/vulture_allowlist.py
@@ -16,7 +16,7 @@ from monkey_island.cc.models import IslandMode, Machine
 from monkey_island.cc.repositories import IAgentEventRepository, MongoAgentEventRepository
 from monkey_island.cc.repositories.i_agent_plugin_repository import IAgentPluginRepository
 from monkey_island.cc.resources.agent_heartbeat import AgentHeartbeat
-from monkey_island.cc.services import ConfigSchemaService
+from monkey_island.cc.services import AgentConfigSchemaService
 from monkey_island.cc.services.reporting.exploitations.monkey_exploitation import MonkeyExploitation
 from monkey_island.cc.services.reporting.issue_processing.exploit_processing.exploiter_descriptor_enum import (
     ExploiterDescriptorEnum,
@@ -151,4 +151,4 @@ IAgentPluginRepository
 IAgentPluginRepository.get_plugin_catalog
 
 # Remove after plugins are fetched from back end
-ConfigSchemaService.get_schema
+AgentConfigSchemaService.get_schema

--- a/vulture_allowlist.py
+++ b/vulture_allowlist.py
@@ -1,6 +1,6 @@
 from common import DIContainer
 from common.agent_configuration import ScanTargetConfiguration
-from common.agent_events import AbstractAgentEvent, FileEncryptedEvent
+from common.agent_events import AbstractAgentEvent, FileEncryptionEvent
 from common.agent_plugins import AgentPlugin, AgentPluginManifest
 from common.base_models import InfectionMonkeyModelConfig, MutableInfectionMonkeyModelConfig
 from common.credentials import LMHash, NTHash, SecretEncodingConfig
@@ -14,8 +14,6 @@ from infection_monkey.transport.http import FileServHTTPRequestHandler
 from monkey_island.cc.deployment import Deployment
 from monkey_island.cc.models import IslandMode, Machine
 from monkey_island.cc.repositories import (
-    AgentPluginRepositoryCachingDecorator,
-    AgentPluginRepositoryLoggingDecorator,
     IAgentEventRepository,
     MongoAgentEventRepository,
 )


### PR DESCRIPTION
# What does this PR do?

Fixes part of #2710.

Adds the ConfigSchemaService, which provides the get_schema() method for retrieving the configuration schema.

We need to change the AgentConfguration to include the title and description the proper way so this PR is a draft PR until we have fixed that.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [x] ~~Was the CHANGELOG.md updated to reflect the changes?~~
* [x] ~~Was the documentation framework updated to reflect the changes?~~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [ ] Have you successfully tested your changes locally? Elaborate:
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [x] If applicable, add screenshots or log transcripts of the feature working

The result schema looks like:
[schema.zip](https://github.com/guardicore/monkey/files/10287302/schema.zip)


