### PR TITLE
2692 add pluginloader to pluginregistry

### DIFF
--- a/monkey/common/utils/file_utils/__init__.py
+++ b/monkey/common/utils/file_utils/__init__.py
@@ -4,6 +4,7 @@ from .file_utils import (
     get_binary_io_sha256_hash,
     get_text_file_contents,
     InvalidPath,
+    random_filename,
 )
 from .secure_directory import create_secure_directory
 from .secure_file import open_new_securely_permissioned_file

--- a/monkey/common/utils/file_utils/file_utils.py
+++ b/monkey/common/utils/file_utils/file_utils.py
@@ -1,7 +1,9 @@
 import hashlib
 import logging
 import os
+import string
 from pathlib import Path
+from random import choices  # noqa: DUO102
 from typing import BinaryIO, Iterable
 
 logger = logging.getLogger(__name__)
@@ -43,3 +45,8 @@ def get_text_file_contents(file_path: Path) -> str:
     with open(file_path, "rt") as f:
         file_contents = f.read()
     return file_contents
+
+
+def random_filename(length: int = 20) -> str:
+    allowed_characters = string.ascii_letters + string.digits
+    return "".join(choices(allowed_characters, k=length))

--- a/monkey/common/utils/file_utils/file_utils.py
+++ b/monkey/common/utils/file_utils/file_utils.py
@@ -3,7 +3,7 @@ import logging
 import os
 import string
 from pathlib import Path
-from random import choices  # noqa: DUO102
+from random import SystemRandom
 from typing import BinaryIO, Iterable
 
 logger = logging.getLogger(__name__)
@@ -48,5 +48,6 @@ def get_text_file_contents(file_path: Path) -> str:
 
 
 def random_filename(length: int = 20) -> str:
+    sys_random = SystemRandom()
     allowed_characters = string.ascii_letters + string.digits
-    return "".join(choices(allowed_characters, k=length))
+    return "".join(sys_random.choices(allowed_characters, k=length))

--- a/monkey/infection_monkey/main.py
+++ b/monkey/infection_monkey/main.py
@@ -1,3 +1,9 @@
+# serpentarium must be the first import, as it needs to save the state of the
+# import system prior to any imports
+# isort: off
+import serpentarium  # noqa: F401
+
+# isort: on
 import argparse
 import logging
 import logging.config

--- a/monkey/infection_monkey/master/plugin_registry.py
+++ b/monkey/infection_monkey/master/plugin_registry.py
@@ -1,3 +1,7 @@
+# isort: off
+from serpentarium import PluginLoader
+
+# isort: on
 import logging
 from typing import Any
 
@@ -9,7 +13,7 @@ logger = logging.getLogger()
 
 
 class PluginRegistry:
-    def __init__(self, island_api_client: IIslandAPIClient):
+    def __init__(self, island_api_client: IIslandAPIClient, plugin_loader: PluginLoader):
         """
         `self._registry` looks like -
             {
@@ -21,6 +25,7 @@ class PluginRegistry:
         """
         self._registry = {}
         self._island_api_client = island_api_client
+        self._plugin_loader = plugin_loader
 
     def load_plugin(self, plugin_name: str, plugin: object, plugin_type: AgentPluginType) -> None:
         self._registry.setdefault(plugin_type, {})

--- a/monkey/infection_monkey/master/plugin_registry.py
+++ b/monkey/infection_monkey/master/plugin_registry.py
@@ -1,9 +1,7 @@
-# isort: off
-from serpentarium import PluginLoader
-
-# isort: on
 import logging
 from typing import Any
+
+from serpentarium import PluginLoader
 
 from common.agent_plugins import AgentPluginType
 from infection_monkey.i_puppet import UnknownPluginError

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -1,7 +1,3 @@
-# isort: off
-from serpentarium import PluginLoader
-
-# isort: on
 import argparse
 import contextlib
 import logging
@@ -17,6 +13,7 @@ from tempfile import gettempdir
 from typing import List, Optional, Sequence, Tuple
 
 from pubsub.core import Publisher
+from serpentarium import PluginLoader
 
 from common.agent_event_serializers import (
     AgentEventSerializerRegistry,

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -89,9 +89,6 @@ from .plugin_event_forwarder import PluginEventForwarder
 logger = logging.getLogger(__name__)
 logging.getLogger("urllib3").setLevel(logging.INFO)
 
-TMP_DIR = Path(gettempdir()) / random_filename()
-PLUGIN_DIR = TMP_DIR / "plugins"
-
 
 class InfectionMonkey:
     def __init__(self, args):
@@ -317,9 +314,13 @@ class InfectionMonkey:
         return list(ordered_servers.keys())
 
     def _build_puppet(self) -> IPuppet:
-        create_secure_directory(TMP_DIR)
-        create_secure_directory(PLUGIN_DIR)
-        plugin_registry = PluginRegistry(self._island_api_client, PluginLoader(PLUGIN_DIR))
+        temp_dir = Path(gettempdir()) / random_filename()
+        plugin_dir = temp_dir / "plugins"
+
+        create_secure_directory(temp_dir)
+        create_secure_directory(plugin_dir)
+
+        plugin_registry = PluginRegistry(self._island_api_client, PluginLoader(plugin_dir))
         puppet = Puppet(self._agent_event_queue, plugin_registry)
 
         puppet.load_plugin(

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -33,7 +33,7 @@ from common.network.network_utils import get_my_ip_addresses, get_network_interf
 from common.tags.attack import T1082_ATTACK_TECHNIQUE_TAG
 from common.types import SocketAddress
 from common.utils.argparse_types import positive_int
-from common.utils.file_utils import create_secure_directory
+from common.utils.file_utils import create_secure_directory, random_filename
 from infection_monkey.agent_event_handlers import (
     AgentEventForwarder,
     add_stolen_credentials_to_propagation_credentials_repository,
@@ -89,8 +89,8 @@ from .plugin_event_forwarder import PluginEventForwarder
 logger = logging.getLogger(__name__)
 logging.getLogger("urllib3").setLevel(logging.INFO)
 
-
-PLUGIN_DIR = Path(gettempdir()) / "plugins"
+TMP_DIR = Path(gettempdir()) / random_filename()
+PLUGIN_DIR = TMP_DIR / "plugins"
 
 
 class InfectionMonkey:

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -317,6 +317,7 @@ class InfectionMonkey:
         return list(ordered_servers.keys())
 
     def _build_puppet(self) -> IPuppet:
+        create_secure_directory(TMP_DIR)
         create_secure_directory(PLUGIN_DIR)
         plugin_registry = PluginRegistry(self._island_api_client, PluginLoader(PLUGIN_DIR))
         puppet = Puppet(self._agent_event_queue, plugin_registry)

--- a/monkey/tests/unit_tests/common/utils/test_common_file_utils.py
+++ b/monkey/tests/unit_tests/common/utils/test_common_file_utils.py
@@ -9,6 +9,7 @@ from common.utils.file_utils import (
     expand_path,
     get_all_regular_files_in_directory,
     get_binary_io_sha256_hash,
+    random_filename,
 )
 
 
@@ -63,3 +64,17 @@ def test_get_all_regular_files_in_directory__subdir_has_files(tmp_path, monkeypa
 
     expected_return_value = sorted(files)
     assert sorted(get_all_regular_files_in_directory(tmp_path)) == expected_return_value
+
+
+def test_random_filename__differs_across_calls():
+    f1 = random_filename()
+    f2 = random_filename()
+
+    assert f1 != f2
+
+
+def test_random_filename__has_correct_length():
+    length = 10
+    f1 = random_filename(length)
+
+    assert len(f1) == length

--- a/monkey/tests/unit_tests/infection_monkey/master/test_plugin_registry.py
+++ b/monkey/tests/unit_tests/infection_monkey/master/test_plugin_registry.py
@@ -1,3 +1,7 @@
+# isort: off
+from serpentarium import PluginLoader
+
+# isort: on
 import pytest
 from flask import Response
 
@@ -14,23 +18,28 @@ class StubIslandAPIClient:
         return Response(status=self._status)
 
 
-def test_get_plugin_not_found():
-    plugin_registry = PluginRegistry(StubIslandAPIClient(status=404))
+@pytest.fixture
+def plugin_loader(tmp_path):
+    return PluginLoader(tmp_path)
+
+
+def test_get_plugin_not_found(plugin_loader: PluginLoader):
+    plugin_registry = PluginRegistry(StubIslandAPIClient(status=404), plugin_loader)
 
     with pytest.raises(UnknownPluginError):
         plugin_registry.get_plugin("Ghost", AgentPluginType.PAYLOAD)
 
 
 # modify when plugin architecture is fully implemented
-def test_get_plugin_not_implemented():
-    plugin_registry = PluginRegistry(StubIslandAPIClient(status=200))
+def test_get_plugin_not_implemented(plugin_loader: PluginLoader):
+    plugin_registry = PluginRegistry(StubIslandAPIClient(status=200), plugin_loader)
 
     with pytest.raises(NotImplementedError):
         plugin_registry.get_plugin("Ghost", AgentPluginType.PAYLOAD)
 
 
-def test_get_plugin_unexpected_response():
-    plugin_registry = PluginRegistry(StubIslandAPIClient(status=100))
+def test_get_plugin_unexpected_response(plugin_loader: PluginLoader):
+    plugin_registry = PluginRegistry(StubIslandAPIClient(status=100), plugin_loader)
 
     with pytest.raises(Exception):
         plugin_registry.get_plugin("Ghost", AgentPluginType.PAYLOAD)

--- a/monkey/tests/unit_tests/infection_monkey/master/test_plugin_registry.py
+++ b/monkey/tests/unit_tests/infection_monkey/master/test_plugin_registry.py
@@ -1,7 +1,5 @@
-# isort: off
-from serpentarium import PluginLoader
+from unittest.mock import MagicMock
 
-# isort: on
 import pytest
 from flask import Response
 
@@ -19,11 +17,11 @@ class StubIslandAPIClient:
 
 
 @pytest.fixture
-def plugin_loader(tmp_path):
-    return PluginLoader(tmp_path)
+def plugin_loader():
+    return MagicMock()
 
 
-def test_get_plugin_not_found(plugin_loader: PluginLoader):
+def test_get_plugin_not_found(plugin_loader):
     plugin_registry = PluginRegistry(StubIslandAPIClient(status=404), plugin_loader)
 
     with pytest.raises(UnknownPluginError):
@@ -31,14 +29,14 @@ def test_get_plugin_not_found(plugin_loader: PluginLoader):
 
 
 # modify when plugin architecture is fully implemented
-def test_get_plugin_not_implemented(plugin_loader: PluginLoader):
+def test_get_plugin_not_implemented(plugin_loader):
     plugin_registry = PluginRegistry(StubIslandAPIClient(status=200), plugin_loader)
 
     with pytest.raises(NotImplementedError):
         plugin_registry.get_plugin("Ghost", AgentPluginType.PAYLOAD)
 
 
-def test_get_plugin_unexpected_response(plugin_loader: PluginLoader):
+def test_get_plugin_unexpected_response(plugin_loader):
     plugin_registry = PluginRegistry(StubIslandAPIClient(status=100), plugin_loader)
 
     with pytest.raises(Exception):

--- a/monkey/tests/unit_tests/infection_monkey/puppet/test_puppet.py
+++ b/monkey/tests/unit_tests/infection_monkey/puppet/test_puppet.py
@@ -11,7 +11,7 @@ from infection_monkey.puppet.puppet import EMPTY_FINGERPRINT, Puppet
 def test_puppet_run_payload_success():
     p = Puppet(
         agent_event_queue=MagicMock(spec=IAgentEventQueue),
-        plugin_registry=PluginRegistry(MagicMock()),
+        plugin_registry=PluginRegistry(MagicMock(), MagicMock()),
     )
 
     payload = MagicMock()
@@ -26,7 +26,7 @@ def test_puppet_run_payload_success():
 def test_puppet_run_multiple_payloads():
     p = Puppet(
         agent_event_queue=MagicMock(spec=IAgentEventQueue),
-        plugin_registry=PluginRegistry(MagicMock()),
+        plugin_registry=PluginRegistry(MagicMock(), MagicMock()),
     )
 
     payload_1 = MagicMock()
@@ -55,7 +55,7 @@ def test_puppet_run_multiple_payloads():
 def test_fingerprint_exception_handling(monkeypatch):
     p = Puppet(
         agent_event_queue=MagicMock(spec=IAgentEventQueue),
-        plugin_registry=PluginRegistry(MagicMock()),
+        plugin_registry=PluginRegistry(MagicMock(), MagicMock()),
     )
     p._plugin_registry.get_plugin = MagicMock(side_effect=Exception)
     assert p.fingerprint("", "", PingScanData("windows", False), {}, {}) == EMPTY_FINGERPRINT


### PR DESCRIPTION
# What does this PR do?

Fixes part of #2692.

Adds serpentarium.PluginLoader to the PluginRegistry.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~~Was the CHANGELOG.md updated to reflect the changes?~~
* [ ] ~~Was the documentation framework updated to reflect the changes?~~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Have you successfully tested your changes locally? Elaborate:
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
