### PR TITLE
UI: Add ErrorModal stylesheet

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/ui-components/ErrorModal.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/ui-components/ErrorModal.tsx
@@ -2,6 +2,7 @@ import {Modal} from 'react-bootstrap';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {faExclamationTriangle} from '@fortawesome/free-solid-svg-icons';
 import React from 'react';
+import '../../styles/components/ErrorModal.scss';
 
 
 interface Props {
@@ -26,7 +27,7 @@ export const ErrorModal = ({
         <Modal.Title> Uh oh... </Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        <div style={{'marginTop': '1em', 'marginBottom': '1em'}}>
+        <div className={'error-modal'}>
           <div className={`alert alert-${errorLevel}`}>
             <FontAwesomeIcon icon={faExclamationTriangle} style={{'marginRight': '5px'}}/>
             {errorMessage}
@@ -36,7 +37,7 @@ export const ErrorModal = ({
           <div>
             <hr/>
             <h4>Error Details</h4>
-            <p style={{'word-wrap': 'break-word', 'white-space': 'pre-wrap'}}>
+            <p className={'error-details'}>
               {errorDetails}
             </p>
           </div>

--- a/monkey/monkey_island/cc/ui/src/styles/components/ErrorModal.scss
+++ b/monkey/monkey_island/cc/ui/src/styles/components/ErrorModal.scss
@@ -1,0 +1,9 @@
+.error-modal {
+    margin-top: 1em;
+    margin-bottom: 1em;
+}
+
+.error-details {
+    word-wrap: break-word;
+    white-space: pre-wrap;
+}


### PR DESCRIPTION
# What does this PR do?

UI couldn't be built because of inline style in ErrorModal

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [x] Was the CHANGELOG.md updated to reflect the changes?
* [x] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [x] If applicable, add screenshots or log transcripts of the feature working

<img width="507" alt="image" src="https://user-images.githubusercontent.com/15820737/208396249-553113e2-3e1f-4a1e-bf6a-e11a632496e3.png">
