### PR TITLE
Island: Switch exploiters in schema type to dict

### DIFF
--- a/monkey/common/agent_configuration/agent_sub_configurations.py
+++ b/monkey/common/agent_configuration/agent_sub_configurations.py
@@ -192,7 +192,7 @@ class ExploitationConfiguration(MutableInfectionMonkeyBaseModel):
     """
 
     options: ExploitationOptionsConfiguration = Field(title="Exploiters Options")
-    exploiters: Tuple[PluginConfiguration, ...] = Field(title="Enabled exploiters")
+    exploiters: Dict = Field(title="Enabled exploiters")
 
 
 class PropagationConfiguration(MutableInfectionMonkeyBaseModel):


### PR DESCRIPTION
# What does this PR do?

This is done to make the structure of hard-coded exploiters' options to match the options of exploiter plugins

