### PR TITLE
UT: Update mock plugins to use credentials repo

### DIFF
--- a/monkey/tests/data_for_tests/agent_plugin/mock1/src/plugin.py
+++ b/monkey/tests/data_for_tests/agent_plugin/mock1/src/plugin.py
@@ -12,6 +12,7 @@ from common.types import AgentID
 from infection_monkey.exploit import IAgentBinaryRepository
 from infection_monkey.i_puppet import ExploiterResultData
 from infection_monkey.model import TargetHost
+from infection_monkey.propagation_credentials_repository import IPropagationCredentialsRepository
 from infection_monkey.utils.threading import interruptible_iter
 
 logger = logging.getLogger(__name__)
@@ -23,11 +24,13 @@ class Plugin:
         agent_id: AgentID,
         agent_binary_repository: IAgentBinaryRepository,
         agent_event_publisher: IAgentEventPublisher,
+        propagation_credentials_repository: IPropagationCredentialsRepository,
         plugin_name="",
     ):
         self._agent_id = agent_id
         self._agent_binary_repository = agent_binary_repository
         self._agent_event_publisher = agent_event_publisher
+        self._propagation_credentials_repository = propagation_credentials_repository
 
     def run(
         self,
@@ -43,6 +46,10 @@ class Plugin:
 
         Plugin._log_options(options)
         Plugin._sleep(options.get("sleep_duration", 0), interrupt)
+
+        credentials = self._propagation_credentials_repository.get_credentials()
+        credentials_str = "\n".join(map(str, credentials))
+        logger.debug(f"Credentials: \n{credentials_str}")
 
         event_fields = {
             "source": self._agent_id,

--- a/monkey/tests/data_for_tests/agent_plugin/mock2/src/plugin.py
+++ b/monkey/tests/data_for_tests/agent_plugin/mock2/src/plugin.py
@@ -10,6 +10,7 @@ from common.types import AgentID
 from infection_monkey.exploit import IAgentBinaryRepository
 from infection_monkey.i_puppet import ExploiterResultData
 from infection_monkey.model import TargetHost
+from infection_monkey.propagation_credentials_repository import IPropagationCredentialsRepository
 
 logger = logging.getLogger(__name__)
 
@@ -20,11 +21,13 @@ class Plugin:
         agent_id: AgentID,
         agent_binary_repository: IAgentBinaryRepository,
         agent_event_publisher: IAgentEventPublisher,
+        propagation_credentials_repository: IPropagationCredentialsRepository,
         plugin_name="",
     ):
         self._agent_id = agent_id
         self._agent_binary_repository = agent_binary_repository
         self._agent_event_publisher = agent_event_publisher
+        self._propagation_credentials_repository = propagation_credentials_repository
 
     def run(
         self,
@@ -39,6 +42,10 @@ class Plugin:
         logger.info(f"Mock dependency package version: {mock_dependency.__version__}")
 
         Plugin._log_options(options)
+
+        credentials = self._propagation_credentials_repository.get_credentials()
+        credentials_str = "\n".join(map(str, credentials))
+        logger.debug(f"Credentials: \n{credentials_str}")
 
         event_fields = {
             "source": self._agent_id,


### PR DESCRIPTION
# What does this PR do?

Fixes #2773.

Updated the mock plugins to print the credentials from the credentials repo.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~~Was the CHANGELOG.md updated to reflect the changes?~~
* [ ] ~~Was the documentation framework updated to reflect the changes?~~
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~~Added relevant unit tests?~~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running in the zoo environment
* [x] If applicable, add screenshots or log transcripts of the feature working
    > [2023-01-06T16.32.16.530Z-island-linux-250.log](https://github.com/guardicore/monkey/files/10361603/2023-01-06T16.32.16.530Z-island-linux-250.log)
