### PR TITLE
Change 'name' in Hadoop manifest

### DIFF
--- a/monkey/agent_plugins/exploiters/hadoop/src/hadoop_exploit_client.py
+++ b/monkey/agent_plugins/exploiters/hadoop/src/hadoop_exploit_client.py
@@ -26,7 +26,7 @@ from .hadoop_options import HadoopOptions
 logger = logging.getLogger(__name__)
 
 HADOOP_EXPLOITER_TAG = "hadoop-exploiter"
-EXPLOITER_NAME = "HadoopExploiter"
+EXPLOITER_NAME = "Hadoop"
 RAND_STR_LEN = 6  # Random string's length that's used for creating unique app name
 EXPLOITER_TAGS = (HADOOP_EXPLOITER_TAG, T1203_ATTACK_TECHNIQUE_TAG, T1210_ATTACK_TECHNIQUE_TAG)
 PROPAGATION_TAGS = (HADOOP_EXPLOITER_TAG, T1105_ATTACK_TECHNIQUE_TAG)


### PR DESCRIPTION
# What does this PR do?

Fixes #2921 

The `name` in the manifest of an exploiter plugin and the `exploiter_name` being sent as part of the `ExploitationEvent` need to be the same.

The plugin registry, when asked for all plugin manifests, returns `Dict[AgentPluginType, Dict[str, AgentPluginManifest]]` where the `str` is whatever is in the `name` field in that plugin's manifest. When the report is being generated, `monkey_island.cc.services.reporting.exploitations.monkey_exploitation.get_monkey_exploited()` requests the plugin registry for all the manifests, and then, in `get_exploits_used_on_node()`, tries to get the manifest that it wants by using whatever is in the exploitation event's `exploiter_name` field as the key. No such key is found in the dictionary which is why the respective field is left empty in the API response and it is not shown in the report.

This PR updates ~the `name` field in the Hadoop manifest so that it matches what the exploiter sends in the exploitation event~ the `exploiter_name` field in the exploitation event that the Hadoop exploiter sends.

In the long term, we should find a way to get rid of this dependency.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing?
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [ ] ~Have you checked that you haven't introduced any duplicate code?~

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by exploiting Hadoop and checking the Island
* [x] If applicable, add screenshots or log transcripts of the feature working

![image](https://user-images.githubusercontent.com/44770317/216547056-4c3943ec-17cc-429e-8457-4412a765958f.png)
