### PR TITLE
BB: Allow tests to be parameterized

### DIFF
--- a/envs/monkey_zoo/blackbox/conftest.py
+++ b/envs/monkey_zoo/blackbox/conftest.py
@@ -34,7 +34,7 @@ def no_gcp(request):
 def gcp_machines_to_start(request: pytest.FixtureRequest) -> Mapping[str, Collection[str]]:
     machines_to_start: Dict[str, Set[str]] = {}
 
-    enabled_tests = (test.name for test in request.node.items)
+    enabled_tests = (test.originalname for test in request.node.items)
     machines_for_enabled_tests = (GCP_SINGLE_TEST_LIST[test] for test in enabled_tests)
 
     for machine_dict in machines_for_enabled_tests:


### PR DESCRIPTION
# What does this PR do?

Each test `name` is overwritten when parameterizing tests. However, `originalname` will keep the original test's name. This change will allow the use of pytest-repeat, enabling something like the following:

> `pytest -k test_depth_3_a --count 1000 -x`

Which will run the `test_depth_3_a` test 1000 times or until it fails.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing?
* [ ] ~~Was the CHANGELOG.md updated to reflect the changes?~~
* [ ] ~~Was the documentation framework updated to reflect the changes?~~
* [c] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~~Added relevant unit tests?~~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running the blackbox tests using the `--count` flag
* [x] If applicable, add screenshots or log transcripts of the feature working
```
kkaaikal@localhost:~/infection_monkey/monkey$ python -m pytest -k test_depth_3_a --count=1000 -x -s --no-gcp --island=34.89.161.57:5000 ../envs/monkey_zoo/blackbox/test_blackbox.py
================================================== test session starts ===================================================
platform linux -- Python 3.7.13, pytest-7.2.0, pluggy-1.0.0
rootdir: /home/kkaaikal/infection_monkey/envs/monkey_zoo/blackbox, configfile: pytest.ini
plugins: repeat-0.9.1, requests-mock-1.8.0, cov-4.0.0, xdist-3.1.0
collected 8000 items / 7000 deselected / 1000 selected                                                                   

../envs/monkey_zoo/blackbox/test_blackbox.py::TestMonkeyBlackbox::test_depth_3_a[1-1000] 
----------------------------------------------------- live log setup -----------------------------------------------------
18:59:50 [INFO] test_blackbox.delete_logs.58: Deleting monkey logs before new tests.
----------------------------------------------------- live log call ------------------------------------------------------
18:59:52 [INFO] monkey_island_client._set_island_mode.48: Setting island mode to Custom.
18:59:52 [INFO] monkey_island_client._import_config.60: Configuration is imported.
18:59:52 [INFO] monkey_island_client._import_credentials.75: Credentials are imported.
18:59:52 [INFO] exploitation.print_test_starting_info.41: Started Depth3A test suite test
18:59:52 [INFO] exploitation.print_test_starting_info.43: Machines participating in test: 10.2.2.9, 10.2.1.10, 10.2.0.11

18:59:53 [INFO] monkey_island_client.run_monkey_local.84: Running the monkey.
19:00:52 [INFO] exploitation.log_success.60: 
CommunicationAnalyzer: 
Agent from 10.2.2.9 communicated back
Agent from 10.2.1.10 communicated back
Agent from 10.2.0.11 communicated back

19:00:52 [INFO] exploitation.log_success.62: Depth3A test suite test passed, time taken: 59.0 seconds.
19:00:52 [INFO] monkey_island_client.kill_all_monkeys.101: Killing all monkeys after the test.
19:01:06 [INFO] exploitation.wait_until_monkeys_die.95: After 10 seconds all monkeys have died
19:01:11 [INFO] exploitation.parse_logs.98: Parsing test logs:
19:01:11 [INFO] monkey_logs_downloader.download_monkey_logs.24: Downloading each monkey log.
19:01:13 [INFO] test_logs_handler.parse_logs.50: Info from log at /home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite/agent_2023-02-03_19-00-43_10.2.0.11.log
19:01:13 [INFO] monkey_log_parser.print_errors.19: Found 6 errors:
...
19:01:13 [INFO] monkey_log_parser.print_warnings.37: No warnings!
19:01:13 [INFO] test_logs_handler.parse_logs.50: Info from log at /home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite/agent_2023-02-03_19-00-28_10.2.0.10.log
19:01:13 [INFO] monkey_log_parser.print_errors.19: Found 4 errors:
...
19:01:13 [INFO] monkey_log_parser.print_warnings.37: No warnings!
19:01:13 [INFO] test_logs_handler.parse_logs.50: Info from log at /home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite/agent_2023-02-03_18-59-52_10.2.2.250.log
19:01:13 [INFO] monkey_log_parser.print_errors.23: No errors!
19:01:13 [INFO] monkey_log_parser.print_warnings.37: No warnings!
19:01:13 [INFO] test_logs_handler.parse_logs.50: Info from log at /home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite/agent_2023-02-03_19-00-07_10.2.1.9.log
19:01:13 [INFO] monkey_log_parser.print_errors.19: Found 1 errors:
...
19:01:13 [INFO] monkey_log_parser.print_warnings.37: No warnings!
19:01:13 [INFO] test_logs_handler.parse_logs.50: Info from log at /home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite/island_2023-02-03_19-01-13.log
19:01:13 [INFO] monkey_log_parser.print_errors.23: No errors!
19:01:13 [INFO] monkey_log_parser.print_warnings.37: No warnings!
19:01:13 [INFO] monkey_island_client._reset_agent_configuration.117: Resetting agent-configuration after the test.
19:01:13 [INFO] monkey_island_client._reset_simulation_data.124: Clearing simulation data.
19:01:14 [INFO] monkey_island_client._reset_credentials.131: Resseting configured credentials after the test.
19:01:14 [INFO] monkey_island_client._reset_island_mode.138: Resetting island mode after the test.
PASSED
../envs/monkey_zoo/blackbox/test_blackbox.py::TestMonkeyBlackbox::test_depth_3_a[2-1000] 
----------------------------------------------------- live log call ------------------------------------------------------
19:01:14 [INFO] monkey_island_client._set_island_mode.48: Setting island mode to Custom.
19:01:15 [INFO] monkey_island_client._import_config.60: Configuration is imported.
19:01:15 [INFO] monkey_island_client._import_credentials.75: Credentials are imported.
19:01:15 [INFO] exploitation.print_test_starting_info.41: Started Depth3A test suite test
19:01:15 [INFO] exploitation.print_test_starting_info.43: Machines participating in test: 10.2.2.9, 10.2.1.10, 10.2.0.11

19:01:15 [INFO] monkey_island_client.run_monkey_local.84: Running the monkey.
19:02:14 [INFO] exploitation.log_success.60: 
CommunicationAnalyzer: 
Agent from 10.2.2.9 communicated back
Agent from 10.2.1.10 communicated back
Agent from 10.2.0.11 communicated back

19:02:14 [INFO] exploitation.log_success.62: Depth3A test suite test passed, time taken: 58.9 seconds.
19:02:15 [INFO] monkey_island_client.kill_all_monkeys.101: Killing all monkeys after the test.
19:02:28 [INFO] exploitation.wait_until_monkeys_die.95: After 10 seconds all monkeys have died
19:02:33 [INFO] exploitation.parse_logs.98: Parsing test logs:
19:02:33 [ERROR] test_logs_handler.try_create_log_dir_for_test.40: Can't create a dir for test logs: [Errno 17] File exists: '/home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite'
19:02:33 [INFO] monkey_logs_downloader.download_monkey_logs.24: Downloading each monkey log.
19:02:36 [INFO] test_logs_handler.parse_logs.50: Info from log at /home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite/agent_2023-02-03_19-02-04_10.2.0.11.log
19:02:36 [INFO] monkey_log_parser.print_errors.19: Found 6 errors:
...
19:02:36 [INFO] monkey_log_parser.print_warnings.37: No warnings!
19:02:36 [INFO] test_logs_handler.parse_logs.50: Info from log at /home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite/agent_2023-02-03_19-01-15_10.2.2.250.log
19:02:36 [INFO] monkey_log_parser.print_errors.23: No errors!
19:02:36 [INFO] monkey_log_parser.print_warnings.37: No warnings!
19:02:36 [INFO] test_logs_handler.parse_logs.50: Info from log at /home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite/agent_2023-02-03_19-01-27_10.2.1.9.log
19:02:36 [INFO] monkey_log_parser.print_errors.19: Found 1 errors:
...
19:02:36 [INFO] monkey_log_parser.print_warnings.37: No warnings!
19:02:36 [INFO] test_logs_handler.parse_logs.50: Info from log at /home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite/agent_2023-02-03_19-01-47_10.2.0.10.log
19:02:36 [INFO] monkey_log_parser.print_errors.19: Found 4 errors:
...
19:02:36 [INFO] monkey_log_parser.print_warnings.37: No warnings!
19:02:36 [INFO] test_logs_handler.parse_logs.50: Info from log at /home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite/island_2023-02-03_19-02-35.log
19:02:36 [INFO] monkey_log_parser.print_errors.23: No errors!
19:02:36 [INFO] monkey_log_parser.print_warnings.37: No warnings!
19:02:36 [INFO] monkey_island_client._reset_agent_configuration.117: Resetting agent-configuration after the test.
19:02:36 [INFO] monkey_island_client._reset_simulation_data.124: Clearing simulation data.
19:02:37 [INFO] monkey_island_client._reset_credentials.131: Resseting configured credentials after the test.
19:02:37 [INFO] monkey_island_client._reset_island_mode.138: Resetting island mode after the test.
PASSED
../envs/monkey_zoo/blackbox/test_blackbox.py::TestMonkeyBlackbox::test_depth_3_a[3-1000] 
----------------------------------------------------- live log call ------------------------------------------------------
19:02:37 [INFO] monkey_island_client._set_island_mode.48: Setting island mode to Custom.
19:02:38 [INFO] monkey_island_client._import_config.60: Configuration is imported.
19:02:38 [INFO] monkey_island_client._import_credentials.75: Credentials are imported.
19:02:38 [INFO] exploitation.print_test_starting_info.41: Started Depth3A test suite test
19:02:38 [INFO] exploitation.print_test_starting_info.43: Machines participating in test: 10.2.2.9, 10.2.1.10, 10.2.0.11

19:02:38 [INFO] monkey_island_client.run_monkey_local.84: Running the monkey.
19:03:32 [INFO] exploitation.log_success.60: 
CommunicationAnalyzer: 
Agent from 10.2.2.9 communicated back
Agent from 10.2.1.10 communicated back
Agent from 10.2.0.11 communicated back

19:03:32 [INFO] exploitation.log_success.62: Depth3A test suite test passed, time taken: 53.9 seconds.
19:03:32 [INFO] monkey_island_client.kill_all_monkeys.101: Killing all monkeys after the test.
19:03:47 [INFO] exploitation.wait_until_monkeys_die.95: After 11 seconds all monkeys have died
19:03:52 [INFO] exploitation.parse_logs.98: Parsing test logs:
19:03:52 [ERROR] test_logs_handler.try_create_log_dir_for_test.40: Can't create a dir for test logs: [Errno 17] File exists: '/home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite'
19:03:52 [INFO] monkey_logs_downloader.download_monkey_logs.24: Downloading each monkey log.
19:03:55 [INFO] test_logs_handler.parse_logs.50: Info from log at /home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite/agent_2023-02-03_19-03-22_10.2.0.11.log
19:03:55 [INFO] monkey_log_parser.print_errors.19: Found 6 errors:
...
19:03:55 [INFO] monkey_log_parser.print_warnings.37: No warnings!
19:03:55 [INFO] test_logs_handler.parse_logs.50: Info from log at /home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite/agent_2023-02-03_19-02-38_10.2.2.250.log
19:03:55 [INFO] monkey_log_parser.print_errors.23: No errors!
19:03:55 [INFO] monkey_log_parser.print_warnings.37: No warnings!
19:03:55 [INFO] test_logs_handler.parse_logs.50: Info from log at /home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite/agent_2023-02-03_19-03-06_10.2.0.10.log
19:03:55 [INFO] monkey_log_parser.print_errors.19: Found 4 errors:
...
19:03:55 [INFO] monkey_log_parser.print_warnings.37: No warnings!
19:03:55 [INFO] test_logs_handler.parse_logs.50: Info from log at /home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite/agent_2023-02-03_19-02-45_10.2.1.9.log
19:03:55 [INFO] monkey_log_parser.print_errors.19: Found 1 errors:
...
19:03:55 [INFO] monkey_log_parser.print_warnings.37: No warnings!
19:03:55 [INFO] test_logs_handler.parse_logs.50: Info from log at /home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite/island_2023-02-03_19-03-54.log
19:03:55 [INFO] monkey_log_parser.print_errors.23: No errors!
19:03:55 [INFO] monkey_log_parser.print_warnings.37: No warnings!
19:03:55 [INFO] monkey_island_client._reset_agent_configuration.117: Resetting agent-configuration after the test.
19:03:55 [INFO] monkey_island_client._reset_simulation_data.124: Clearing simulation data.
19:03:56 [INFO] monkey_island_client._reset_credentials.131: Resseting configured credentials after the test.
19:03:56 [INFO] monkey_island_client._reset_island_mode.138: Resetting island mode after the test.
PASSED
../envs/monkey_zoo/blackbox/test_blackbox.py::TestMonkeyBlackbox::test_depth_3_a[4-1000] 
----------------------------------------------------- live log call ------------------------------------------------------
19:03:56 [INFO] monkey_island_client._set_island_mode.48: Setting island mode to Custom.
19:03:57 [INFO] monkey_island_client._import_config.60: Configuration is imported.
19:03:57 [INFO] monkey_island_client._import_credentials.75: Credentials are imported.
19:03:57 [INFO] exploitation.print_test_starting_info.41: Started Depth3A test suite test
19:03:57 [INFO] exploitation.print_test_starting_info.43: Machines participating in test: 10.2.2.9, 10.2.1.10, 10.2.0.11

19:03:57 [INFO] monkey_island_client.run_monkey_local.84: Running the monkey.
19:04:53 [INFO] exploitation.log_success.60: 
CommunicationAnalyzer: 
Agent from 10.2.2.9 communicated back
Agent from 10.2.1.10 communicated back
Agent from 10.2.0.11 communicated back

19:04:53 [INFO] exploitation.log_success.62: Depth3A test suite test passed, time taken: 55.5 seconds.
19:04:53 [INFO] monkey_island_client.kill_all_monkeys.101: Killing all monkeys after the test.
19:05:05 [INFO] exploitation.wait_until_monkeys_die.95: After 9 seconds all monkeys have died
19:05:10 [INFO] exploitation.parse_logs.98: Parsing test logs:
19:05:10 [ERROR] test_logs_handler.try_create_log_dir_for_test.40: Can't create a dir for test logs: [Errno 17] File exists: '/home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite'
19:05:10 [INFO] monkey_logs_downloader.download_monkey_logs.24: Downloading each monkey log.
19:05:13 [INFO] test_logs_handler.parse_logs.50: Info from log at /home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite/agent_2023-02-03_19-04-42_10.2.0.11.log
19:05:13 [INFO] monkey_log_parser.print_errors.19: Found 6 errors:
...
19:05:13 [INFO] monkey_log_parser.print_warnings.37: No warnings!
19:05:13 [INFO] test_logs_handler.parse_logs.50: Info from log at /home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite/agent_2023-02-03_19-03-57_10.2.2.250.log
19:05:13 [INFO] monkey_log_parser.print_errors.23: No errors!
19:05:13 [INFO] monkey_log_parser.print_warnings.37: No warnings!
19:05:13 [INFO] test_logs_handler.parse_logs.50: Info from log at /home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite/agent_2023-02-03_19-04-28_10.2.0.10.log
19:05:13 [INFO] monkey_log_parser.print_errors.19: Found 4 errors:
...
19:05:13 [INFO] monkey_log_parser.print_warnings.37: No warnings!
19:05:13 [INFO] test_logs_handler.parse_logs.50: Info from log at /home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite/agent_2023-02-03_19-04-08_10.2.1.9.log
19:05:13 [INFO] monkey_log_parser.print_errors.19: Found 1 errors:
...
19:05:13 [INFO] monkey_log_parser.print_warnings.37: No warnings!
19:05:13 [INFO] test_logs_handler.parse_logs.50: Info from log at /home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite/island_2023-02-03_19-05-12.log
19:05:13 [INFO] monkey_log_parser.print_errors.23: No errors!
19:05:13 [INFO] monkey_log_parser.print_warnings.37: No warnings!
19:05:13 [INFO] monkey_island_client._reset_agent_configuration.117: Resetting agent-configuration after the test.
19:05:13 [INFO] monkey_island_client._reset_simulation_data.124: Clearing simulation data.
19:05:14 [INFO] monkey_island_client._reset_credentials.131: Resseting configured credentials after the test.
19:05:14 [INFO] monkey_island_client._reset_island_mode.138: Resetting island mode after the test.
PASSED
../envs/monkey_zoo/blackbox/test_blackbox.py::TestMonkeyBlackbox::test_depth_3_a[5-1000] 
----------------------------------------------------- live log call ------------------------------------------------------
19:05:14 [INFO] monkey_island_client._set_island_mode.48: Setting island mode to Custom.
19:05:15 [INFO] monkey_island_client._import_config.60: Configuration is imported.
19:05:15 [INFO] monkey_island_client._import_credentials.75: Credentials are imported.
19:05:15 [INFO] exploitation.print_test_starting_info.41: Started Depth3A test suite test
19:05:15 [INFO] exploitation.print_test_starting_info.43: Machines participating in test: 10.2.2.9, 10.2.1.10, 10.2.0.11

19:05:15 [INFO] monkey_island_client.run_monkey_local.84: Running the monkey.
19:06:04 [INFO] exploitation.log_success.60: 
CommunicationAnalyzer: 
Agent from 10.2.2.9 communicated back
Agent from 10.2.1.10 communicated back
Agent from 10.2.0.11 communicated back

19:06:04 [INFO] exploitation.log_success.62: Depth3A test suite test passed, time taken: 49.0 seconds.
19:06:05 [INFO] monkey_island_client.kill_all_monkeys.101: Killing all monkeys after the test.
19:06:21 [INFO] exploitation.wait_until_monkeys_die.95: After 12 seconds all monkeys have died
19:06:26 [INFO] exploitation.parse_logs.98: Parsing test logs:
19:06:26 [ERROR] test_logs_handler.try_create_log_dir_for_test.40: Can't create a dir for test logs: [Errno 17] File exists: '/home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite'
19:06:26 [INFO] monkey_logs_downloader.download_monkey_logs.24: Downloading each monkey log.
19:06:28 [INFO] test_logs_handler.parse_logs.50: Info from log at /home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite/agent_2023-02-03_19-05-55_10.2.0.11.log
19:06:28 [INFO] monkey_log_parser.print_errors.19: Found 6 errors:
...
19:06:28 [INFO] monkey_log_parser.print_warnings.37: No warnings!
19:06:28 [INFO] test_logs_handler.parse_logs.50: Info from log at /home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite/agent_2023-02-03_19-05-15_10.2.2.250.log
19:06:28 [INFO] monkey_log_parser.print_errors.23: No errors!
19:06:28 [INFO] monkey_log_parser.print_warnings.37: No warnings!
19:06:28 [INFO] test_logs_handler.parse_logs.50: Info from log at /home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite/agent_2023-02-03_19-05-39_10.2.0.10.log
19:06:28 [INFO] monkey_log_parser.print_errors.19: Found 4 errors:
...
19:06:28 [INFO] monkey_log_parser.print_warnings.37: No warnings!
19:06:28 [INFO] test_logs_handler.parse_logs.50: Info from log at /home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite/agent_2023-02-03_19-05-24_10.2.1.9.log
19:06:28 [INFO] monkey_log_parser.print_errors.19: Found 1 errors:
...
19:06:28 [INFO] monkey_log_parser.print_warnings.37: No warnings!
19:06:28 [INFO] test_logs_handler.parse_logs.50: Info from log at /home/kkaaikal/infection_monkey/monkey/logs/Depth3A test suite/island_2023-02-03_19-06-28.log
19:06:28 [INFO] monkey_log_parser.print_errors.23: No errors!
19:06:28 [INFO] monkey_log_parser.print_warnings.37: No warnings!
19:06:29 [INFO] monkey_island_client._reset_agent_configuration.117: Resetting agent-configuration after the test.
19:06:29 [INFO] monkey_island_client._reset_simulation_data.124: Clearing simulation data.
19:06:29 [INFO] monkey_island_client._reset_credentials.131: Resseting configured credentials after the test.
19:06:30 [INFO] monkey_island_client._reset_island_mode.138: Resetting island mode after the test.
PASSED
...
```