### PR TITLE
Common: Disable credential collectors in ransomware configuration

### DIFF
--- a/monkey/common/agent_configuration/default_agent_configuration.py
+++ b/monkey/common/agent_configuration/default_agent_configuration.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from . import AgentConfiguration
 from .agent_sub_configurations import (
     ExploitationConfiguration,
@@ -97,4 +99,5 @@ DEFAULT_AGENT_CONFIGURATION = AgentConfiguration(
     propagation=PROPAGATION_CONFIGURATION,
 )
 
-DEFAULT_RANSOMWARE_AGENT_CONFIGURATION = DEFAULT_AGENT_CONFIGURATION.copy()
+DEFAULT_RANSOMWARE_AGENT_CONFIGURATION = deepcopy(DEFAULT_AGENT_CONFIGURATION)
+DEFAULT_RANSOMWARE_AGENT_CONFIGURATION.credential_collectors = tuple()


### PR DESCRIPTION
# What does this PR do?
Disables credential collectors by default in the ransomware simulation.

Since the configuration UI hides these settings when ransomware is selected, they should be disabled. 

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Have you successfully tested your changes locally? Elaborate:
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
