### PR TITLE
2136 update hadoop to skip closed ports

### DIFF
--- a/monkey/agent_plugins/exploiters/hadoop/src/hadoop_exploiter.py
+++ b/monkey/agent_plugins/exploiters/hadoop/src/hadoop_exploiter.py
@@ -111,23 +111,35 @@ class HadoopExploiter:
         return exploit_result
 
 
+def _build_potential_urls(target_host: TargetHost, options: HadoopOptions) -> Sequence[str]:
+    # Note: Currently using a set, so ordering is not preserved
+    ports = set(_filter_out_closed_ports(options.target_ports, target_host))
+    if options.try_all_discovered_http_ports:
+        ports.update(_get_open_http_ports(target_host))
+
+    potential_urls = build_urls(str(target_host.ip), [(str(p), False) for p in ports])
+    logger.debug(f"Potential URLs: {potential_urls}")
+
+    return potential_urls
+
+
+def _filter_out_closed_ports(
+    ports: Sequence[NetworkPort], target_host: TargetHost
+) -> Sequence[NetworkPort]:
+    closed_ports = [
+        port
+        for port, psd in target_host.ports_status.tcp_ports.items()
+        if psd.status == PortStatus.CLOSED
+    ]
+    return [port for port in ports if port not in closed_ports]
+
+
 def _get_open_http_ports(target_host: TargetHost) -> Sequence[NetworkPort]:
     return [
         port
         for port, psd in target_host.ports_status.tcp_ports.items()
         if psd.status == PortStatus.OPEN and psd.service == NetworkService.HTTP
     ]
-
-
-def _build_potential_urls(target_host: TargetHost, options: HadoopOptions) -> Sequence[str]:
-    # Note: Currently using a set, so ordering is not preserved
-    ports = set(options.target_ports)
-    if options.try_all_discovered_http_ports:
-        ports.update(_get_open_http_ports(target_host))
-    potential_urls = build_urls(str(target_host.ip), [(str(p), False) for p in ports])
-    logger.debug(f"Potential URLs: {potential_urls}")
-
-    return potential_urls
 
 
 def _stop_agent_binary_http_server(

--- a/monkey/tests/unit_tests/agent_plugins/exploiters/hadoop/test_hadoop_exploiter.py
+++ b/monkey/tests/unit_tests/agent_plugins/exploiters/hadoop/test_hadoop_exploiter.py
@@ -30,6 +30,13 @@ CLOSED_PORT_DATA = PortScanData(
     protocol=NetworkProtocol.TCP,
     service=NetworkService.HTTP,
 )
+CLOSED_PORT_80 = NetworkPort(80)
+CLOSED_PORT_80_DATA = PortScanData(
+    port=CLOSED_PORT_80,
+    status=PortStatus.CLOSED,
+    protocol=NetworkProtocol.TCP,
+    service=NetworkService.HTTP,
+)
 HTTPS_PORT = NetworkPort(12347)
 HTTPS_PORT_DATA = PortScanData(
     port=HTTPS_PORT,
@@ -203,6 +210,32 @@ def test_exploit_attempt_on_all_discovered_open_http_ports(
     assert f"http://{TARGET_IP}:80/" in urls_passed_to_exploit
     assert f"http://{TARGET_IP}:443/" in urls_passed_to_exploit
     assert f"http://{TARGET_IP}:{HTTP_PORT}/" in urls_passed_to_exploit
+
+
+def test_exploit_attempt_skips_configured_ports_if_closed(
+    hadoop_exploiter: HadoopExploiter,
+    mock_hadoop_exploit_client: HadoopExploitClient,
+):
+    target_host = TargetHost(
+        ip=IPv4Address("1.1.1.1"),
+        operating_system=OperatingSystem.WINDOWS,
+        ports_status=TargetHostPorts(tcp_ports={CLOSED_PORT_80: CLOSED_PORT_80_DATA}),
+    )
+    hadoop_exploiter.exploit_host(
+        target_host=target_host,
+        servers=SERVERS,
+        current_depth=1,
+        options=HadoopOptions(target_ports=[80, 443, 8080]),
+        interrupt=Event(),
+    )
+
+    urls_passed_to_exploit = [
+        args[0][3] for args in mock_hadoop_exploit_client.exploit.call_args_list
+    ]
+
+    assert len(urls_passed_to_exploit) == 2
+    assert f"http://{TARGET_IP}:443/" in urls_passed_to_exploit
+    assert f"http://{TARGET_IP}:8080/" in urls_passed_to_exploit
 
 
 def test_exploit_attempt_skipped_on_interrupt(


### PR DESCRIPTION
# What does this PR do?

Fixes part of #2136

Updates Hadoop to skip configured ports if they are closed

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~~Was the CHANGELOG.md updated to reflect the changes?~~
* [ ] ~~Was the documentation framework updated to reflect the changes?~~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running unit tests
* [ ] If applicable, add screenshots or log transcripts of the feature working
