### PR TITLE
2705 upgrade python version hadoop

### DIFF
--- a/monkey/agent_plugins/exploiters/hadoop/Pipfile
+++ b/monkey/agent_plugins/exploiters/hadoop/Pipfile
@@ -10,4 +10,4 @@ requests = ">=2.24"
 pydantic = "*"
 
 [requires]
-python_version = "3.7"
+python_version = "3.11"

--- a/monkey/agent_plugins/exploiters/hadoop/Pipfile.lock
+++ b/monkey/agent_plugins/exploiters/hadoop/Pipfile.lock
@@ -1,10 +1,12 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7a3f6fddea6cf3b2998db14f27072833b4256d40a881efca26ae1126d656e0d9"
+            "sha256": "fabb108cf37b426b265341e817daa29ad60682daec0eef61f8584a0d963b610d"
         },
         "pipfile-spec": 6,
-        "requires": {},
+        "requires": {
+            "python_version": "3.11"
+        },
         "sources": [
             {
                 "name": "pypi",
@@ -140,5 +142,56 @@
             "version": "==1.26.14"
         }
     },
-    "develop": {}
+    "develop": {
+        "pydantic": {
+            "hashes": [
+                "sha256:1fd326aff5d6c36f05735c7c9b3d5b0e933b4ca52ad0b6e4b38038d82703d35b",
+                "sha256:2185a3b3d98ab4506a3f6707569802d2d92c3a7ba3a9a35683a7709ea6c2aaa2",
+                "sha256:261f357f0aecda005934e413dfd7aa4077004a174dafe414a8325e6098a8e419",
+                "sha256:305d0376c516b0dfa1dbefeae8c21042b57b496892d721905a6ec6b79494a66d",
+                "sha256:3257bd714de9db2102b742570a56bf7978e90441193acac109b1f500290f5718",
+                "sha256:3353072625ea2a9a6c81ad01b91e5c07fa70deb06368c71307529abf70d23325",
+                "sha256:36e44a4de37b8aecffa81c081dbfe42c4d2bf9f6dff34d03dce157ec65eb0f15",
+                "sha256:3bb99cf9655b377db1a9e47fa4479e3330ea96f4123c6c8200e482704bf1eda2",
+                "sha256:3f9d9b2be177c3cb6027cd67fbf323586417868c06c3c85d0d101703136e6b31",
+                "sha256:45edea10b75d3da43cfda12f3792833a3fa70b6eee4db1ed6aed528cef17c74e",
+                "sha256:51782fd81f09edcf265823c3bf43ff36d00db246eca39ee765ef58dc8421a642",
+                "sha256:532e97c35719f137ee5405bd3eeddc5c06eb91a032bc755a44e34a712420daf3",
+                "sha256:58e41dd1e977531ac6073b11baac8c013f3cd8706a01d3dc74e86955be8b2c0c",
+                "sha256:5920824fe1e21cbb3e38cf0f3dd24857c8959801d1031ce1fac1d50857a03bfb",
+                "sha256:5f3bc8f103b56a8c88021d481410874b1f13edf6e838da607dcb57ecff9b4594",
+                "sha256:63200cd8af1af2c07964546b7bc8f217e8bda9d0a2ef0ee0c797b36353914984",
+                "sha256:663d2dd78596c5fa3eb996bc3f34b8c2a592648ad10008f98d1348be7ae212fb",
+                "sha256:6a4b0aab29061262065bbdede617ef99cc5914d1bf0ddc8bcd8e3d7928d85bd6",
+                "sha256:6bb0452d7b8516178c969d305d9630a3c9b8cf16fcf4713261c9ebd465af0d73",
+                "sha256:72ef3783be8cbdef6bca034606a5de3862be6b72415dc5cb1fb8ddbac110049a",
+                "sha256:76c930ad0746c70f0368c4596020b736ab65b473c1f9b3872310a835d852eb19",
+                "sha256:7c5b94d598c90f2f46b3a983ffb46ab806a67099d118ae0da7ef21a2a4033b28",
+                "sha256:7ce1612e98c6326f10888df951a26ec1a577d8df49ddcaea87773bfbe23ba5cc",
+                "sha256:8481dca324e1c7b715ce091a698b181054d22072e848b6fc7895cd86f79b4449",
+                "sha256:87f831e81ea0589cd18257f84386bf30154c5f4bed373b7b75e5cb0b5d53ea87",
+                "sha256:9a9d9155e2a9f38b2eb9374c88f02fd4d6851ae17b65ee786a87d032f87008f8",
+                "sha256:9e337ac83686645a46db0e825acceea8e02fca4062483f40e9ae178e8bd1103a",
+                "sha256:b429f7c457aebb7fbe7cd69c418d1cd7c6fdc4d3c8697f45af78b8d5a7955760",
+                "sha256:b473d00ccd5c2061fd896ac127b7755baad233f8d996ea288af14ae09f8e0d1e",
+                "sha256:bd46a0e6296346c477e59a954da57beaf9c538da37b9df482e50f836e4a7d4bb",
+                "sha256:c428c0f64a86661fb4873495c4fac430ec7a7cef2b8c1c28f3d1a7277f9ea5ab",
+                "sha256:c9e5b778b6842f135902e2d82624008c6a79710207e28e86966cd136c621bfee",
+                "sha256:ca9075ab3de9e48b75fa8ccb897c34ccc1519177ad8841d99f7fd74cf43be5bf",
+                "sha256:f582cac9d11c227c652d3ce8ee223d94eb06f4228b52a8adaafa9fa62e73d5c9",
+                "sha256:f5bee6c523d13944a1fdc6f0525bc86dbbd94372f17b83fa6331aabacc8fd08e",
+                "sha256:f836444b4c5ece128b23ec36a446c9ab7f9b0f7981d0d27e13a7c366ee163f8a"
+            ],
+            "index": "pypi",
+            "version": "==1.10.5"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb",
+                "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==4.5.0"
+        }
+    }
 }

--- a/monkey/agent_plugins/exploiters/hadoop/build.sh
+++ b/monkey/agent_plugins/exploiters/hadoop/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+umask 077
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+GID=$(id -g)
+TAG="latest"
+
+DOCKER_COMMANDS="
+cd /plugin &&
+bash build_plugin.sh &&
+chown ${UID}:${GID} \"/plugin/Hadoop-exploiter.tar\"
+"
+
+docker pull infectionmonkey/agent-builder:$TAG
+docker run \
+    --rm \
+    -v "$SCRIPT_DIR:/plugin" \
+    infectionmonkey/agent-builder:$TAG \
+    /bin/bash -c "$DOCKER_COMMANDS" | ts  '[%Y-%m-%d %H:%M:%S]'

--- a/monkey/agent_plugins/exploiters/hadoop/build_plugin.sh
+++ b/monkey/agent_plugins/exploiters/hadoop/build_plugin.sh
@@ -3,6 +3,8 @@
 # Build hadoop package
 # Usage: ./build_plugin.sh
 
+
+
 MANIFEST_FILENAME=manifest.yaml
 SCHEMA_FILENAME=config-schema.json
 SOURCE_FILENAME=source.tar
@@ -24,8 +26,14 @@ lower() {
     echo "$1" | tr "[:upper:]" "[:lower:]"
 }
 
-python3.7 -m pipenv requirements >> requirements.txt
-python3.7 -m pip install -r requirements.txt -t src/vendor
+set -x
+export PYENV_ROOT="$HOME/.pyenv"
+command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
+eval "$(pyenv init -)"
+
+pip install pipenv
+pipenv requirements >> requirements.txt
+pip install -r requirements.txt -t src/vendor
 rm requirements.txt
 
 # Package everything up

--- a/monkey/agent_plugins/exploiters/hadoop/build_plugin.sh
+++ b/monkey/agent_plugins/exploiters/hadoop/build_plugin.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Build hadoop package
-# Usage: ./build.sh
+# Usage: ./build_plugin.sh
 
 MANIFEST_FILENAME=manifest.yaml
 SCHEMA_FILENAME=config-schema.json


### PR DESCRIPTION
# What does this PR do?

Issue #2705

- Upgrade Hadoop to depend on Python3.11
- Create a single-touch build script to build the Hadoop plugin in the same container as the Agent

Add any further explanations here.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] ~Is the TravisCI build passing?~
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [x] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by running ETE tests
* [ ] ~If applicable, add screenshots or log transcripts of the feature working~
