### PR TITLE
Fix Windows `expanduser()` UTs after Python upgrade

### DIFF
--- a/monkey/tests/unit_tests/common/utils/test_common_file_utils.py
+++ b/monkey/tests/unit_tests/common/utils/test_common_file_utils.py
@@ -19,8 +19,8 @@ def test_expand_user(patched_home_env):
     assert expand_path(input_path) == expected_path
 
 
-def test_expand_vars(patched_home_env):
-    input_path = os.path.join("$HOME", "test")
+def test_expand_vars(home_env_variable, patched_home_env):
+    input_path = os.path.join(home_env_variable, "test")
     expected_path = patched_home_env / "test"
 
     assert expand_path(input_path) == expected_path

--- a/monkey/tests/unit_tests/conftest.py
+++ b/monkey/tests/unit_tests/conftest.py
@@ -8,6 +8,7 @@ MONKEY_BASE_PATH = str(Path(__file__).parent.parent.parent)
 sys.path.insert(0, MONKEY_BASE_PATH)
 
 from common.agent_configuration import DEFAULT_AGENT_CONFIGURATION, AgentConfiguration  # noqa: E402
+from common.utils.environment import is_windows_os  # noqa: E402
 
 
 @pytest.fixture(scope="session")
@@ -26,8 +27,16 @@ def stable_file_sha256_hash() -> str:
 
 
 @pytest.fixture
-def patched_home_env(monkeypatch, tmp_path):
-    monkeypatch.setenv("HOME", str(tmp_path))
+def home_env_variable():
+    if is_windows_os():
+        return "$USERPROFILE"
+    else:
+        return "$HOME"
+
+
+@pytest.fixture
+def patched_home_env(monkeypatch, tmp_path, home_env_variable):
+    monkeypatch.setenv(home_env_variable.strip("$"), str(tmp_path))
 
     return tmp_path
 

--- a/monkey/tests/unit_tests/infection_monkey/payload/ransomware/conftest.py
+++ b/monkey/tests/unit_tests/infection_monkey/payload/ransomware/conftest.py
@@ -5,13 +5,6 @@ import pytest
 
 
 @pytest.fixture
-def patched_home_env(monkeypatch, tmp_path):
-    monkeypatch.setenv("HOME", str(tmp_path))
-
-    return tmp_path
-
-
-@pytest.fixture
 def ransomware_test_data(data_for_tests_dir):
     return Path(data_for_tests_dir) / "ransomware_targets"
 

--- a/monkey/tests/unit_tests/infection_monkey/payload/ransomware/test_ransomware_options.py
+++ b/monkey/tests/unit_tests/infection_monkey/payload/ransomware/test_ransomware_options.py
@@ -63,8 +63,10 @@ def test_windows_target_dir(monkeypatch, options_from_island):
     assert options.target_directory == Path(WINDOWS_DIR)
 
 
-def test_env_variables_in_target_dir_resolved(options_from_island, patched_home_env, tmp_path):
-    path_with_env_variable = "$HOME/ransomware_target"
+def test_env_variables_in_target_dir_resolved(
+    options_from_island, home_env_variable, patched_home_env, tmp_path
+):
+    path_with_env_variable = f"{home_env_variable}/ransomware_target"
 
     options_from_island["encryption"]["directories"]["linux_target_dir"] = options_from_island[
         "encryption"

--- a/monkey/tests/unit_tests/monkey_island/cc/setup/test_island_config_options.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/setup/test_island_config_options.py
@@ -42,11 +42,11 @@ def test_data_dir_expanduser(patched_home_env):
     )
 
 
-def test_data_dir_expandvars(patched_home_env):
+def test_data_dir_expandvars(home_env_variable, patched_home_env):
     DATA_DIR_NAME = "test_data_dir"
 
     assert_data_dir_equals(
-        {"data_dir": os.path.join("$HOME", DATA_DIR_NAME)},
+        {"data_dir": os.path.join(home_env_variable, DATA_DIR_NAME)},
         patched_home_env / DATA_DIR_NAME,
     )
 
@@ -91,11 +91,11 @@ def test_crt_path_expanduser(patched_home_env):
     )
 
 
-def test_crt_path_expandvars(patched_home_env):
+def test_crt_path_expandvars(home_env_variable, patched_home_env):
     FILE_NAME = "test.crt"
 
     assert_ssl_certificate_file_equals(
-        {"ssl_certificate": {"ssl_certificate_file": os.path.join("$HOME", FILE_NAME)}},
+        {"ssl_certificate": {"ssl_certificate_file": os.path.join(home_env_variable, FILE_NAME)}},
         patched_home_env / FILE_NAME,
     )
 
@@ -126,11 +126,15 @@ def test_key_path_expanduser(patched_home_env):
     )
 
 
-def test_key_path_expandvars(patched_home_env):
+def test_key_path_expandvars(home_env_variable, patched_home_env):
     FILE_NAME = "test.key"
 
     assert_ssl_certificate_key_file_equals(
-        {"ssl_certificate": {"ssl_certificate_key_file": os.path.join("$HOME", FILE_NAME)}},
+        {
+            "ssl_certificate": {
+                "ssl_certificate_key_file": os.path.join(home_env_variable, FILE_NAME)
+            }
+        },
         patched_home_env / FILE_NAME,
     )
 


### PR DESCRIPTION
# What does this PR do?

Fixes a part of #2705
 
`expanduser()`'s functionality was changed in Python 3.8 to not allow "$HOME" on Windows anymore. See [this](https://docs.python.org/3/whatsnew/3.8.html#os-path).

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [x] Have you successfully tested your changes locally? Elaborate:
    > `expanduser()` UTs pass
* [ ] ~If applicable, add screenshots or log transcripts of the feature working~
