### PR TITLE
2817 add agent registration time field

### DIFF
--- a/monkey/monkey_island/cc/island_event_handlers/handle_agent_registration.py
+++ b/monkey/monkey_island/cc/island_event_handlers/handle_agent_registration.py
@@ -1,6 +1,7 @@
+from datetime import datetime
 from contextlib import suppress
 from ipaddress import IPv4Interface
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 from common import AgentRegistrationData
 from common.types import SocketAddress
@@ -23,10 +24,12 @@ class handle_agent_registration:
         machine_repository: IMachineRepository,
         agent_repository: IAgentRepository,
         node_repository: INodeRepository,
+        get_current_datetime: Callable[[], datetime] = datetime.now(),
     ):
         self._machine_repository = machine_repository
         self._agent_repository = agent_repository
         self._node_repository = node_repository
+        self._get_current_datetime = get_current_datetime
 
     def __call__(self, agent_registration_data: AgentRegistrationData):
         machine = self._update_machine_repository(agent_registration_data)
@@ -101,6 +104,7 @@ class handle_agent_registration:
         new_agent = Agent(
             id=agent_registration_data.id,
             machine_id=machine.id,
+            registration_time=self._get_current_datetime(),
             start_time=agent_registration_data.start_time,
             parent_id=agent_registration_data.parent_id,
             cc_server=agent_registration_data.cc_server,

--- a/monkey/monkey_island/cc/island_event_handlers/handle_agent_registration.py
+++ b/monkey/monkey_island/cc/island_event_handlers/handle_agent_registration.py
@@ -1,5 +1,5 @@
-from datetime import datetime
 from contextlib import suppress
+from datetime import datetime
 from ipaddress import IPv4Interface
 from typing import Callable, List, Optional
 

--- a/monkey/monkey_island/cc/island_event_handlers/handle_agent_registration.py
+++ b/monkey/monkey_island/cc/island_event_handlers/handle_agent_registration.py
@@ -24,7 +24,7 @@ class handle_agent_registration:
         machine_repository: IMachineRepository,
         agent_repository: IAgentRepository,
         node_repository: INodeRepository,
-        get_current_datetime: Callable[[], datetime] = datetime.now(),
+        get_current_datetime: Callable[[], datetime] = datetime.now,
     ):
         self._machine_repository = machine_repository
         self._agent_repository = agent_repository

--- a/monkey/monkey_island/cc/models/agent.py
+++ b/monkey/monkey_island/cc/models/agent.py
@@ -18,6 +18,9 @@ class Agent(MutableInfectionMonkeyBaseModel):
     machine_id: MachineID = Field(..., allow_mutation=False)
     """The machine that the agent ran on"""
 
+    registration_time: datetime = Field(..., allow_mutation=False)
+    """The time the agent registered with the island"""
+
     start_time: datetime = Field(..., allow_mutation=False)
     """The time the agent process started"""
 

--- a/monkey/monkey_island/cc/models/agent.py
+++ b/monkey/monkey_island/cc/models/agent.py
@@ -18,7 +18,7 @@ class Agent(MutableInfectionMonkeyBaseModel):
     machine_id: MachineID = Field(..., allow_mutation=False)
     """The machine that the agent ran on"""
 
-    registration_time: datetime = Field(..., allow_mutation=False)
+    registration_time: datetime = Field(allow_mutation=False, default_factory=datetime.now)
     """The time the agent registered with the island"""
 
     start_time: datetime = Field(..., allow_mutation=False)

--- a/monkey/tests/unit_tests/monkey_island/cc/island_event_handlers/test_handle_agent_registration.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/island_event_handlers/test_handle_agent_registration.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from ipaddress import IPv4Address, IPv4Interface
 from itertools import count
 from typing import Sequence
@@ -28,6 +29,7 @@ MACHINE = Machine(
 )
 
 IP = "192.168.1.1:5000"
+NOW = datetime.fromtimestamp(12345)
 
 AGENT_REGISTRATION_DATA = AgentRegistrationData(
     id=AGENT_ID,
@@ -65,7 +67,10 @@ def node_repository() -> INodeRepository:
 
 @pytest.fixture
 def handler(machine_repository, agent_repository, node_repository) -> handle_agent_registration:
-    return handle_agent_registration(machine_repository, agent_repository, node_repository)
+
+    return handle_agent_registration(
+        machine_repository, agent_repository, node_repository, get_current_datetime=lambda: NOW
+    )
 
 
 def build_get_machines_by_ip(ip_to_match: IPv4Address, machine_to_return: Machine):
@@ -161,6 +166,7 @@ def test_add_agent(handler, agent_repository):
     expected_agent = Agent(
         id=AGENT_REGISTRATION_DATA.id,
         machine_id=SEED_ID,
+        registration_time=NOW,
         start_time=AGENT_REGISTRATION_DATA.start_time,
         parent_id=AGENT_REGISTRATION_DATA.parent_id,
         cc_server=AGENT_REGISTRATION_DATA.cc_server,

--- a/monkey/tests/unit_tests/monkey_island/cc/models/test_agent.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/models/test_agent.py
@@ -107,7 +107,7 @@ def test_registration_time_immutable():
     a = Agent(**AGENT_SIMPLE_DICT)
 
     with pytest.raises(TypeError):
-        a.start_time = 100
+        a.registration_time = 100
 
 
 def test_start_time_immutable():

--- a/monkey/tests/unit_tests/monkey_island/cc/models/test_agent.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/models/test_agent.py
@@ -12,6 +12,7 @@ AGENT_OBJECT_DICT = {
     "id": AGENT_ID,
     "machine_id": 2,
     "parent_id": PARENT_ID,
+    "registration_time": datetime.fromtimestamp(1660848410, tz=timezone.utc),
     "start_time": datetime.fromtimestamp(1660848408, tz=timezone.utc),
 }
 
@@ -19,6 +20,7 @@ AGENT_SIMPLE_DICT = {
     "id": str(AGENT_ID),
     "machine_id": 2,
     "parent_id": str(PARENT_ID),
+    "registration_time": "2022-08-18T18:46:50+00:00",
     "start_time": "2022-08-18T18:46:48+00:00",
 }
 
@@ -54,6 +56,7 @@ def test_to_dict():
     [
         ("id", 1),
         ("machine_id", "not-an-int"),
+        ("registration_time", None),
         ("start_time", None),
         ("stop_time", []),
         ("parent_id", 2.1),
@@ -72,6 +75,7 @@ def test_construct_invalid_field__type_error(key, value):
     "key, value",
     [
         ("machine_id", -1),
+        ("registration_time", "not-a-datetime"),
         ("start_time", "not-a-datetime"),
         ("stop_time", "not-a-datetime"),
         ("cc_server", []),
@@ -97,6 +101,13 @@ def test_machine_id_immutable():
 
     with pytest.raises(TypeError):
         a.machine_id = 10
+
+
+def test_registration_time_immutable():
+    a = Agent(**AGENT_SIMPLE_DICT)
+
+    with pytest.raises(TypeError):
+        a.start_time = 100
 
 
 def test_start_time_immutable():

--- a/vulture_allowlist.py
+++ b/vulture_allowlist.py
@@ -20,7 +20,7 @@ from infection_monkey.exploit.zerologon import NetrServerPasswordSet, NetrServer
 from infection_monkey.exploit.zerologon_utils.remote_shell import RemoteShell
 from infection_monkey.transport.http import FileServHTTPRequestHandler
 from monkey_island.cc.deployment import Deployment
-from monkey_island.cc.models import IslandMode, Machine
+from monkey_island.cc.models import Agent, IslandMode, Machine
 from monkey_island.cc.repositories import IAgentEventRepository, MongoAgentEventRepository
 from monkey_island.cc.repositories.utils.hard_coded_credential_collector_schemas import (
     HARD_CODED_CREDENTIAL_COLLECTOR_SCHEMAS,
@@ -140,3 +140,6 @@ HadoopPlugin
 # Remove after #2952
 generate_brute_force_credentials
 secret_type_filter
+
+# Remove after #2817
+Agent.registration_time


### PR DESCRIPTION
# What does this PR do?

Fixes part of #2817.

Adds Agent.registration_time field
Sets registration_time when an agent registers

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by {Running the unit tests}
* [ ] If applicable, add screenshots or log transcripts of the feature working
