### PR TITLE
Island: Disable default flask-security endpoints

### DIFF
--- a/monkey/monkey_island/cc/app.py
+++ b/monkey/monkey_island/cc/app.py
@@ -31,7 +31,15 @@ from monkey_island.cc.resources import (
     ResetAgentConfiguration,
     TerminateAllAgents,
 )
-from monkey_island.cc.resources.auth import Login, Logout, Register, RegistrationStatus
+from monkey_island.cc.resources.auth import (
+    LOGIN_URL,
+    LOGOUT_URL,
+    REGISTER_URL,
+    Login,
+    Logout,
+    Register,
+    RegistrationStatus,
+)
 from monkey_island.cc.resources.exploitations.monkey_exploitation import MonkeyExploitation
 from monkey_island.cc.resources.island_mode import IslandMode
 from monkey_island.cc.resources.local_run import LocalRun
@@ -79,6 +87,9 @@ def setup_authentication(app, data_dir):
     # the discussion https://github.com/guardicore/monkey/pull/3006#discussion_r1116944571
     app.config["SECRET_KEY"] = flask_security_config["secret_key"]
     app.config["SECURITY_PASSWORD_SALT"] = flask_security_config["password_salt"]
+    app.config["SECURITY_LOGIN_URL"] = LOGIN_URL
+    app.config["SECURITY_LOGOUT_URL"] = LOGOUT_URL
+    app.config["SECURITY_REGISTER_URL"] = REGISTER_URL
     app.config["SECURITY_USERNAME_ENABLE"] = True
     app.config["SECURITY_USERNAME_REQUIRED"] = True
     app.config["SECURITY_REGISTERABLE"] = True

--- a/monkey/monkey_island/cc/resources/auth/__init__.py
+++ b/monkey/monkey_island/cc/resources/auth/__init__.py
@@ -1,4 +1,4 @@
-from .login import Login
-from .logout import Logout
+from .login import Login, LOGIN_URL
+from .logout import Logout, LOGOUT_URL
 from .registration_status import RegistrationStatus
-from .register import Register
+from .register import Register, REGISTER_URL

--- a/monkey/monkey_island/cc/resources/auth/login.py
+++ b/monkey/monkey_island/cc/resources/auth/login.py
@@ -12,13 +12,15 @@ from monkey_island.cc.services import AuthenticationService
 
 logger = logging.getLogger(__name__)
 
+LOGIN_URL = "/api/login"
+
 
 class Login(AbstractResource):
     """
     A resource for user authentication
     """
 
-    urls = ["/api/login"]
+    urls = [LOGIN_URL]
 
     def __init__(self, authentication_service: AuthenticationService):
         self._authentication_service = authentication_service

--- a/monkey/monkey_island/cc/resources/auth/logout.py
+++ b/monkey/monkey_island/cc/resources/auth/logout.py
@@ -11,13 +11,15 @@ from monkey_island.cc.services import AuthenticationService
 
 logger = logging.getLogger(__name__)
 
+LOGOUT_URL = "/api/logout"
+
 
 class Logout(AbstractResource):
     """
     A resource logging out an authenticated user
     """
 
-    urls = ["/api/logout"]
+    urls = [LOGOUT_URL]
 
     def __init__(self, authentication_service: AuthenticationService):
         self._authentication_service = authentication_service

--- a/monkey/monkey_island/cc/resources/auth/register.py
+++ b/monkey/monkey_island/cc/resources/auth/register.py
@@ -12,13 +12,15 @@ from monkey_island.cc.services.authentication_service import AuthenticationServi
 
 logger = logging.getLogger(__name__)
 
+REGISTER_URL = "/api/register"
+
 
 class Register(AbstractResource):
     """
     A resource for user registration
     """
 
-    urls = ["/api/register"]
+    urls = [REGISTER_URL]
 
     def __init__(self, authentication_service: AuthenticationService):
         self._authentication_service = authentication_service


### PR DESCRIPTION
# What does this PR do?

Fixes part of #2157.

Disables the default login, logout, and register endpoints provided by flask-security

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by sending cURL commands to the endpoints
* [ ] If applicable, add screenshots or log transcripts of the feature working
