### PR TITLE
2952 config schema

### DIFF
--- a/monkey/agent_plugins/exploiters/smb/config-schema.json
+++ b/monkey/agent_plugins/exploiters/smb/config-schema.json
@@ -11,7 +11,8 @@
             "description": "The timeout (in seconds) for uploading the Agent binary to the target machine.",
             "type": "number",
             "minimum": 0,
-            "default": 30.0
+            "default": 30.0,
+            "maximum": 100.0
         },
         "use_kerberos": {
             "title": "Use Kerberos for authentication",
@@ -25,7 +26,8 @@
             "description": "The maximum time (in seconds) to wait for a response on an SMB connection.",
             "type": "number",
             "minimum": 0,
-            "default": 15.0
+            "default": 15.0,
+            "maximum": 100.0
         }
     }
 }


### PR DESCRIPTION
# What does this PR do?

Fixes part of #2952.

Add config schema for the SMB exploiter plugin.
This depends on #3089 

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Have you successfully tested your changes locally? Elaborate:
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
