### PR TITLE
Simplify authentication HTTP API

### DIFF
--- a/envs/monkey_zoo/blackbox/island_client/monkey_island_requests.py
+++ b/envs/monkey_zoo/blackbox/island_client/monkey_island_requests.py
@@ -27,7 +27,7 @@ class MonkeyIslandRequests:
 
     def get_token_from_server(self):
         resp = requests.post(  # noqa: DUO123
-            self.addr + "api/login?include_auth_token",
+            self.addr + "api/login",
             json={"username": ISLAND_USERNAME, "password": ISLAND_PASSWORD},
             verify=False,
         )
@@ -40,7 +40,7 @@ class MonkeyIslandRequests:
 
     def try_set_island_to_credentials(self):
         resp = requests.post(  # noqa: DUO123
-            self.addr + "api/register?include_auth_token",
+            self.addr + "api/register",
             json={"username": ISLAND_USERNAME, "password": ISLAND_PASSWORD},
             verify=False,
         )

--- a/monkey/monkey_island/cc/services/authentication_service/flask_resources/login.py
+++ b/monkey/monkey_island/cc/services/authentication_service/flask_resources/login.py
@@ -8,7 +8,7 @@ from flask_security.views import login
 from monkey_island.cc.flask_utils import AbstractResource, responses
 
 from ..authentication_facade import AuthenticationFacade
-from .utils import get_username_password_from_request
+from .utils import get_username_password_from_request, include_auth_token
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +23,7 @@ class Login(AbstractResource):
     def __init__(self, authentication_facade: AuthenticationFacade):
         self._authentication_facade = authentication_facade
 
+    @include_auth_token
     def post(self):
         """
         Authenticates a user

--- a/monkey/monkey_island/cc/services/authentication_service/flask_resources/register.py
+++ b/monkey/monkey_island/cc/services/authentication_service/flask_resources/register.py
@@ -8,7 +8,7 @@ from flask_security.views import register
 from monkey_island.cc.flask_utils import AbstractResource, responses
 
 from ..authentication_facade import AuthenticationFacade
-from .utils import get_username_password_from_request
+from .utils import get_username_password_from_request, include_auth_token
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +23,7 @@ class Register(AbstractResource):
     def __init__(self, authentication_facade: AuthenticationFacade):
         self._authentication_facade = authentication_facade
 
+    @include_auth_token
     def post(self):
         """
         Registers a new user using flask security register

--- a/monkey/monkey_island/cc/services/authentication_service/flask_resources/utils.py
+++ b/monkey/monkey_island/cc/services/authentication_service/flask_resources/utils.py
@@ -1,7 +1,9 @@
 import json
+from functools import wraps
 from typing import Tuple
 
 from flask import Request, request
+from werkzeug.datastructures import ImmutableMultiDict
 
 
 def get_username_password_from_request(_request: Request) -> Tuple[str, str]:
@@ -16,3 +18,20 @@ def get_username_password_from_request(_request: Request) -> Tuple[str, str]:
     username = cred_dict.get("username", "")
     password = cred_dict.get("password", "")
     return username, password
+
+
+def include_auth_token(func):
+    """
+    A decorator that ensures that flask-security-too response includes an authentication token
+    """
+
+    @wraps(func)
+    def decorated_function(*args, **kwargs):
+        http_args = request.args.to_dict()
+        http_args["include_auth_token"] = ""
+
+        request.args = ImmutableMultiDict(http_args)
+
+        return func(*args, **kwargs)
+
+    return decorated_function

--- a/monkey/monkey_island/cc/ui/src/services/AuthService.js
+++ b/monkey/monkey_island/cc/ui/src/services/AuthService.js
@@ -12,9 +12,9 @@ export function getErrors(errors) {
 }
 
 export default class AuthService {
-  LOGIN_ENDPOINT = '/api/login?include_auth_token';
+  LOGIN_ENDPOINT = '/api/login';
   LOGOUT_ENDPOINT = '/api/logout';
-  REGISTRATION_API_ENDPOINT = '/api/register?include_auth_token';
+  REGISTRATION_API_ENDPOINT = '/api/register';
   REGISTRATION_STATUS_API_ENDPOINT = '/api/registration-status';
 
   TOKEN_NAME_IN_LOCALSTORAGE = 'authentication_token';


### PR DESCRIPTION
This parameter shouldn't be required as our API doesn't support any other authentication method besides the token

# What does this PR do?

Simplifies the login/register endpoints to not require `?auth_token_required` in the URL

Add any further explanations here.

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [x] Have you successfully tested your changes locally? Elaborate:
    > Tested by registering/logging in manually
* [ ] If applicable, add screenshots or log transcripts of the feature working
