### PR TITLE
Island: Do manual "is user already registered" check

### DIFF
--- a/monkey/monkey_island/cc/services/authentication_service/configure_flask_security.py
+++ b/monkey/monkey_island/cc/services/authentication_service/configure_flask_security.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 from flask.sessions import SecureCookieSessionInterface
 from flask_mongoengine import MongoEngine
 from flask_security import ConfirmRegisterForm, MongoEngineUserDatastore, Security, UserDatastore
-from wtforms import StringField, ValidationError
+from wtforms import StringField
 
 from common.utils.file_utils import open_new_securely_permissioned_file
 from monkey_island.cc.mongo_consts import MONGO_DB_HOST, MONGO_DB_NAME, MONGO_DB_PORT, MONGO_URL
@@ -44,19 +44,12 @@ def setup_authentication(app, data_dir: Path):
 
     _create_roles(user_datastore)
 
-    # Only one user can be registered in the Island, so we need a custom validator
-    def validate_no_user_exists_already(_, field):
-        if user_datastore.find_user():
-            raise ValidationError("A user already exists. Only a single user can be registered.")
-
     class CustomConfirmRegisterForm(ConfirmRegisterForm):
         # We don't use the email, but the field is required by ConfirmRegisterForm.
         # Email validators need to be overriden, otherwise an error about invalid email is raised.
         # Added custom validator to the email field because we have to override
         # email validators anyway.
-        email = StringField(
-            "Email", default="dummy@dummy.com", validators=[validate_no_user_exists_already]
-        )
+        email = StringField("Email", default="dummy@dummy.com", validators=[])
 
         def to_dict(self, only_user):
             registration_dict = super().to_dict(only_user)

--- a/monkey/monkey_island/cc/services/authentication_service/flask_resources/register.py
+++ b/monkey/monkey_island/cc/services/authentication_service/flask_resources/register.py
@@ -30,6 +30,10 @@ class Register(AbstractResource):
 
         """
         try:
+            if not self._authentication_facade.needs_registration():
+                return {
+                    "errors": ["A user already exists. Only a single user can be registered."]
+                }, HTTPStatus.CONFLICT
             username, password = get_username_password_from_request(request)
             response: ResponseValue = register()
         except Exception:

--- a/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/flask_resources/test_register.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/flask_resources/test_register.py
@@ -36,6 +36,17 @@ def test_register_failed(
     assert response.status_code == HTTPStatus.BAD_REQUEST
 
 
+def test_register__already_registered(
+    monkeypatch, make_registration_request, mock_authentication_facade: AuthenticationFacade
+):
+    mock_authentication_facade.needs_registration.return_value = False
+
+    response = make_registration_request("{}")
+
+    assert response.status_code == HTTPStatus.CONFLICT
+    assert response.json["errors"]
+
+
 def test_register_successful(
     monkeypatch, make_registration_request, mock_authentication_facade: AuthenticationFacade
 ):


### PR DESCRIPTION
This check is moved from a validator, because flask-security-too ignores email validators if generic responses are enabled

Add any further explanations here.

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
