### PR TITLE
UT: Fix AWS unit tests

### DIFF
--- a/monkey/tests/unit_tests/monkey_island/cc/services/aws/test_aws_command_runner.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/aws/test_aws_command_runner.py
@@ -11,7 +11,7 @@ from monkey_island.cc.services.aws.aws_command_runner import (
     start_infection_monkey_agent,
 )
 
-TIMEOUT = 0.03
+TIMEOUT = 0.1
 INSTANCE_ID = "BEEFFACE"
 ISLAND_IP = "127.0.0.1"
 


### PR DESCRIPTION
Issue: #3096

Sleep precision depends on the OS, that's why we can't reproduce locally. Based on the logic, the increase in timeout should fix it. The bigger the timeout, the more requests will be made. The timeout size is irrelevant for the failing test as long as it's long enough for the client to send at least 3 requests (the responses are mocked, so the third response will be a success). 

Add any further explanations here.

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [x] Any other testing performed?
    > Tested by running travis
* [ ] If applicable, add screenshots or log transcripts of the feature working
