### PR TITLE
SMB: Check for SMB ports before running exploiter

### DIFF
--- a/monkey/agent_plugins/exploiters/smb/src/plugin.py
+++ b/monkey/agent_plugins/exploiters/smb/src/plugin.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 # common imports
 from common.event_queue import IAgentEventPublisher
-from common.types import Event
+from common.types import Event, PortStatus
 from common.utils.code_utils import del_key
 
 # dependencies to get rid of or internalize
@@ -17,12 +17,18 @@ from infection_monkey.exploit.tools import (
     generate_brute_force_credentials,
 )
 from infection_monkey.exploit.tools.helpers import get_agent_dst_path
-from infection_monkey.i_puppet import ExploiterResultData, TargetHost
+from infection_monkey.i_puppet import ExploiterResultData, PortScanData, TargetHost
 from infection_monkey.propagation_credentials_repository import IPropagationCredentialsRepository
 
 from .smb_command_builder import build_smb_command
 from .smb_options import SMBOptions
+from .smb_remote_access_client import SMB_PORTS
 from .smb_remote_access_client_factory import SMBRemoteAccessClientFactory
+
+
+def is_open_port(psd: PortScanData) -> bool:
+    return psd.status != PortStatus.CLOSED
+
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +71,11 @@ class Plugin:
         except Exception as err:
             msg = f"Failed to parse SMB options: {err}"
             logger.exception(msg)
+            return ExploiterResultData(error_message=msg)
+
+        if len(host.filter_selected_tcp_ports(SMB_PORTS, is_open_port)) == 0:
+            msg = f"Host {host.ip} has no open SMB ports"
+            logger.debug(msg)
             return ExploiterResultData(error_message=msg)
 
         command_builder = partial(

--- a/monkey/agent_plugins/exploiters/smb/src/plugin.py
+++ b/monkey/agent_plugins/exploiters/smb/src/plugin.py
@@ -27,7 +27,7 @@ from .smb_remote_access_client_factory import SMBRemoteAccessClientFactory
 
 
 def should_attempt_exploit(host: TargetHost) -> bool:
-    closed_tcp_ports = host.ports_status.closed_tcp_ports
+    closed_tcp_ports = host.ports_status.tcp_ports.closed
     return not all([p in closed_tcp_ports for p in SMB_PORTS])
 
 

--- a/monkey/agent_plugins/exploiters/smb/src/plugin.py
+++ b/monkey/agent_plugins/exploiters/smb/src/plugin.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 # common imports
 from common.event_queue import IAgentEventPublisher
-from common.types import Event, PortStatus
+from common.types import Event
 from common.utils.code_utils import del_key
 
 # dependencies to get rid of or internalize
@@ -27,14 +27,8 @@ from .smb_remote_access_client_factory import SMBRemoteAccessClientFactory
 
 
 def should_attempt_exploit(host: TargetHost) -> bool:
-    for smb_port in SMB_PORTS:
-        if smb_port not in host.ports_status.tcp_ports:
-            return True
-
-        if host.ports_status.tcp_ports[smb_port].status == PortStatus.OPEN:
-            return True
-
-    return False
+    closed_tcp_ports = host.ports_status.closed_tcp_ports
+    return not all([p in closed_tcp_ports for p in SMB_PORTS])
 
 
 logger = logging.getLogger(__name__)

--- a/monkey/agent_plugins/exploiters/smb/src/plugin.py
+++ b/monkey/agent_plugins/exploiters/smb/src/plugin.py
@@ -17,7 +17,7 @@ from infection_monkey.exploit.tools import (
     generate_brute_force_credentials,
 )
 from infection_monkey.exploit.tools.helpers import get_agent_dst_path
-from infection_monkey.i_puppet import ExploiterResultData, PortScanData, TargetHost
+from infection_monkey.i_puppet import ExploiterResultData, TargetHost
 from infection_monkey.propagation_credentials_repository import IPropagationCredentialsRepository
 
 from .smb_command_builder import build_smb_command
@@ -26,8 +26,15 @@ from .smb_remote_access_client import SMB_PORTS
 from .smb_remote_access_client_factory import SMBRemoteAccessClientFactory
 
 
-def is_open_port(psd: PortScanData) -> bool:
-    return psd.status != PortStatus.CLOSED
+def should_attempt_exploit(host: TargetHost) -> bool:
+    for smb_port in SMB_PORTS:
+        if smb_port not in host.ports_status.tcp_ports:
+            return True
+
+        if host.ports_status.tcp_ports[smb_port].status == PortStatus.OPEN:
+            return True
+
+    return False
 
 
 logger = logging.getLogger(__name__)
@@ -73,10 +80,12 @@ class Plugin:
             logger.exception(msg)
             return ExploiterResultData(error_message=msg)
 
-        if len(host.filter_selected_tcp_ports(SMB_PORTS, is_open_port)) == 0:
+        if not should_attempt_exploit(host):
             msg = f"Host {host.ip} has no open SMB ports"
             logger.debug(msg)
-            return ExploiterResultData(error_message=msg)
+            return ExploiterResultData(
+                exploitation_success=False, propagation_success=False, error_message=msg
+            )
 
         command_builder = partial(
             build_smb_command,

--- a/monkey/infection_monkey/i_puppet/__init__.py
+++ b/monkey/infection_monkey/i_puppet/__init__.py
@@ -10,4 +10,4 @@ from .i_puppet import (
 )
 from .i_fingerprinter import IFingerprinter
 from .i_credential_collector import ICredentialCollector
-from .target_host import TargetHost, TargetHostPorts
+from .target_host import TargetHost, TargetHostPorts, PortScanDataDict

--- a/monkey/infection_monkey/i_puppet/i_puppet.py
+++ b/monkey/infection_monkey/i_puppet/i_puppet.py
@@ -4,9 +4,9 @@ from typing import Dict, Mapping, Sequence
 from common.agent_plugins import AgentPluginType
 from common.credentials import Credentials
 from common.types import Event, NetworkPort
-from infection_monkey.i_puppet.target_host import TargetHost
 
-from . import ExploiterResultData, FingerprintData, PingScanData, PortScanData
+from . import ExploiterResultData, FingerprintData, PingScanData
+from .target_host import PortScanDataDict, TargetHost
 
 
 class UnknownPluginError(Exception):
@@ -58,7 +58,7 @@ class IPuppet(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def scan_tcp_ports(
         self, host: str, ports: Sequence[NetworkPort], timeout: float = 3
-    ) -> Dict[NetworkPort, PortScanData]:
+    ) -> PortScanDataDict:
         """
         Scans a list of TCP ports on a remote host
 
@@ -74,7 +74,7 @@ class IPuppet(metaclass=abc.ABCMeta):
         name: str,
         host: str,
         ping_scan_data: PingScanData,
-        port_scan_data: Dict[NetworkPort, PortScanData],
+        port_scan_data: PortScanDataDict,
         options: Dict,
     ) -> FingerprintData:
         """

--- a/monkey/infection_monkey/i_puppet/target_host.py
+++ b/monkey/infection_monkey/i_puppet/target_host.py
@@ -1,6 +1,6 @@
 import pprint
 from ipaddress import IPv4Address
-from typing import Dict, Optional
+from typing import Callable, Dict, Optional, Sequence
 
 from pydantic import Field
 
@@ -9,6 +9,8 @@ from common.base_models import MutableInfectionMonkeyBaseModel
 from common.types import NetworkPort
 
 from . import PortScanData
+
+FilterPortFunc = Callable[[PortScanData], bool]
 
 
 class TargetHostPorts(MutableInfectionMonkeyBaseModel):
@@ -21,6 +23,15 @@ class TargetHost(MutableInfectionMonkeyBaseModel):
     operating_system: Optional[OperatingSystem] = Field(default=None)
     icmp: bool = Field(default=False)
     ports_status: TargetHostPorts = Field(default=TargetHostPorts())
+
+    def filter_selected_tcp_ports(
+        self, ports: Sequence[NetworkPort], filter: FilterPortFunc
+    ) -> Sequence[PortScanData]:
+        return [
+            p
+            for p in ports
+            if p in self.ports_status.tcp_ports and filter(self.ports_status.tcp_ports[p])
+        ]
 
     def __hash__(self):
         return hash(self.ip)

--- a/monkey/infection_monkey/i_puppet/target_host.py
+++ b/monkey/infection_monkey/i_puppet/target_host.py
@@ -1,12 +1,12 @@
 import pprint
 from collections import UserDict
 from ipaddress import IPv4Address
-from typing import Dict, Optional, Set
+from typing import Optional, Set
 
 from pydantic import Field, validate_arguments
 
 from common import OperatingSystem
-from common.base_models import MutableInfectionMonkeyBaseModel
+from common.base_models import MutableInfectionMonkeyBaseModel, MutableInfectionMonkeyModelConfig
 from common.types import NetworkPort, PortStatus
 
 from . import PortScanData
@@ -19,8 +19,11 @@ class PortScanDataDict(UserDict[NetworkPort, PortScanData]):
 
 
 class TargetHostPorts(MutableInfectionMonkeyBaseModel):
-    tcp_ports: Dict[NetworkPort, PortScanData] = Field(default={})
-    udp_ports: Dict[NetworkPort, PortScanData] = Field(default={})
+    class Config(MutableInfectionMonkeyModelConfig):
+        arbitrary_types_allowed = True
+
+    tcp_ports: PortScanDataDict = Field(default_factory=PortScanDataDict)
+    udp_ports: PortScanDataDict = Field(default_factory=PortScanDataDict)
 
     @property
     def closed_tcp_ports(self) -> Set[NetworkPort]:
@@ -32,6 +35,9 @@ class TargetHostPorts(MutableInfectionMonkeyBaseModel):
 
 
 class TargetHost(MutableInfectionMonkeyBaseModel):
+    class Config(MutableInfectionMonkeyModelConfig):
+        json_encoders = {PortScanDataDict: dict}
+
     ip: IPv4Address
     operating_system: Optional[OperatingSystem] = Field(default=None)
     icmp: bool = Field(default=False)

--- a/monkey/infection_monkey/i_puppet/target_host.py
+++ b/monkey/infection_monkey/i_puppet/target_host.py
@@ -1,14 +1,21 @@
 import pprint
+from collections import UserDict
 from ipaddress import IPv4Address
 from typing import Dict, Optional, Set
 
-from pydantic import Field
+from pydantic import Field, validate_arguments
 
 from common import OperatingSystem
 from common.base_models import MutableInfectionMonkeyBaseModel
 from common.types import NetworkPort, PortStatus
 
 from . import PortScanData
+
+
+class PortScanDataDict(UserDict[NetworkPort, PortScanData]):
+    @validate_arguments
+    def __setitem__(self, key: NetworkPort, value: PortScanData):
+        super().__setitem__(key, value)
 
 
 class TargetHostPorts(MutableInfectionMonkeyBaseModel):

--- a/monkey/infection_monkey/i_puppet/target_host.py
+++ b/monkey/infection_monkey/i_puppet/target_host.py
@@ -17,6 +17,14 @@ class PortScanDataDict(UserDict[NetworkPort, PortScanData]):
     def __setitem__(self, key: NetworkPort, value: PortScanData):
         super().__setitem__(key, value)
 
+    @property
+    def closed(self) -> Set[NetworkPort]:
+        return {
+            port
+            for port, port_scan_data in self.data.items()
+            if port_scan_data.status == PortStatus.CLOSED
+        }
+
 
 class TargetHostPorts(MutableInfectionMonkeyBaseModel):
     class Config(MutableInfectionMonkeyModelConfig):

--- a/monkey/infection_monkey/i_puppet/target_host.py
+++ b/monkey/infection_monkey/i_puppet/target_host.py
@@ -1,6 +1,6 @@
 import pprint
 from ipaddress import IPv4Address
-from typing import Callable, Dict, Optional, Sequence
+from typing import Dict, Optional
 
 from pydantic import Field
 
@@ -9,8 +9,6 @@ from common.base_models import MutableInfectionMonkeyBaseModel
 from common.types import NetworkPort
 
 from . import PortScanData
-
-FilterPortFunc = Callable[[PortScanData], bool]
 
 
 class TargetHostPorts(MutableInfectionMonkeyBaseModel):
@@ -23,15 +21,6 @@ class TargetHost(MutableInfectionMonkeyBaseModel):
     operating_system: Optional[OperatingSystem] = Field(default=None)
     icmp: bool = Field(default=False)
     ports_status: TargetHostPorts = Field(default=TargetHostPorts())
-
-    def filter_selected_tcp_ports(
-        self, ports: Sequence[NetworkPort], filter: FilterPortFunc
-    ) -> Sequence[PortScanData]:
-        return [
-            p
-            for p in ports
-            if p in self.ports_status.tcp_ports and filter(self.ports_status.tcp_ports[p])
-        ]
 
     def __hash__(self):
         return hash(self.ip)

--- a/monkey/infection_monkey/i_puppet/target_host.py
+++ b/monkey/infection_monkey/i_puppet/target_host.py
@@ -1,12 +1,12 @@
 import pprint
 from ipaddress import IPv4Address
-from typing import Dict, Optional
+from typing import Dict, Optional, Set
 
 from pydantic import Field
 
 from common import OperatingSystem
 from common.base_models import MutableInfectionMonkeyBaseModel
-from common.types import NetworkPort
+from common.types import NetworkPort, PortStatus
 
 from . import PortScanData
 
@@ -14,6 +14,14 @@ from . import PortScanData
 class TargetHostPorts(MutableInfectionMonkeyBaseModel):
     tcp_ports: Dict[NetworkPort, PortScanData] = Field(default={})
     udp_ports: Dict[NetworkPort, PortScanData] = Field(default={})
+
+    @property
+    def closed_tcp_ports(self) -> Set[NetworkPort]:
+        return {
+            port
+            for port, port_scan_data in self.tcp_ports.items()
+            if port_scan_data.status == PortStatus.CLOSED
+        }
 
 
 class TargetHost(MutableInfectionMonkeyBaseModel):

--- a/monkey/infection_monkey/i_puppet/target_host.py
+++ b/monkey/infection_monkey/i_puppet/target_host.py
@@ -33,14 +33,6 @@ class TargetHostPorts(MutableInfectionMonkeyBaseModel):
     tcp_ports: PortScanDataDict = Field(default_factory=PortScanDataDict)
     udp_ports: PortScanDataDict = Field(default_factory=PortScanDataDict)
 
-    @property
-    def closed_tcp_ports(self) -> Set[NetworkPort]:
-        return {
-            port
-            for port, port_scan_data in self.tcp_ports.items()
-            if port_scan_data.status == PortStatus.CLOSED
-        }
-
 
 class TargetHost(MutableInfectionMonkeyBaseModel):
     class Config(MutableInfectionMonkeyModelConfig):

--- a/monkey/infection_monkey/master/ip_scan_results.py
+++ b/monkey/infection_monkey/master/ip_scan_results.py
@@ -1,8 +1,7 @@
 from dataclasses import dataclass
 from typing import Dict
 
-from common.types import NetworkPort
-from infection_monkey.i_puppet import FingerprintData, PingScanData, PortScanData
+from infection_monkey.i_puppet import FingerprintData, PingScanData, PortScanDataDict
 
 FingerprinterName = str
 
@@ -10,5 +9,5 @@ FingerprinterName = str
 @dataclass
 class IPScanResults:
     ping_scan_data: PingScanData
-    port_scan_data: Dict[NetworkPort, PortScanData]
+    port_scan_data: PortScanDataDict
     fingerprint_data: Dict[FingerprinterName, FingerprintData]

--- a/monkey/infection_monkey/master/ip_scanner.py
+++ b/monkey/infection_monkey/master/ip_scanner.py
@@ -8,8 +8,8 @@ from common.agent_configuration.agent_sub_configurations import (
     NetworkScanConfiguration,
     PluginConfiguration,
 )
-from common.types import Event, NetworkPort, PortStatus
-from infection_monkey.i_puppet import FingerprintData, IPuppet, PingScanData, PortScanData
+from common.types import Event, PortStatus
+from infection_monkey.i_puppet import FingerprintData, IPuppet, PingScanData, PortScanDataDict
 from infection_monkey.network import NetworkAddress
 from infection_monkey.utils.threading import interruptible_iter, run_worker_threads
 
@@ -86,7 +86,7 @@ class IPScanner:
             )
 
     @staticmethod
-    def port_scan_found_open_port(port_scan_data: Dict[NetworkPort, PortScanData]):
+    def port_scan_found_open_port(port_scan_data: PortScanDataDict):
         return any(psd.status == PortStatus.OPEN for psd in port_scan_data.values())
 
     def _run_fingerprinters(
@@ -94,7 +94,7 @@ class IPScanner:
         ip: str,
         fingerprinters: Sequence[PluginConfiguration],
         ping_scan_data: PingScanData,
-        port_scan_data: Dict[NetworkPort, PortScanData],
+        port_scan_data: PortScanDataDict,
         stop: Event,
     ) -> Dict[str, FingerprintData]:
         fingerprint_data = {}

--- a/monkey/infection_monkey/puppet/puppet.py
+++ b/monkey/infection_monkey/puppet/puppet.py
@@ -13,7 +13,7 @@ from infection_monkey.i_puppet import (
     IncompatibleOperatingSystemError,
     IPuppet,
     PingScanData,
-    PortScanData,
+    PortScanDataDict,
     TargetHost,
 )
 from infection_monkey.puppet import PluginCompatabilityVerifier
@@ -50,7 +50,7 @@ class Puppet(IPuppet):
 
     def scan_tcp_ports(
         self, host: str, ports: Sequence[NetworkPort], timeout: float = CONNECTION_TIMEOUT
-    ) -> Dict[NetworkPort, PortScanData]:
+    ) -> PortScanDataDict:
         return network_scanning.scan_tcp_ports(host, ports, timeout, self._agent_event_queue)
 
     def fingerprint(
@@ -58,7 +58,7 @@ class Puppet(IPuppet):
         name: str,
         host: str,
         ping_scan_data: PingScanData,
-        port_scan_data: Dict[NetworkPort, PortScanData],
+        port_scan_data: PortScanDataDict,
         options: Dict,
     ) -> FingerprintData:
         try:

--- a/monkey/tests/unit_tests/agent_plugins/exploiters/hadoop/test_hadoop_exploiter.py
+++ b/monkey/tests/unit_tests/agent_plugins/exploiters/hadoop/test_hadoop_exploiter.py
@@ -11,7 +11,13 @@ from agent_plugins.exploiters.hadoop.src.hadoop_options import HadoopOptions
 from common import OperatingSystem
 from common.types import NetworkPort, NetworkProtocol, NetworkService, PortStatus
 from infection_monkey.exploit.tools import HTTPBytesServer
-from infection_monkey.i_puppet import ExploiterResultData, PortScanData, TargetHost, TargetHostPorts
+from infection_monkey.i_puppet import (
+    ExploiterResultData,
+    PortScanData,
+    PortScanDataDict,
+    TargetHost,
+    TargetHostPorts,
+)
 
 TARGET_IP = IPv4Address("1.1.1.1")
 SERVERS = ["10.10.10.10"]
@@ -187,11 +193,13 @@ def test_exploit_attempt_on_all_discovered_open_http_ports(
         ip=IPv4Address("1.1.1.1"),
         operating_system=OperatingSystem.WINDOWS,
         ports_status=TargetHostPorts(
-            tcp_ports={
-                HTTP_PORT: HTTP_PORT_DATA,
-                CLOSED_PORT: CLOSED_PORT_DATA,
-                HTTPS_PORT: HTTPS_PORT_DATA,
-            }
+            tcp_ports=PortScanDataDict(
+                {
+                    HTTP_PORT: HTTP_PORT_DATA,
+                    CLOSED_PORT: CLOSED_PORT_DATA,
+                    HTTPS_PORT: HTTPS_PORT_DATA,
+                }
+            )
         ),
     )
     hadoop_exploiter.exploit_host(
@@ -219,7 +227,9 @@ def test_exploit_attempt_skips_configured_ports_if_closed(
     target_host = TargetHost(
         ip=IPv4Address("1.1.1.1"),
         operating_system=OperatingSystem.WINDOWS,
-        ports_status=TargetHostPorts(tcp_ports={CLOSED_PORT_80: CLOSED_PORT_80_DATA}),
+        ports_status=TargetHostPorts(
+            tcp_ports=PortScanDataDict({CLOSED_PORT_80: CLOSED_PORT_80_DATA})
+        ),
     )
     hadoop_exploiter.exploit_host(
         target_host=target_host,

--- a/monkey/tests/unit_tests/agent_plugins/exploiters/smb/test_smb_plugin.py
+++ b/monkey/tests/unit_tests/agent_plugins/exploiters/smb/test_smb_plugin.py
@@ -7,14 +7,24 @@ import pytest
 from agent_plugins.exploiters.smb.src.plugin import Plugin
 
 from common import OperatingSystem
+from common.types import NetworkPort, PortStatus
 from infection_monkey.exploit.tools import BruteForceExploiter
-from infection_monkey.i_puppet import ExploiterResultData, TargetHost
+from infection_monkey.i_puppet import ExploiterResultData, PortScanData, TargetHost, TargetHostPorts
 from infection_monkey.propagation_credentials_repository import IPropagationCredentialsRepository
 
 AGENT_ID = UUID("5c145d4e-ec61-44f7-998e-17477112f50f")
 BAD_SMB_OPTIONS_DICT = {"blah": "blah"}
 TARGET_IP = IPv4Address("1.1.1.1")
-TARGET_HOST = TargetHost(ip=TARGET_IP, operating_system=OperatingSystem.WINDOWS)
+SMB_PORT = NetworkPort(139)
+OPEN_SMB_PORTS = TargetHostPorts(
+    tcp_ports={SMB_PORT: PortScanData(port=SMB_PORT, status=PortStatus.OPEN)}
+)
+CLOSED_SMB_PORTS = TargetHostPorts()
+TARGET_HOST = TargetHost(
+    ip=TARGET_IP,
+    operating_system=OperatingSystem.WINDOWS,
+    ports_status=OPEN_SMB_PORTS,
+)
 SERVERS = ["10.10.10.10"]
 EXPLOITER_RESULT_DATA = ExploiterResultData(True, False, error_message="Test error")
 
@@ -68,6 +78,38 @@ def test_run__fails_on_bad_options(plugin: Plugin):
 
     assert not result.exploitation_success
     assert not result.propagation_success
+
+
+def test_run__fails_if_no_open_smb_ports(plugin: Plugin):
+    host = TARGET_HOST.copy(deep=True)
+    host.ports_status = CLOSED_SMB_PORTS
+    result = plugin.run(
+        host=host,
+        servers=SERVERS,
+        current_depth=1,
+        options={},
+        interrupt=Event(),
+    )
+
+    assert not result.exploitation_success
+    assert not result.propagation_success
+
+
+@pytest.mark.parametrize("port", [NetworkPort(445), NetworkPort(139)])
+def test_run__proceeds_if_open_smb_ports(plugin: Plugin, port: NetworkPort):
+    host = TARGET_HOST.copy(deep=True)
+    host.ports_status = TargetHostPorts(
+        tcp_ports={port: PortScanData(port=port, status=PortStatus.OPEN)}
+    )
+    result = plugin.run(
+        host=host,
+        servers=SERVERS,
+        current_depth=1,
+        options={},
+        interrupt=Event(),
+    )
+
+    assert result == EXPLOITER_RESULT_DATA
 
 
 def test_run__returns_exploiter_result_data(plugin: Plugin):

--- a/monkey/tests/unit_tests/agent_plugins/exploiters/smb/test_smb_plugin.py
+++ b/monkey/tests/unit_tests/agent_plugins/exploiters/smb/test_smb_plugin.py
@@ -1,6 +1,5 @@
 from ipaddress import IPv4Address
 from threading import Event
-from typing import Dict
 from unittest.mock import MagicMock
 from uuid import UUID
 
@@ -8,16 +7,22 @@ import pytest
 from agent_plugins.exploiters.smb.src.plugin import SMB_PORTS, Plugin
 
 from common import OperatingSystem
-from common.types import NetworkPort, PortStatus
+from common.types import PortStatus
 from infection_monkey.exploit.tools import BruteForceExploiter
-from infection_monkey.i_puppet import ExploiterResultData, PortScanData, TargetHost, TargetHostPorts
+from infection_monkey.i_puppet import (
+    ExploiterResultData,
+    PortScanData,
+    PortScanDataDict,
+    TargetHost,
+    TargetHostPorts,
+)
 from infection_monkey.propagation_credentials_repository import IPropagationCredentialsRepository
 
 AGENT_ID = UUID("5c145d4e-ec61-44f7-998e-17477112f50f")
 BAD_SMB_OPTIONS_DICT = {"blah": "blah"}
 TARGET_IP = IPv4Address("1.1.1.1")
 OPEN_SMB_PORTS = TargetHostPorts(
-    tcp_ports={p: PortScanData(port=p, status=PortStatus.OPEN) for p in SMB_PORTS}
+    tcp_ports=PortScanDataDict({p: PortScanData(port=p, status=PortStatus.OPEN) for p in SMB_PORTS})
 )
 EMPTY_TARGET_HOST_PORTS = TargetHostPorts()
 SERVERS = ["10.10.10.10"]
@@ -89,16 +94,16 @@ def test_run__fails_on_bad_options(plugin: Plugin, target_host: TargetHost):
 @pytest.mark.parametrize(
     "tcp_port_status",
     (
-        {SMB_PORTS[0]: PortScanData(port=SMB_PORTS[0], status=PortStatus.CLOSED)},
-        {SMB_PORTS[1]: PortScanData(port=SMB_PORTS[1], status=PortStatus.CLOSED)},
-        {},
+        PortScanDataDict({SMB_PORTS[0]: PortScanData(port=SMB_PORTS[0], status=PortStatus.CLOSED)}),
+        PortScanDataDict({SMB_PORTS[1]: PortScanData(port=SMB_PORTS[1], status=PortStatus.CLOSED)}),
+        PortScanDataDict({}),
     ),
 )
 def test_run__attempts_exploit_if_port_status_unknown(
     plugin: Plugin,
     mock_smb_exploiter: BruteForceExploiter,
     target_host: TargetHost,
-    tcp_port_status: Dict[NetworkPort, PortScanData],
+    tcp_port_status: PortScanDataDict,
 ):
     host = target_host
     host.ports_status.tcp_ports = tcp_port_status
@@ -117,27 +122,33 @@ def test_run__attempts_exploit_if_port_status_unknown(
 @pytest.mark.parametrize(
     "tcp_port_status",
     (
-        {SMB_PORTS[0]: PortScanData(port=SMB_PORTS[0], status=PortStatus.OPEN)},
-        {SMB_PORTS[1]: PortScanData(port=SMB_PORTS[1], status=PortStatus.OPEN)},
-        {
-            SMB_PORTS[0]: PortScanData(port=SMB_PORTS[0], status=PortStatus.CLOSED),
-            SMB_PORTS[1]: PortScanData(port=SMB_PORTS[1], status=PortStatus.OPEN),
-        },
-        {
-            SMB_PORTS[0]: PortScanData(port=SMB_PORTS[0], status=PortStatus.OPEN),
-            SMB_PORTS[1]: PortScanData(port=SMB_PORTS[1], status=PortStatus.CLOSED),
-        },
-        {
-            SMB_PORTS[0]: PortScanData(port=SMB_PORTS[0], status=PortStatus.OPEN),
-            SMB_PORTS[1]: PortScanData(port=SMB_PORTS[1], status=PortStatus.OPEN),
-        },
+        PortScanDataDict({SMB_PORTS[0]: PortScanData(port=SMB_PORTS[0], status=PortStatus.OPEN)}),
+        PortScanDataDict({SMB_PORTS[1]: PortScanData(port=SMB_PORTS[1], status=PortStatus.OPEN)}),
+        PortScanDataDict(
+            {
+                SMB_PORTS[0]: PortScanData(port=SMB_PORTS[0], status=PortStatus.CLOSED),
+                SMB_PORTS[1]: PortScanData(port=SMB_PORTS[1], status=PortStatus.OPEN),
+            }
+        ),
+        PortScanDataDict(
+            {
+                SMB_PORTS[0]: PortScanData(port=SMB_PORTS[0], status=PortStatus.OPEN),
+                SMB_PORTS[1]: PortScanData(port=SMB_PORTS[1], status=PortStatus.CLOSED),
+            }
+        ),
+        PortScanDataDict(
+            {
+                SMB_PORTS[0]: PortScanData(port=SMB_PORTS[0], status=PortStatus.OPEN),
+                SMB_PORTS[1]: PortScanData(port=SMB_PORTS[1], status=PortStatus.OPEN),
+            }
+        ),
     ),
 )
 def test_run__attempts_exploit_if_port_status_open(
     plugin: Plugin,
     mock_smb_exploiter: BruteForceExploiter,
     target_host: TargetHost,
-    tcp_port_status: Dict[NetworkPort, PortScanData],
+    tcp_port_status: PortScanDataDict,
 ):
     host = target_host
     host.ports_status.tcp_ports = tcp_port_status
@@ -159,10 +170,12 @@ def test_run__skips_exploit_if_port_status_closed(
     target_host: TargetHost,
 ):
     host = target_host
-    host.ports_status.tcp_ports = {
-        SMB_PORTS[0]: PortScanData(port=SMB_PORTS[0], status=PortStatus.CLOSED),
-        SMB_PORTS[1]: PortScanData(port=SMB_PORTS[1], status=PortStatus.CLOSED),
-    }
+    host.ports_status.tcp_ports = PortScanDataDict(
+        {
+            SMB_PORTS[0]: PortScanData(port=SMB_PORTS[0], status=PortStatus.CLOSED),
+            SMB_PORTS[1]: PortScanData(port=SMB_PORTS[1], status=PortStatus.CLOSED),
+        }
+    )
 
     result = plugin.run(
         host=host,

--- a/monkey/tests/unit_tests/agent_plugins/exploiters/smb/test_smb_plugin.py
+++ b/monkey/tests/unit_tests/agent_plugins/exploiters/smb/test_smb_plugin.py
@@ -1,10 +1,11 @@
 from ipaddress import IPv4Address
 from threading import Event
+from typing import Dict
 from unittest.mock import MagicMock
 from uuid import UUID
 
 import pytest
-from agent_plugins.exploiters.smb.src.plugin import Plugin
+from agent_plugins.exploiters.smb.src.plugin import SMB_PORTS, Plugin
 
 from common import OperatingSystem
 from common.types import NetworkPort, PortStatus
@@ -15,31 +16,26 @@ from infection_monkey.propagation_credentials_repository import IPropagationCred
 AGENT_ID = UUID("5c145d4e-ec61-44f7-998e-17477112f50f")
 BAD_SMB_OPTIONS_DICT = {"blah": "blah"}
 TARGET_IP = IPv4Address("1.1.1.1")
-SMB_PORT = NetworkPort(139)
 OPEN_SMB_PORTS = TargetHostPorts(
-    tcp_ports={SMB_PORT: PortScanData(port=SMB_PORT, status=PortStatus.OPEN)}
+    tcp_ports={p: PortScanData(port=p, status=PortStatus.OPEN) for p in SMB_PORTS}
 )
-CLOSED_SMB_PORTS = TargetHostPorts()
-TARGET_HOST = TargetHost(
-    ip=TARGET_IP,
-    operating_system=OperatingSystem.WINDOWS,
-    ports_status=OPEN_SMB_PORTS,
-)
+EMPTY_TARGET_HOST_PORTS = TargetHostPorts()
 SERVERS = ["10.10.10.10"]
 EXPLOITER_RESULT_DATA = ExploiterResultData(True, False, error_message="Test error")
 
 
 @pytest.fixture
+def target_host() -> TargetHost:
+    return TargetHost(
+        ip=TARGET_IP,
+        operating_system=OperatingSystem.WINDOWS,
+        ports_status=OPEN_SMB_PORTS,
+    )
+
+
+@pytest.fixture
 def propagation_credentials_repository():
     return MagicMock(spec=IPropagationCredentialsRepository)
-
-
-class MockSMBExploiter(BruteForceExploiter):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def exploit_host(self, *args, **kwargs) -> ExploiterResultData:
-        return EXPLOITER_RESULT_DATA
 
 
 class ErrorRaisingMockSMBExploiter(BruteForceExploiter):
@@ -51,11 +47,21 @@ class ErrorRaisingMockSMBExploiter(BruteForceExploiter):
 
 
 @pytest.fixture
+def mock_smb_exploiter():
+    exploiter = MagicMock(spec=BruteForceExploiter)
+    exploiter.exploit_host.return_value = EXPLOITER_RESULT_DATA
+    return exploiter
+
+
+@pytest.fixture
 def plugin(
-    monkeypatch, propagation_credentials_repository: IPropagationCredentialsRepository
+    monkeypatch,
+    propagation_credentials_repository: IPropagationCredentialsRepository,
+    mock_smb_exploiter: BruteForceExploiter,
 ) -> Plugin:
     monkeypatch.setattr(
-        "agent_plugins.exploiters.smb.src.plugin.BruteForceExploiter", MockSMBExploiter
+        "agent_plugins.exploiters.smb.src.plugin.BruteForceExploiter",
+        lambda *args, **kwargs: mock_smb_exploiter,
     )
 
     return Plugin(
@@ -67,9 +73,9 @@ def plugin(
     )
 
 
-def test_run__fails_on_bad_options(plugin: Plugin):
+def test_run__fails_on_bad_options(plugin: Plugin, target_host: TargetHost):
     result = plugin.run(
-        host=TARGET_HOST,
+        host=target_host,
         servers=SERVERS,
         current_depth=1,
         options=BAD_SMB_OPTIONS_DICT,
@@ -80,9 +86,22 @@ def test_run__fails_on_bad_options(plugin: Plugin):
     assert not result.propagation_success
 
 
-def test_run__fails_if_no_open_smb_ports(plugin: Plugin):
-    host = TARGET_HOST.copy(deep=True)
-    host.ports_status = CLOSED_SMB_PORTS
+@pytest.mark.parametrize(
+    "tcp_port_status",
+    (
+        {SMB_PORTS[0]: PortScanData(port=SMB_PORTS[0], status=PortStatus.CLOSED)},
+        {SMB_PORTS[1]: PortScanData(port=SMB_PORTS[1], status=PortStatus.CLOSED)},
+        {},
+    ),
+)
+def test_run__attempts_exploit_if_port_status_unknown(
+    plugin: Plugin,
+    mock_smb_exploiter: BruteForceExploiter,
+    target_host: TargetHost,
+    tcp_port_status: Dict[NetworkPort, PortScanData],
+):
+    host = target_host
+    host.ports_status.tcp_ports = tcp_port_status
     result = plugin.run(
         host=host,
         servers=SERVERS,
@@ -91,30 +110,76 @@ def test_run__fails_if_no_open_smb_ports(plugin: Plugin):
         interrupt=Event(),
     )
 
-    assert not result.exploitation_success
-    assert not result.propagation_success
-
-
-@pytest.mark.parametrize("port", [NetworkPort(445), NetworkPort(139)])
-def test_run__proceeds_if_open_smb_ports(plugin: Plugin, port: NetworkPort):
-    host = TARGET_HOST.copy(deep=True)
-    host.ports_status = TargetHostPorts(
-        tcp_ports={port: PortScanData(port=port, status=PortStatus.OPEN)}
-    )
-    result = plugin.run(
-        host=host,
-        servers=SERVERS,
-        current_depth=1,
-        options={},
-        interrupt=Event(),
-    )
-
+    mock_smb_exploiter.exploit_host.assert_called_once()
     assert result == EXPLOITER_RESULT_DATA
 
 
-def test_run__returns_exploiter_result_data(plugin: Plugin):
+@pytest.mark.parametrize(
+    "tcp_port_status",
+    (
+        {SMB_PORTS[0]: PortScanData(port=SMB_PORTS[0], status=PortStatus.OPEN)},
+        {SMB_PORTS[1]: PortScanData(port=SMB_PORTS[1], status=PortStatus.OPEN)},
+        {
+            SMB_PORTS[0]: PortScanData(port=SMB_PORTS[0], status=PortStatus.CLOSED),
+            SMB_PORTS[1]: PortScanData(port=SMB_PORTS[1], status=PortStatus.OPEN),
+        },
+        {
+            SMB_PORTS[0]: PortScanData(port=SMB_PORTS[0], status=PortStatus.OPEN),
+            SMB_PORTS[1]: PortScanData(port=SMB_PORTS[1], status=PortStatus.CLOSED),
+        },
+        {
+            SMB_PORTS[0]: PortScanData(port=SMB_PORTS[0], status=PortStatus.OPEN),
+            SMB_PORTS[1]: PortScanData(port=SMB_PORTS[1], status=PortStatus.OPEN),
+        },
+    ),
+)
+def test_run__attempts_exploit_if_port_status_open(
+    plugin: Plugin,
+    mock_smb_exploiter: BruteForceExploiter,
+    target_host: TargetHost,
+    tcp_port_status: Dict[NetworkPort, PortScanData],
+):
+    host = target_host
+    host.ports_status.tcp_ports = tcp_port_status
     result = plugin.run(
-        host=TARGET_HOST,
+        host=host,
+        servers=SERVERS,
+        current_depth=1,
+        options={},
+        interrupt=Event(),
+    )
+
+    mock_smb_exploiter.exploit_host.assert_called_once()
+    assert result == EXPLOITER_RESULT_DATA
+
+
+def test_run__skips_exploit_if_port_status_closed(
+    plugin: Plugin,
+    mock_smb_exploiter: BruteForceExploiter,
+    target_host: TargetHost,
+):
+    host = target_host
+    host.ports_status.tcp_ports = {
+        SMB_PORTS[0]: PortScanData(port=SMB_PORTS[0], status=PortStatus.CLOSED),
+        SMB_PORTS[1]: PortScanData(port=SMB_PORTS[1], status=PortStatus.CLOSED),
+    }
+
+    result = plugin.run(
+        host=host,
+        servers=SERVERS,
+        current_depth=1,
+        options={},
+        interrupt=Event(),
+    )
+
+    mock_smb_exploiter.exploit_host.assert_not_called()
+    assert result.exploitation_success is False
+    assert result.propagation_success is False
+
+
+def test_run__returns_exploiter_result_data(plugin: Plugin, target_host: TargetHost):
+    result = plugin.run(
+        host=target_host,
         servers=SERVERS,
         current_depth=1,
         options={},
@@ -128,6 +193,7 @@ def test_run__exploit_host_raises_exception(
     monkeypatch,
     plugin: Plugin,
     propagation_credentials_repository: IPropagationCredentialsRepository,
+    target_host: TargetHost,
 ):
     monkeypatch.setattr(
         "agent_plugins.exploiters.smb.src.plugin.BruteForceExploiter",
@@ -142,7 +208,7 @@ def test_run__exploit_host_raises_exception(
         propagation_credentials_repository=propagation_credentials_repository,
     )
     result = plugin.run(
-        host=TARGET_HOST,
+        host=target_host,
         servers=SERVERS,
         current_depth=1,
         options={},

--- a/monkey/tests/unit_tests/infection_monkey/i_puppet/test_target_host.py
+++ b/monkey/tests/unit_tests/infection_monkey/i_puppet/test_target_host.py
@@ -1,14 +1,70 @@
+import pytest
+
 from common.types import NetworkPort, PortStatus
-from infection_monkey.i_puppet import PortScanData, TargetHostPorts
+from infection_monkey.i_puppet import PortScanData, PortScanDataDict, TargetHostPorts
+
+
+def test_port_scan_data_dict__constructor():
+    input_dict = {
+        NetworkPort(1): PortScanData(port=1, status=PortStatus.OPEN),
+        NetworkPort(2): PortScanData(port=2, status=PortStatus.CLOSED),
+        NetworkPort(3): PortScanData(port=3, status=PortStatus.OPEN),
+    }
+    expected_port_scan_data_dict = {
+        1: PortScanData(port=1, status=PortStatus.OPEN),
+        2: PortScanData(port=2, status=PortStatus.CLOSED),
+        3: PortScanData(port=3, status=PortStatus.OPEN),
+    }
+
+    port_scan_data_dict: PortScanDataDict = PortScanDataDict(input_dict)
+
+    assert port_scan_data_dict == expected_port_scan_data_dict
+
+
+def test_port_scan_data_dict__set():
+    expected_port_scan_data_dict = {
+        1: PortScanData(port=1, status=PortStatus.OPEN),
+        2: PortScanData(port=2, status=PortStatus.CLOSED),
+    }
+
+    port_scan_data_dict = PortScanDataDict()
+    port_scan_data_dict[1] = PortScanData(port=1, status=PortStatus.OPEN)
+    port_scan_data_dict[2] = PortScanData(port=2, status=PortStatus.CLOSED)
+
+    assert port_scan_data_dict == expected_port_scan_data_dict
+
+
+INVALID_PORTS = (-1, 65536, "string", None, "22.2")
+VALID_PORT_SCAN_DATA = PortScanData(port=1, status=PortStatus.OPEN)
+
+
+@pytest.mark.parametrize("invalid_port", INVALID_PORTS)
+def test_port_scan_data_dict_constructor__invalid_port(invalid_port):
+    with pytest.raises((ValueError, TypeError)):
+        PortScanDataDict({invalid_port: VALID_PORT_SCAN_DATA})
+
+
+@pytest.mark.parametrize("invalid_port", INVALID_PORTS)
+def test_port_scan_data_dict_update__invalid_port(invalid_port):
+    port_scan_data_dict = PortScanDataDict()
+    with pytest.raises((ValueError, TypeError)):
+        port_scan_data_dict.update({invalid_port: VALID_PORT_SCAN_DATA})
+
+
+@pytest.mark.parametrize("invalid_port", INVALID_PORTS)
+def test_port_scan_data_dict_set__invalid_port(invalid_port):
+    port_scan_data_dict = PortScanDataDict()
+    with pytest.raises((ValueError, TypeError)):
+        port_scan_data_dict[invalid_port] = VALID_PORT_SCAN_DATA
 
 
 def test_closed_tcp_ports():
-    expected_closed_ports = {NetworkPort(2), NetworkPort(4)}
+    expected_closed_ports = {2, 4}
     tcp_ports = {
-        NetworkPort(1): PortScanData(port=NetworkPort(1), status=PortStatus.OPEN),
-        NetworkPort(2): PortScanData(port=NetworkPort(2), status=PortStatus.CLOSED),
-        NetworkPort(3): PortScanData(port=NetworkPort(3), status=PortStatus.OPEN),
-        NetworkPort(4): PortScanData(port=NetworkPort(4), status=PortStatus.CLOSED),
+        1: PortScanData(port=1, status=PortStatus.OPEN),
+        2: PortScanData(port=2, status=PortStatus.CLOSED),
+        3: PortScanData(port=3, status=PortStatus.OPEN),
+        4: PortScanData(port=4, status=PortStatus.CLOSED),
     }
     thp = TargetHostPorts(tcp_ports=tcp_ports)
 

--- a/monkey/tests/unit_tests/infection_monkey/i_puppet/test_target_host.py
+++ b/monkey/tests/unit_tests/infection_monkey/i_puppet/test_target_host.py
@@ -1,7 +1,7 @@
 import pytest
 
 from common.types import NetworkPort, PortStatus
-from infection_monkey.i_puppet import PortScanData, PortScanDataDict, TargetHostPorts
+from infection_monkey.i_puppet import PortScanData, PortScanDataDict
 
 
 def test_port_scan_data_dict__constructor():
@@ -62,12 +62,11 @@ def test_closed_tcp_ports():
     expected_closed_ports = {2, 4}
     tcp_ports = PortScanDataDict(
         {
-            1: PortScanData(port=1, status=PortStatus.OPEN),
-            2: PortScanData(port=2, status=PortStatus.CLOSED),
-            3: PortScanData(port=3, status=PortStatus.OPEN),
-            4: PortScanData(port=4, status=PortStatus.CLOSED),
+            NetworkPort(1): PortScanData(port=1, status=PortStatus.OPEN),
+            NetworkPort(2): PortScanData(port=2, status=PortStatus.CLOSED),
+            NetworkPort(3): PortScanData(port=3, status=PortStatus.OPEN),
+            NetworkPort(4): PortScanData(port=4, status=PortStatus.CLOSED),
         }
     )
-    thp = TargetHostPorts(tcp_ports=tcp_ports)
 
-    assert thp.closed_tcp_ports == expected_closed_ports
+    assert tcp_ports.closed == expected_closed_ports

--- a/monkey/tests/unit_tests/infection_monkey/i_puppet/test_target_host.py
+++ b/monkey/tests/unit_tests/infection_monkey/i_puppet/test_target_host.py
@@ -1,0 +1,15 @@
+from common.types import NetworkPort, PortStatus
+from infection_monkey.i_puppet import PortScanData, TargetHostPorts
+
+
+def test_closed_tcp_ports():
+    expected_closed_ports = {NetworkPort(2), NetworkPort(4)}
+    tcp_ports = {
+        NetworkPort(1): PortScanData(port=NetworkPort(1), status=PortStatus.OPEN),
+        NetworkPort(2): PortScanData(port=NetworkPort(2), status=PortStatus.CLOSED),
+        NetworkPort(3): PortScanData(port=NetworkPort(3), status=PortStatus.OPEN),
+        NetworkPort(4): PortScanData(port=NetworkPort(4), status=PortStatus.CLOSED),
+    }
+    thp = TargetHostPorts(tcp_ports=tcp_ports)
+
+    assert thp.closed_tcp_ports == expected_closed_ports

--- a/monkey/tests/unit_tests/infection_monkey/i_puppet/test_target_host.py
+++ b/monkey/tests/unit_tests/infection_monkey/i_puppet/test_target_host.py
@@ -60,12 +60,14 @@ def test_port_scan_data_dict_set__invalid_port(invalid_port):
 
 def test_closed_tcp_ports():
     expected_closed_ports = {2, 4}
-    tcp_ports = {
-        1: PortScanData(port=1, status=PortStatus.OPEN),
-        2: PortScanData(port=2, status=PortStatus.CLOSED),
-        3: PortScanData(port=3, status=PortStatus.OPEN),
-        4: PortScanData(port=4, status=PortStatus.CLOSED),
-    }
+    tcp_ports = PortScanDataDict(
+        {
+            1: PortScanData(port=1, status=PortStatus.OPEN),
+            2: PortScanData(port=2, status=PortStatus.CLOSED),
+            3: PortScanData(port=3, status=PortStatus.OPEN),
+            4: PortScanData(port=4, status=PortStatus.CLOSED),
+        }
+    )
     thp = TargetHostPorts(tcp_ports=tcp_ports)
 
     assert thp.closed_tcp_ports == expected_closed_ports

--- a/monkey/tests/unit_tests/infection_monkey/master/mock_puppet.py
+++ b/monkey/tests/unit_tests/infection_monkey/master/mock_puppet.py
@@ -4,7 +4,7 @@ from typing import Dict, Sequence
 from common import OperatingSystem
 from common.agent_plugins import AgentPluginType
 from common.credentials import Credentials, LMHash, Password, SSHKeypair, Username
-from common.types import Event, NetworkPort, NetworkProtocol, NetworkService, PortStatus
+from common.types import Event, NetworkProtocol, NetworkService, PortStatus
 from infection_monkey.i_puppet import (
     DiscoveredService,
     ExploiterResultData,
@@ -13,6 +13,7 @@ from infection_monkey.i_puppet import (
     IPuppet,
     PingScanData,
     PortScanData,
+    PortScanDataDict,
     TargetHost,
 )
 
@@ -74,7 +75,7 @@ class MockPuppet(IPuppet):
 
     def scan_tcp_ports(
         self, host: str, ports: Sequence[int], timeout: float = 3
-    ) -> Dict[NetworkPort, PortScanData]:
+    ) -> PortScanDataDict:
         logger.debug(f"run_scan_tcp_port({host}, {ports}, {timeout})")
         dot_1_results = {
             22: PortScanData(port=22, status=PortStatus.CLOSED),


### PR DESCRIPTION
# What does this PR do?

Fixes part of #2952.

Adds the following checks before running the exploiter:
  - Check that the target has SMB ports open

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Do all unit tests pass?
* [x] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
