### PR TITLE
Agent: Pass Agent ID to credentials collectors

### DIFF
--- a/monkey/infection_monkey/credential_collectors/mimikatz_collector/mimikatz_credential_collector.py
+++ b/monkey/infection_monkey/credential_collectors/mimikatz_collector/mimikatz_credential_collector.py
@@ -5,9 +5,9 @@ from common.agent_events import CredentialsStolenEvent
 from common.credentials import Credentials, LMHash, NTHash, Password, Username
 from common.event_queue import IAgentEventQueue
 from common.tags import T1003_ATTACK_TECHNIQUE_TAG, T1005_ATTACK_TECHNIQUE_TAG
+from common.types import AgentID
 from infection_monkey.i_puppet import ICredentialCollector
 from infection_monkey.model import USERNAME_PREFIX
-from infection_monkey.utils.ids import get_agent_id
 
 from . import pypykatz_handler
 from .windows_credentials import WindowsCredentials
@@ -27,8 +27,9 @@ MIMIKATZ_EVENT_TAGS = frozenset(
 
 
 class MimikatzCredentialCollector(ICredentialCollector):
-    def __init__(self, agent_event_queue: IAgentEventQueue):
+    def __init__(self, agent_event_queue: IAgentEventQueue, agent_id: AgentID):
         self._agent_event_queue = agent_event_queue
+        self._agent_id = agent_id
 
     def collect_credentials(self, options=None) -> Sequence[Credentials]:
         logger.info("Attempting to collect windows credentials with pypykatz.")
@@ -76,7 +77,7 @@ class MimikatzCredentialCollector(ICredentialCollector):
 
     def _publish_credentials_stolen_event(self, collected_credentials: Sequence[Credentials]):
         credentials_stolen_event = CredentialsStolenEvent(
-            source=get_agent_id(),
+            source=self._agent_id,
             tags=MIMIKATZ_EVENT_TAGS,
             stolen_credentials=collected_credentials,
         )

--- a/monkey/infection_monkey/credential_collectors/ssh_collector/ssh_credential_collector.py
+++ b/monkey/infection_monkey/credential_collectors/ssh_collector/ssh_credential_collector.py
@@ -3,6 +3,7 @@ from typing import Sequence
 
 from common.credentials import Credentials
 from common.event_queue import IAgentEventQueue
+from common.types import AgentID
 from infection_monkey.credential_collectors.ssh_collector import ssh_handler
 from infection_monkey.i_puppet import ICredentialCollector
 
@@ -14,12 +15,13 @@ class SSHCredentialCollector(ICredentialCollector):
     SSH keys credential collector
     """
 
-    def __init__(self, agent_event_queue: IAgentEventQueue):
+    def __init__(self, agent_event_queue: IAgentEventQueue, agent_id: AgentID):
         self._agent_event_queue = agent_event_queue
+        self._agent_id = agent_id
 
     def collect_credentials(self, _options=None) -> Sequence[Credentials]:
         logger.info("Started scanning for SSH credentials")
-        ssh_info = ssh_handler.get_ssh_info(self._agent_event_queue)
+        ssh_info = ssh_handler.get_ssh_info(self._agent_event_queue, self._agent_id)
         logger.info("Finished scanning for SSH credentials")
 
         return ssh_handler.to_credentials(ssh_info)

--- a/monkey/infection_monkey/credential_collectors/ssh_collector/ssh_handler.py
+++ b/monkey/infection_monkey/credential_collectors/ssh_collector/ssh_handler.py
@@ -11,8 +11,8 @@ from common.tags import (
     T1005_ATTACK_TECHNIQUE_TAG,
     T1145_ATTACK_TECHNIQUE_TAG,
 )
+from common.types import AgentID
 from common.utils.environment import is_windows_os
-from infection_monkey.utils.ids import get_agent_id
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ SSH_COLLECTOR_EVENT_TAGS = frozenset(
 )
 
 
-def get_ssh_info(agent_event_queue: IAgentEventQueue) -> Iterable[Dict]:
+def get_ssh_info(agent_event_queue: IAgentEventQueue, agent_id: AgentID) -> Iterable[Dict]:
     # TODO: Remove this check when this is turned into a plugin.
     if is_windows_os():
         logger.debug(
@@ -38,7 +38,7 @@ def get_ssh_info(agent_event_queue: IAgentEventQueue) -> Iterable[Dict]:
         return []
 
     home_dirs = _get_home_dirs()
-    ssh_info = _get_ssh_files(home_dirs, agent_event_queue)
+    ssh_info = _get_ssh_files(home_dirs, agent_event_queue, agent_id)
 
     return ssh_info
 
@@ -79,6 +79,7 @@ def _get_ssh_struct(name: str, home_dir: str) -> Dict:
 def _get_ssh_files(
     user_info: Iterable[Dict],
     agent_event_queue: IAgentEventQueue,
+    agent_id: AgentID,
 ) -> Iterable[Dict]:
     for info in user_info:
         path = info["home_dir"]
@@ -109,7 +110,7 @@ def _get_ssh_files(
                                             logger.info("Found private key in %s" % private)
                                             collected_credentials = to_credentials([info])
                                             _publish_credentials_stolen_event(
-                                                collected_credentials, agent_event_queue
+                                                collected_credentials, agent_event_queue, agent_id
                                             )
                                         else:
                                             continue
@@ -154,10 +155,12 @@ def to_credentials(ssh_info: Iterable[Dict]) -> Sequence[Credentials]:
 
 
 def _publish_credentials_stolen_event(
-    collected_credentials: Sequence[Credentials], agent_event_queue: IAgentEventQueue
+    collected_credentials: Sequence[Credentials],
+    agent_event_queue: IAgentEventQueue,
+    agent_id: AgentID,
 ):
     credentials_stolen_event = CredentialsStolenEvent(
-        source=get_agent_id(),
+        source=agent_id,
         tags=SSH_COLLECTOR_EVENT_TAGS,
         stolen_credentials=collected_credentials,
     )

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -412,12 +412,12 @@ class InfectionMonkey:
         puppet.load_plugin(
             AgentPluginType.CREDENTIAL_COLLECTOR,
             "MimikatzCollector",
-            MimikatzCredentialCollector(self._agent_event_queue),
+            MimikatzCredentialCollector(self._agent_event_queue, self._agent_id),
         )
         puppet.load_plugin(
             AgentPluginType.CREDENTIAL_COLLECTOR,
             "SSHCollector",
-            SSHCredentialCollector(self._agent_event_queue),
+            SSHCredentialCollector(self._agent_event_queue, self._agent_id),
         )
 
         puppet.load_plugin(AgentPluginType.FINGERPRINTER, "http", HTTPFingerprinter())

--- a/monkey/tests/unit_tests/infection_monkey/credential_collectors/test_ssh_credentials_collector.py
+++ b/monkey/tests/unit_tests/infection_monkey/credential_collectors/test_ssh_credentials_collector.py
@@ -4,13 +4,16 @@ import pytest
 
 from common.credentials import Credentials, SSHKeypair, Username
 from common.event_queue import IAgentEventQueue
+from common.types import AgentID
 from infection_monkey.credential_collectors import SSHCredentialCollector
+
+AGENT_ID = AgentID("ed077054-a316-479a-a99d-75bb378c0a6e")
 
 
 def patch_ssh_handler(ssh_creds, monkeypatch):
     monkeypatch.setattr(
         "infection_monkey.credential_collectors.ssh_collector.ssh_handler.get_ssh_info",
-        lambda _: ssh_creds,
+        lambda _, __: ssh_creds,
     )
 
 
@@ -19,7 +22,9 @@ def patch_ssh_handler(ssh_creds, monkeypatch):
 )
 def test_ssh_credentials_empty_results(monkeypatch, ssh_creds):
     patch_ssh_handler(ssh_creds, monkeypatch)
-    collected = SSHCredentialCollector(MagicMock(spec=IAgentEventQueue)).collect_credentials()
+    collected = SSHCredentialCollector(
+        MagicMock(spec=IAgentEventQueue), AGENT_ID
+    ).collect_credentials()
     assert not collected
 
 
@@ -64,5 +69,7 @@ def test_ssh_info_result_parsing(monkeypatch):
         Credentials(identity=username3, secret=None),
         Credentials(identity=None, secret=ssh_keypair3),
     ]
-    collected = SSHCredentialCollector(MagicMock(spec=IAgentEventQueue)).collect_credentials()
+    collected = SSHCredentialCollector(
+        MagicMock(spec=IAgentEventQueue), AGENT_ID
+    ).collect_credentials()
     assert expected == collected


### PR DESCRIPTION
# What does this PR do?

Fixes part of #3119 by passing Agent ID to the mimikatz and SSH credential collectors.

Add any further explanations here.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [x] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
