### PR TITLE
3150 log target host ip

### DIFF
--- a/monkey/agent_plugins/exploiters/smb/src/smb_client.py
+++ b/monkey/agent_plugins/exploiters/smb/src/smb_client.py
@@ -82,16 +82,16 @@ class SMBClient:
             )
             return
         except SessionError as err:
-            logger.debug(f"Failed to create SMB connection to {host} on port 445: {err}")
+            logger.debug(f"Failed to create SMB connection to {host.ip} on port 445: {err}")
 
         try:
             # "*SMBSERVER" and port 139 is a special case. See doc for SMBConnection
             self._smb_connection = SMBConnection("*SMBSEVER", str(host.ip), sess_port=139)
             return
         except SessionError as err:
-            logger.debug(f"Failed to create SMB connection to {host} on port 139: {err}")
+            logger.debug(f"Failed to create SMB connection to {host.ip} on port 139: {err}")
 
-        raise Exception(f"Failed to create SMB connection to {host}")
+        raise Exception(f"Failed to create SMB connection to {host.ip}")
 
     def _smb_login(self, credentials: Credentials):
         """Raise SessionError if login fails"""

--- a/monkey/infection_monkey/exploit/mssqlexec.py
+++ b/monkey/infection_monkey/exploit/mssqlexec.py
@@ -69,7 +69,7 @@ class MSSQLExploiter(HostExploiter):
             self.cursor = self._brute_force(str(self.host.ip), self.SQL_DEFAULT_TCP_PORT, creds)
         except FailedExploitationError:
             error_message = (
-                f"Failed brute-forcing of MSSQL server on {self.host},"
+                f"Failed brute-forcing of MSSQL server on {self.host.ip},"
                 f" no credentials were successful"
             )
             logger.error(error_message)
@@ -85,7 +85,7 @@ class MSSQLExploiter(HostExploiter):
         except Exception as e:
             error_message = (
                 f"An unexpected error occurred when trying "
-                f"to exploit MSSQL on host {self.host}: {e}"
+                f"to exploit MSSQL on host {self.host.ip}: {e}"
             )
 
             logger.error(error_message)

--- a/monkey/infection_monkey/exploit/sshexec.py
+++ b/monkey/infection_monkey/exploit/sshexec.py
@@ -100,7 +100,7 @@ class SSHExploiter(HostExploiter):
                     allow_agent=False,
                 )
                 logger.debug(
-                    "Successfully logged in %s using %s users private key", self.host, ssh_string
+                    "Successfully logged in %s using %s users private key", self.host.ip, ssh_string
                 )
                 self.add_vuln_port(port)
                 self.exploit_result.exploitation_success = True
@@ -110,7 +110,8 @@ class SSHExploiter(HostExploiter):
             except paramiko.AuthenticationException as err:
                 ssh.close()
                 error_message = (
-                    f"Failed logging into victim {self.host} with {ssh_string} private key: {err}"
+                    f"Failed logging into victim {self.host.ip} with {ssh_string} "
+                    f"private key: {err}"
                 )
                 logger.info(error_message)
                 self._publish_exploitation_event(timestamp, False, error_message=error_message)
@@ -158,7 +159,7 @@ class SSHExploiter(HostExploiter):
                     allow_agent=False,
                 )
 
-                logger.debug("Successfully logged in %r using SSH. User: %s", self.host, user)
+                logger.debug("Successfully logged in %r using SSH. User: %s", self.host.ip, user)
                 self.add_vuln_port(port)
                 self.exploit_result.exploitation_success = True
                 self._publish_exploitation_event(timestamp, True)
@@ -166,7 +167,9 @@ class SSHExploiter(HostExploiter):
                 return ssh
 
             except paramiko.AuthenticationException as err:
-                error_message = f"Failed logging into victim {self.host} with user: {user}: {err}"
+                error_message = (
+                    f"Failed logging into victim {self.host.ip} with user: {user}: {err}"
+                )
                 logger.debug(error_message)
                 self._publish_exploitation_event(timestamp, False, error_message=error_message)
                 self.report_login_attempt(False, user, current_password)
@@ -174,7 +177,7 @@ class SSHExploiter(HostExploiter):
                 continue
             except Exception as err:
                 error_message = (
-                    f"Unexpected error while attempting to login to {self.host} with password: "
+                    f"Unexpected error while attempting to login to {self.host.ip} with password: "
                     f"{err}"
                 )
                 logger.error(error_message)
@@ -187,7 +190,7 @@ class SSHExploiter(HostExploiter):
         port = self._get_ssh_port()
 
         if not self._is_port_open(self.host.ip, port):
-            self.exploit_result.error_message = f"SSH port is closed on {self.host}, skipping"
+            self.exploit_result.error_message = f"SSH port is closed on {self.host.ip}, skipping"
             logger.info(self.exploit_result.error_message)
             return self.exploit_result
 
@@ -225,7 +228,7 @@ class SSHExploiter(HostExploiter):
     def _propagate(self, ssh: paramiko.SSHClient):
         agent_binary_file_object = self._get_agent_binary(ssh)
         if agent_binary_file_object is None:
-            raise RuntimeError(f"Can't find suitable monkey executable for host {self.host}")
+            raise RuntimeError(f"Can't find suitable monkey executable for host {self.host.ip}")
 
         if self._is_interrupted():
             raise RuntimeError("Propagation was interrupted")
@@ -247,7 +250,7 @@ class SSHExploiter(HostExploiter):
             logger.info(
                 "Executed monkey '%s' on remote victim %r (cmdline=%r)",
                 monkey_path_on_victim,
-                self.host,
+                self.host.ip,
                 cmdline,
             )
 
@@ -256,7 +259,7 @@ class SSHExploiter(HostExploiter):
             self.add_executed_cmd(cmdline)
 
         except Exception as exc:
-            error_message = f"Error running monkey on victim {self.host}: ({exc})"
+            error_message = f"Error running monkey on victim {self.host.ip}: ({exc})"
             self._publish_propagation_event(timestamp, False, error_message=error_message)
             raise FailedExploitationError(error_message)
 
@@ -293,7 +296,7 @@ class SSHExploiter(HostExploiter):
                     logger.error(self.exploit_result.error_message)
                 return False
         except Exception as exc:
-            logger.error(f"Error running uname os command on victim {self.host}: ({exc})")
+            logger.error(f"Error running uname os command on victim {self.host.ip}: ({exc})")
             return False
         return True
 
@@ -329,7 +332,7 @@ class SSHExploiter(HostExploiter):
 
             return ScanStatus.USED
         except Exception as exc:
-            error_message = f"Error uploading file into victim {self.host}: ({exc})"
+            error_message = f"Error uploading file into victim {self.host.ip}: ({exc})"
             self._publish_propagation_event(timestamp, False, error_message=error_message)
             self.exploit_result.error_message = error_message
             return ScanStatus.SCANNED

--- a/monkey/infection_monkey/exploit/tools/brute_force_exploiter.py
+++ b/monkey/infection_monkey/exploit/tools/brute_force_exploiter.py
@@ -83,14 +83,14 @@ class BruteForceExploiter:
         try:
             self._exploit(exploit_client, host, interrupt)
         except Exception as err:
-            logger.exception(f"Failed to exploit {host}: {err}")
+            logger.exception(f"Failed to exploit {host.ip}: {err}")
             return ExploiterResultData(exploitation_success=False, propagation_success=False)
 
         try:
             self._propagate(exploit_client, host, interrupt)
             return ExploiterResultData(exploitation_success=True, propagation_success=True)
         except Exception as err:
-            logger.exception(f"Failed to propagate to {host}: {err}")
+            logger.exception(f"Failed to propagate to {host.ip}: {err}")
             return ExploiterResultData(exploitation_success=True, propagation_success=False)
 
     def _exploit(self, exploit_client: IRemoteAccessClient, host: TargetHost, interrupt: Event):

--- a/monkey/infection_monkey/exploit/web_rce.py
+++ b/monkey/infection_monkey/exploit/web_rce.py
@@ -238,7 +238,7 @@ class WebRCE(HostExploiter):
         """
         ports = WebRCE.get_open_service_ports(self.host, ports, services)
         if not ports:
-            logger.info("All default web ports are closed on %r, skipping", str(self.host))
+            logger.info(f"All default web ports are closed on {self.host.ip}, skipping")
             return False
         else:
             return ports

--- a/monkey/infection_monkey/exploit/wmiexec.py
+++ b/monkey/infection_monkey/exploit/wmiexec.py
@@ -50,7 +50,7 @@ class WmiExploiter(HostExploiter):
 
         for user, password, lm_hash, ntlm_hash in intp_creds:
             creds_for_log = get_credential_string([user, password, lm_hash, ntlm_hash])
-            logger.debug(f"Attempting to connect to {self.host} using WMI with {creds_for_log}")
+            logger.debug(f"Attempting to connect to {self.host.ip} using WMI with {creds_for_log}")
 
             wmi_connection = WmiTools.WmiConnection()
 
@@ -66,26 +66,26 @@ class WmiExploiter(HostExploiter):
                 )
             except AccessDeniedException:
                 self.report_login_attempt(False, user, password, lm_hash, ntlm_hash)
-                error_message = f"Failed connecting to {self.host} using WMI"
+                error_message = f"Failed connecting to {self.host.ip} using WMI"
                 logger.debug(error_message)
                 self._publish_exploitation_event(timestamp, False, error_message=error_message)
                 continue
             except DCERPCException:
                 self.report_login_attempt(False, user, password, lm_hash, ntlm_hash)
-                error_message = f"Failed connecting to {self.host} using WMI"
+                error_message = f"Failed connecting to {self.host.ip} using WMI"
                 logger.debug(error_message)
                 self._publish_exploitation_event(timestamp, False, error_message=error_message)
                 continue
 
             except socket.error:
-                error_message = f"Network error in WMI connection to {self.host}"
+                error_message = f"Network error in WMI connection to {self.host.ip}"
                 logger.debug(error_message)
                 self._publish_exploitation_event(timestamp, False, error_message=error_message)
                 return self.exploit_result
 
             except Exception as exc:
                 error_message = (
-                    f"Unknown WMI connection error to {self.host}: "
+                    f"Unknown WMI connection error to {self.host.ip}: "
                     f"{exc} {traceback.format_exc()}"
                 )
                 logger.debug(error_message)
@@ -150,7 +150,7 @@ class WmiExploiter(HostExploiter):
 
             if (0 != result.ProcessId) and (not result.ReturnValue):
                 logger.info(
-                    f"Executed dropper '{remote_full_path}' on remote victim {self.host} "
+                    f"Executed dropper '{remote_full_path}' on remote victim {self.host.ip} "
                     f"(pid={result.ProcessId}, cmdline={cmdline})"
                 )
 
@@ -159,7 +159,7 @@ class WmiExploiter(HostExploiter):
                 self._publish_propagation_event(propagation_timestamp, True)
             else:
                 error_message = (
-                    f"Error executing dropper '{remote_full_path}' on remote victim {self.host} "
+                    f"Error executing dropper '{remote_full_path}' on remote victim {self.host.ip} "
                     f"(pid={result.ProcessId}, exit_code={result.ReturnValue}, cmdline={cmdline})"
                 )
                 logger.debug(error_message)

--- a/monkey/infection_monkey/exploit/zerologon.py
+++ b/monkey/infection_monkey/exploit/zerologon.py
@@ -140,7 +140,7 @@ class ZerologonExploiter(HostExploiter):
                 error_message = "Failed to authenticate with domain controller"
                 self._publish_exploitation_event(timestamp, False, error_message=error_message)
             except Exception as err:
-                error_message = f"Error occured while authenticating to {self.host}: {err}"
+                error_message = f"Error occured while authenticating to {self.host.ip}: {err}"
                 logger.info(error_message)
                 self._publish_exploitation_event(timestamp, False, error_message=error_message)
                 return False, None, timestamp

--- a/monkey/infection_monkey/master/propagator.py
+++ b/monkey/infection_monkey/master/propagator.py
@@ -224,13 +224,14 @@ class Propagator:
         self, exploiter_name: str, host: TargetHost, result: ExploiterResultData
     ):
         if result.propagation_success:
-            logger.info(f"Successfully propagated to {host} using {exploiter_name}")
+            logger.info(f"Successfully propagated to {host.ip} using {exploiter_name}")
         elif result.exploitation_success:
             logger.info(
-                f"Successfully exploited (but did not propagate to) {host} using {exploiter_name}"
+                f"Successfully exploited (but did not propagate to) {host.ip} using "
+                f"{exploiter_name}"
             )
         else:
             logger.info(
-                f"Failed to exploit or propagate to {host} using {exploiter_name}: "
+                f"Failed to exploit or propagate to {host.ip} using {exploiter_name}: "
                 f"{result.error_message}"
             )

--- a/monkey/infection_monkey/puppet/puppet.py
+++ b/monkey/infection_monkey/puppet/puppet.py
@@ -85,7 +85,7 @@ class Puppet(IPuppet):
     ) -> ExploiterResultData:
         if self._plugin_compatability_verifier.verify_exploiter_compatibility(name, host) is False:
             raise IncompatibleOperatingSystemError(
-                f'The exploiter, "{name}", is not compatible with the operating system on {host}'
+                f'The exploiter, "{name}", is not compatible with the operating system on {host.ip}'
             )
         exploiter = self._plugin_registry.get_plugin(AgentPluginType.EXPLOITER, name)
         exploiter_result_data = exploiter.run(

--- a/monkey/tests/unit_tests/infection_monkey/master/mock_puppet.py
+++ b/monkey/tests/unit_tests/infection_monkey/master/mock_puppet.py
@@ -169,7 +169,7 @@ class MockPuppet(IPuppet):
         options: Dict,
         interrupt: Event,
     ) -> ExploiterResultData:
-        logger.debug(f"exploit_hosts({name}, {host}, {options})")
+        logger.debug(f"exploit_hosts({name}, {host.ip}, {options})")
         info_wmi = {
             "display_name": "WMI",
             "started": "2021-11-25T15:57:06.307696",


### PR DESCRIPTION
# What does this PR do?

Fixes #3150.

Instead of logging the whole TragetHost object, it logs only the host IP.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [x] Was the CHANGELOG.md updated to reflect the changes?
* [x] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Do all unit tests pass?
* [x] Do all end-to-end tests pass?
* [x] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] ~If applicable, add screenshots or log transcripts of the feature working~
