### PR TITLE
Island: Include refresh token into responses

### DIFF
--- a/monkey/monkey_island/cc/app.py
+++ b/monkey/monkey_island/cc/app.py
@@ -44,10 +44,7 @@ from monkey_island.cc.services.authentication_service.authentication_facade impo
 from monkey_island.cc.services.authentication_service.configure_flask_security import (
     configure_flask_security,
 )
-from monkey_island.cc.services.authentication_service.token import (
-    TokenGenerator,
-    TokenValidator,
-)
+from monkey_island.cc.services.authentication_service.token import TokenGenerator, TokenValidator
 from monkey_island.cc.services.representations import output_json
 
 HOME_FILE = "index.html"

--- a/monkey/monkey_island/cc/services/authentication_service/flask_resources/login.py
+++ b/monkey/monkey_island/cc/services/authentication_service/flask_resources/login.py
@@ -9,7 +9,11 @@ from flask_security.views import login
 from monkey_island.cc.flask_utils import AbstractResource, responses
 
 from ..authentication_facade import AuthenticationFacade
-from .utils import get_username_password_from_request, include_auth_token
+from .utils import (
+    add_refresh_token_to_response,
+    get_username_password_from_request,
+    include_auth_token,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -38,9 +42,8 @@ class Login(AbstractResource):
         try:
             username, password = get_username_password_from_request(request)
             response: ResponseValue = login()
-            # TODO send these back
-            _tokens = self._authentication_facade.generate_refresh_token(current_user)
-            del _tokens
+            refresh_token = self._authentication_facade.generate_refresh_token(current_user)
+            response = add_refresh_token_to_response(response, refresh_token)
         except Exception:
             return responses.make_response_to_invalid_request()
 

--- a/monkey/monkey_island/cc/services/authentication_service/flask_resources/register.py
+++ b/monkey/monkey_island/cc/services/authentication_service/flask_resources/register.py
@@ -9,7 +9,11 @@ from flask_security.views import register
 from monkey_island.cc.flask_utils import AbstractResource, responses
 
 from ..authentication_facade import AuthenticationFacade
-from .utils import get_username_password_from_request, include_auth_token
+from .utils import (
+    add_refresh_token_to_response,
+    get_username_password_from_request,
+    include_auth_token,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -37,9 +41,8 @@ class Register(AbstractResource):
                 }, HTTPStatus.CONFLICT
             username, password = get_username_password_from_request(request)
             response: ResponseValue = register()
-            # TODO send these back
-            _tokens = self._authentication_facade.generate_refresh_token(current_user)
-            del _tokens
+            refresh_token = self._authentication_facade.generate_refresh_token(current_user)
+            response = add_refresh_token_to_response(response, refresh_token)
         except Exception:
             return responses.make_response_to_invalid_request()
 

--- a/monkey/monkey_island/cc/services/authentication_service/flask_resources/utils.py
+++ b/monkey/monkey_island/cc/services/authentication_service/flask_resources/utils.py
@@ -1,9 +1,12 @@
 import json
+from copy import deepcopy
 from functools import wraps
 from typing import Tuple
 
-from flask import Request, request
+from flask import Request, Response, request
 from werkzeug.datastructures import ImmutableMultiDict
+
+from monkey_island.cc.services.authentication_service.token import Token
 
 
 def get_username_password_from_request(_request: Request) -> Tuple[str, str]:
@@ -35,3 +38,14 @@ def include_auth_token(func):
         return func(*args, **kwargs)
 
     return decorated_function
+
+
+def add_refresh_token_to_response(response: Response, refresh_token: Token) -> Response:
+    """
+    Adds a refresh token to the response
+    :param response: A Flask Response object
+    """
+    new_data = deepcopy(response.json)
+    new_data["response"]["user"]["refresh_token"] = refresh_token
+    response.data = json.dumps(new_data).encode()
+    return response

--- a/monkey/monkey_island/cc/services/authentication_service/flask_resources/utils.py
+++ b/monkey/monkey_island/cc/services/authentication_service/flask_resources/utils.py
@@ -42,8 +42,11 @@ def include_auth_token(func):
 
 def add_refresh_token_to_response(response: Response, refresh_token: Token) -> Response:
     """
-    Adds a refresh token to the response
+    Returns a copy of the response object with the refresh token added to it
+
     :param response: A Flask Response object
+    :param refresh_token: Refresh token to add to the response
+    :return: A Flask Response object
     """
     new_data = deepcopy(response.json)
     new_data["response"]["user"]["refresh_token"] = refresh_token

--- a/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/conftest.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/conftest.py
@@ -15,12 +15,14 @@ from monkey_island.cc.services.authentication_service.flask_resources import (
     RegistrationStatus,
 )
 
+REFRESH_TOKEN = "refresh_token"
+
 
 @pytest.fixture
 def mock_authentication_facade():
     mock_service = MagicMock(spec=AuthenticationFacade)
     mock_service.generate_refresh_token = MagicMock()
-    mock_service.generate_refresh_token.return_value = "refresh_token"
+    mock_service.generate_refresh_token.return_value = REFRESH_TOKEN
 
     return mock_service
 

--- a/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/conftest.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/conftest.py
@@ -19,6 +19,8 @@ from monkey_island.cc.services.authentication_service.flask_resources import (
 @pytest.fixture
 def mock_authentication_facade():
     mock_service = MagicMock(spec=AuthenticationFacade)
+    mock_service.generate_refresh_token = MagicMock()
+    mock_service.generate_refresh_token.return_value = "refresh_token"
 
     return mock_service
 

--- a/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/flask_resources/test_login.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/flask_resources/test_login.py
@@ -13,6 +13,14 @@ USERNAME = "test_user"
 PASSWORD = "test_password"
 TEST_REQUEST = f'{{"username": "{USERNAME}", "password": "{PASSWORD}"}}'
 FLASK_LOGIN_IMPORT = "monkey_island.cc.services.authentication_service.flask_resources.login.login"
+LOGIN_RESPONSE_DATA = (
+    b'{"response": {"user": {"authentication_token": "abcdefg"}, "csrf_token": "hijklmnop"}}'
+)
+LOGIN_RESPONSE = Response(
+    response=LOGIN_RESPONSE_DATA,
+    status=HTTPStatus.OK,
+    mimetype="application/json",
+)
 
 
 @pytest.fixture
@@ -28,12 +36,7 @@ def make_login_request(flask_client):
 def test_credential_parsing(
     monkeypatch, make_login_request, mock_authentication_facade: AuthenticationFacade
 ):
-    monkeypatch.setattr(
-        FLASK_LOGIN_IMPORT,
-        lambda: Response(
-            status=HTTPStatus.OK,
-        ),
-    )
+    monkeypatch.setattr(FLASK_LOGIN_IMPORT, lambda: LOGIN_RESPONSE)
 
     make_login_request(TEST_REQUEST)
     mock_authentication_facade.handle_successful_login.assert_called_with(USERNAME, PASSWORD)
@@ -45,12 +48,7 @@ def test_empty_credentials(make_login_request, mock_authentication_facade: Authe
 
 
 def test_login_successful(make_login_request, monkeypatch):
-    monkeypatch.setattr(
-        FLASK_LOGIN_IMPORT,
-        lambda: Response(
-            status=HTTPStatus.OK,
-        ),
-    )
+    monkeypatch.setattr(FLASK_LOGIN_IMPORT, lambda: LOGIN_RESPONSE)
 
     response = make_login_request(TEST_REQUEST)
 
@@ -104,12 +102,7 @@ def test_login_invalid_request(
 def test_login_error(
     monkeypatch, make_login_request, mock_authentication_facade: AuthenticationFacade
 ):
-    monkeypatch.setattr(
-        FLASK_LOGIN_IMPORT,
-        lambda: Response(
-            status=HTTPStatus.OK,
-        ),
-    )
+    monkeypatch.setattr(FLASK_LOGIN_IMPORT, lambda: LOGIN_RESPONSE)
     mock_authentication_facade.handle_successful_login = MagicMock(side_effect=Exception())
 
     response = make_login_request(TEST_REQUEST)

--- a/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/flask_resources/test_login.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/flask_resources/test_login.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from flask import Response
+from tests.unit_tests.monkey_island.cc.services.authentication_service.conftest import REFRESH_TOKEN
 
 from monkey_island.cc.services.authentication_service.authentication_facade import (
     AuthenticationFacade,
@@ -53,6 +54,7 @@ def test_login_successful(make_login_request, monkeypatch):
     response = make_login_request(TEST_REQUEST)
 
     assert response.status_code == HTTPStatus.OK
+    assert response.json["response"]["user"]["refresh_token"] == REFRESH_TOKEN
 
 
 def test_login_failure(

--- a/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/flask_resources/test_register.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/flask_resources/test_register.py
@@ -15,6 +15,14 @@ TEST_REQUEST = f'{{"username": "{USERNAME}", "password": "{PASSWORD}"}}'
 FLASK_REGISTER_IMPORT = (
     "monkey_island.cc.services.authentication_service.flask_resources.register.register"
 )
+REGISTER_RESPONSE_DATA = (
+    b'{"response": {"user": {"authentication_token": "abcdefg"}, "csrf_token": "hijklmnop"}}'
+)
+REGISTER_RESPONSE = Response(
+    response=REGISTER_RESPONSE_DATA,
+    status=HTTPStatus.OK,
+    mimetype="application/json",
+)
 
 
 @pytest.fixture
@@ -50,12 +58,7 @@ def test_register__already_registered(
 def test_register_successful(
     monkeypatch, make_registration_request, mock_authentication_facade: AuthenticationFacade
 ):
-    monkeypatch.setattr(
-        FLASK_REGISTER_IMPORT,
-        lambda: Response(
-            status=HTTPStatus.OK,
-        ),
-    )
+    monkeypatch.setattr(FLASK_REGISTER_IMPORT, lambda: REGISTER_RESPONSE)
 
     response = make_registration_request(TEST_REQUEST)
 
@@ -94,10 +97,7 @@ def test_register_invalid_request(
 def test_register_error(
     monkeypatch, make_registration_request, mock_authentication_facade: AuthenticationFacade
 ):
-    monkeypatch.setattr(
-        FLASK_REGISTER_IMPORT,
-        lambda: Response(status=HTTPStatus.OK),
-    )
+    monkeypatch.setattr(FLASK_REGISTER_IMPORT, lambda: REGISTER_RESPONSE)
 
     mock_authentication_facade.handle_successful_registration = MagicMock(side_effect=Exception())
 

--- a/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/flask_resources/test_register.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/flask_resources/test_register.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from flask import Response
+from tests.unit_tests.monkey_island.cc.services.authentication_service.conftest import REFRESH_TOKEN
 
 from monkey_island.cc.services.authentication_service.authentication_facade import (
     AuthenticationFacade,
@@ -63,6 +64,7 @@ def test_register_successful(
     response = make_registration_request(TEST_REQUEST)
 
     assert response.status_code == HTTPStatus.OK
+    assert response.json["response"]["user"]["refresh_token"] == REFRESH_TOKEN
     mock_authentication_facade.handle_successful_registration.assert_called_with(USERNAME, PASSWORD)
 
 


### PR DESCRIPTION
# What does this PR do?

Fixes part of #3137.

Login and registration should respond with a token pair


## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [x] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [x] Any other testing performed?
    > Tested by validating the output of cURL commands to the endpoints 
* [x] If applicable, add screenshots or log transcripts of the feature working
    > ```
    > $ curl -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' --data '{"username": "test", "password": "testtest"}' -k ${ISLAND}/api/register
    > {"meta": {"code": 200}, "response": {"user": {"authentication_token": "WyJmOGMxZTc0YzBkNWM0MjQzYWI4NTE0NDY3MGYzNzRhYiJd.ZCW59Q.RHLJsim5y-SvYb8Nppe1qy_p0UY", "refresh_token": "ImY4YzFlNzRjMGQ1YzQyNDNhYjg1MTQ0NjcwZjM3NGFiIg.ZCW59Q.GaWzjz9XpCu50VItcHp8OYhgk6o"}, "csrf_token": "IjFhMzJmNDdlMzEyYmM1NDNjM2EwOGJlYzBmYWY2ZjI2OGFiZmE2MmIi.ZCW59Q.aPp670PyIpbjDa21IggSRVC1Zic"}}
    >```
    >```
    > $ curl -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' --data '{"username": "test", "password": "testtest"}' -k ${ISLAND}/api/login
    > {"meta": {"code": 200}, "response": {"user": {"authentication_token": "WyJmOGMxZTc0YzBkNWM0MjQzYWI4NTE0NDY3MGYzNzRhYiJd.ZCW6oQ.rDpRYYkGKD5ZqP0mcr3Ht1mdR3U", "refresh_token": "ImY4YzFlNzRjMGQ1YzQyNDNhYjg1MTQ0NjcwZjM3NGFiIg.ZCW6oQ.Fzt20Y92SD1cp7HTcMJrau7zP6Q"}, "csrf_token": "ImRmODNmN2E4Mzg1MTY4MjA5YTgxMGVhYzRiNzNhYmE1NzUwYTZiMjgi.ZCW6oQ.naYnUG37y7TmpBA-LrmCduFDB04"}}
    >```