### PR TITLE
Island: Change access token lifetime to 15 minutes

### DIFF
--- a/monkey/monkey_island/cc/services/authentication_service/configure_flask_security.py
+++ b/monkey/monkey_island/cc/services/authentication_service/configure_flask_security.py
@@ -16,7 +16,7 @@ from .role import Role
 from .user import User
 
 SECRET_FILE_NAME = ".flask_security_configuration.json"
-ACCESS_TOKEN_LIFETIME = 15 * 60  # 15 minutes
+ACCESS_TOKEN_TTL = 15 * 60  # 15 minutes
 # Refresh token lives for 3 minutes longer than auth token
 REFRESH_TOKEN_EXPIRATION_DELTA = 3 * 60  # 3 minutes
 
@@ -32,7 +32,7 @@ def configure_flask_security(app, data_dir: Path) -> Security:
     app.config["SECURITY_REGISTERABLE"] = True
     app.config["SECURITY_SEND_REGISTER_EMAIL"] = False
 
-    app.config["SECURITY_TOKEN_MAX_AGE"] = ACCESS_TOKEN_LIFETIME
+    app.config["SECURITY_TOKEN_MAX_AGE"] = ACCESS_TOKEN_TTL
     # This is a custom configuration parameter that we use
     # It shows how much time the refresh token is valid after the auth token expires
     app.config["SECURITY_REFRESH_TOKEN_TIMEDELTA"] = REFRESH_TOKEN_EXPIRATION_DELTA

--- a/monkey/monkey_island/cc/services/authentication_service/configure_flask_security.py
+++ b/monkey/monkey_island/cc/services/authentication_service/configure_flask_security.py
@@ -16,7 +16,7 @@ from .role import Role
 from .user import User
 
 SECRET_FILE_NAME = ".flask_security_configuration.json"
-AUTH_EXPIRATION_TIME = 30 * 60  # 30 minutes
+ACCESS_TOKEN_LIFETIME = 15 * 60  # 15 minutes
 # Refresh token lives for 3 minutes longer than auth token
 REFRESH_TOKEN_EXPIRATION_DELTA = 3 * 60  # 3 minutes
 
@@ -32,7 +32,7 @@ def configure_flask_security(app, data_dir: Path) -> Security:
     app.config["SECURITY_REGISTERABLE"] = True
     app.config["SECURITY_SEND_REGISTER_EMAIL"] = False
 
-    app.config["SECURITY_TOKEN_MAX_AGE"] = AUTH_EXPIRATION_TIME
+    app.config["SECURITY_TOKEN_MAX_AGE"] = ACCESS_TOKEN_LIFETIME
     # This is a custom configuration parameter that we use
     # It shows how much time the refresh token is valid after the auth token expires
     app.config["SECURITY_REFRESH_TOKEN_TIMEDELTA"] = REFRESH_TOKEN_EXPIRATION_DELTA


### PR DESCRIPTION
This change means that the user will be able to be AFK for at most 17 minutes 59 seconds before getting logged out. Refresh token being 3 minutes means that the user has to be AFK at least 3 minutes to get logged out.

Issue: #3137

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
