### PR TITLE
3078 otp expiration timer

### DIFF
--- a/monkey/monkey_island/cc/ui/package-lock.json
+++ b/monkey/monkey_island/cc/ui/package-lock.json
@@ -46,6 +46,7 @@
         "react-router-dom": "6.8.2",
         "react-spinners": "0.13.8",
         "react-table": "^6.11.5",
+        "react-timer-hook": "^3.0.5",
         "react-tsparticles": "^1.43.1",
         "remark-breaks": "3.0.2",
         "request": "^2.88.2",
@@ -13655,6 +13656,15 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-timer-hook": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/react-timer-hook/-/react-timer-hook-3.0.5.tgz",
+      "integrity": "sha512-n+98SdmYvui2ne3KyWb3Ldu4k0NYQa3g/VzW6VEIfZJ8GAk/jJsIY700M8Nd2vNSTj05c7wKyQfJBqZ0x7zfiA==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
     },
     "node_modules/react-to-print": {
       "version": "2.14.12",

--- a/monkey/monkey_island/cc/ui/package.json
+++ b/monkey/monkey_island/cc/ui/package.json
@@ -100,6 +100,7 @@
     "react-router-dom": "6.8.2",
     "react-spinners": "0.13.8",
     "react-table": "^6.11.5",
+    "react-timer-hook": "^3.0.5",
     "react-tsparticles": "^1.43.1",
     "remark-breaks": "3.0.2",
     "request": "^2.88.2",

--- a/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/RunManually/LocalManualRunOptions.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/RunManually/LocalManualRunOptions.js
@@ -30,7 +30,7 @@ const getContents = (props) => {
     seconds,
     minutes,
     restart
-  } = useTimer({ expiryTimestamp: new Date() });
+  } = useTimer({ expiryTimestamp: new Date(), onExpire: () => getOtp() });
 
   const [otp, setOtp] = useState('');
   const [osType, setOsType] = useState(OS_TYPES.WINDOWS_64);

--- a/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/RunManually/LocalManualRunOptions.js
+++ b/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/RunManually/LocalManualRunOptions.js
@@ -8,6 +8,8 @@ import GenerateLocalLinuxCurl from '../commands/local_linux_curl';
 import CommandDisplay from '../utils/CommandDisplay';
 import {Button, Form, Col} from 'react-bootstrap';
 import IslandHttpClient, { APIEndpoint } from '../../../IslandHttpClient';
+import { useTimer } from 'react-timer-hook';
+import { CommandExpirationTimer } from '../utils/CommandExpirationTimer';
 
 
 const LocalManualRunOptions = (props) => {
@@ -23,6 +25,12 @@ const getContents = (props) => {
     [OS_TYPES.WINDOWS_64]: 'Windows 64bit',
     [OS_TYPES.LINUX_64]: 'Linux 64bit'
   }
+
+  const {
+    seconds,
+    minutes,
+    restart
+  } = useTimer({ expiryTimestamp: new Date() });
 
   const [otp, setOtp] = useState('');
   const [osType, setOsType] = useState(OS_TYPES.WINDOWS_64);
@@ -52,8 +60,9 @@ const getContents = (props) => {
   }
 
   function getOtp() {
-    IslandHttpClient.get(APIEndpoint.agent_otp).then(res =>{
+    IslandHttpClient.get(APIEndpoint.agent_otp).then(res => {
       setOtp(res.body.otp);
+      restart(newExpirationTime());
     });
   }
 
@@ -64,6 +73,13 @@ const getContents = (props) => {
       return [{type: 'cURL', command: GenerateLocalLinuxCurl(selectedIp, customUsername, otp)},
         {type: 'Wget', command: GenerateLocalLinuxWget(selectedIp, customUsername, otp)}]
     }
+  }
+
+  function newExpirationTime() {
+    const time = new Date();
+    time.setSeconds(time.getSeconds() + 120);
+    console.log('timeout is now: ' + time);
+    return time;
   }
 
   return (
@@ -84,9 +100,14 @@ const getContents = (props) => {
         </div>
       </div>
       <CommandDisplay commands={commands} onCopy={getOtp} />
-        <Col lg={{span:3, offset: 9}} md={{span:4, offset: 8}} sm={{span:4, offset: 8}} xs={12}>
-          <Button style={{'float': 'right'}} title="Refresh OTP" onClick={getOtp}>Refresh OTP</Button>
-        </Col>
+      <div style={{marginTop: '-0.5em', marginBottom: '0.5em'}}>
+        <CommandExpirationTimer minutes={minutes} seconds={seconds}/>
+      </div>
+      <div style={{textAlign: 'right'}}>
+        <span>
+          <Button title="Copy to Clipboard" onClick={getOtp}>Refresh OTP</Button>
+        </span>
+      </div>
     </>
   )
 }

--- a/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/utils/CommandExpirationTimer.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/pages/RunMonkeyPage/utils/CommandExpirationTimer.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export function CommandExpirationTimer({ minutes, seconds }) {
+
+    function formatDigits(number) {
+      return number.toLocaleString('en-US', { minimumIntegerDigits: 2, useGrouping: false})
+    }
+
+    function generateText() {
+      if (minutes === 0 && seconds === 0) {
+        return 'Command expired';
+      } else {
+        return 'Command expires in: ' + formatDigits(minutes) + ':' + formatDigits(seconds);
+      }
+    }
+
+    return (
+      <div style={{textAlign: 'right'}}>
+        {generateText()}
+      </div>
+    );
+}


### PR DESCRIPTION
# What does this PR do?

Fixes part of #3078 by displaying a countdown timer for the OTP expiration.

- Displays a countdown timer for command expiration

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
