### PR TITLE
3078 revoke agent tokens

### DIFF
--- a/envs/monkey_zoo/blackbox/test_blackbox.py
+++ b/envs/monkey_zoo/blackbox/test_blackbox.py
@@ -307,6 +307,9 @@ def test_agent__logout(island):
     agent_requests.post(GET_AGENTS_ENDPOINT, data=agent_registration_dict)
     assert agent_requests.post(LOGOUT_ENDPOINT, data=None).status_code == HTTPStatus.OK
 
+    # After logout, agent should not be able to access any endpoints
+    assert agent_requests.get(GET_AGENT_OTP_ENDPOINT).status_code == HTTPStatus.UNAUTHORIZED
+
 
 # NOTE: These test methods are ordered to give time for the slower zoo machines
 # to boot up and finish starting services.

--- a/envs/monkey_zoo/blackbox/test_blackbox.py
+++ b/envs/monkey_zoo/blackbox/test_blackbox.py
@@ -290,7 +290,6 @@ def test_agent__logout(island):
     island_requests = MonkeyIslandRequests(island)
     island_requests.login()
     response = island_requests.get(GET_AGENT_OTP_ENDPOINT)
-    print(f"response: {response.json()}")
     otp = response.json()["otp"]
 
     agent_requests = AgentRequests(island, LOGOUT_AGENT_ID, OTP(otp))

--- a/envs/monkey_zoo/blackbox/test_blackbox.py
+++ b/envs/monkey_zoo/blackbox/test_blackbox.py
@@ -123,7 +123,7 @@ def register(island_client):
         GET_MACHINES_ENDPOINT,
     ],
 )
-def test_logout(island, authenticated_endpoint):
+def test_island_logout(island, authenticated_endpoint):
     monkey_island_requests = MonkeyIslandRequests(island)
     # Prove that we can't access authenticated endpoints without logging in
     resp = monkey_island_requests.get(authenticated_endpoint)
@@ -286,7 +286,7 @@ def test_agent__cannot_access_nonagent_endpoints(island):
 LOGOUT_AGENT_ID = uuid4()
 
 
-def test_agent__logout(island):
+def test_agent_logout(island):
     island_requests = MonkeyIslandRequests(island)
     island_requests.login()
     response = island_requests.get(GET_AGENT_OTP_ENDPOINT)

--- a/monkey/monkey_island/cc/event_queue/i_island_event_queue.py
+++ b/monkey/monkey_island/cc/event_queue/i_island_event_queue.py
@@ -7,6 +7,7 @@ from . import IslandEventSubscriber
 class IslandEventTopic(Enum):
     AGENT_HEARTBEAT = auto()
     AGENT_REGISTERED = auto()
+    AGENT_TIMED_OUT = auto()
     CLEAR_SIMULATION_DATA = auto()
     RESET_AGENT_CONFIGURATION = auto()
     SET_ISLAND_MODE = auto()

--- a/monkey/monkey_island/cc/services/authentication_service/authentication_facade.py
+++ b/monkey/monkey_island/cc/services/authentication_service/authentication_facade.py
@@ -63,7 +63,7 @@ class AuthenticationFacade:
         """
         user = self._datastore.find_user(username=username)
         if user is not None:
-            self.revoke_all_tokens_for_user(user)  # Redundant?
+            self.revoke_all_tokens_for_user(user)
             self._datastore.delete_user(user)
 
     def revoke_all_tokens_for_user(self, user: User):

--- a/monkey/monkey_island/cc/services/authentication_service/authentication_facade.py
+++ b/monkey/monkey_island/cc/services/authentication_service/authentication_facade.py
@@ -55,6 +55,17 @@ class AuthenticationFacade:
         )
         return not self._datastore.find_user(roles=[island_api_user_role])
 
+    def remove_user(self, username: str):
+        """
+        Unregisters a user, removing all tokens in the process
+
+        :param username: Username of the user to unregister
+        """
+        user = self._datastore.find_user(username=username)
+        if user is not None:
+            self.revoke_all_tokens_for_user(user)  # Redundant?
+            self._datastore.delete_user(user)
+
     def revoke_all_tokens_for_user(self, user: User):
         """
         Revokes all tokens for a specific user

--- a/monkey/monkey_island/cc/services/authentication_service/authentication_facade.py
+++ b/monkey/monkey_island/cc/services/authentication_service/authentication_facade.py
@@ -43,6 +43,7 @@ class AuthenticationFacade:
         self._token_parser = token_parser
         self._otp_repository = otp_repository
         self._otp_read_lock = Lock()
+        self._user_lock = Lock()
 
     def needs_registration(self) -> bool:
         """
@@ -59,12 +60,15 @@ class AuthenticationFacade:
         """
         Unregisters a user, removing all tokens in the process
 
+        Idempotent. Will not do anything if the user does not exist.
+
         :param username: Username of the user to unregister
         """
-        user = self._datastore.find_user(username=username)
-        if user is not None:
-            self.revoke_all_tokens_for_user(user)
-            self._datastore.delete_user(user)
+        with self._user_lock:
+            user = self._datastore.find_user(username=username)
+            if user is not None:
+                self.revoke_all_tokens_for_user(user)
+                self._datastore.delete_user(user)
 
     def revoke_all_tokens_for_user(self, user: User):
         """

--- a/monkey/monkey_island/cc/services/authentication_service/flask_resources/logout.py
+++ b/monkey/monkey_island/cc/services/authentication_service/flask_resources/logout.py
@@ -1,4 +1,5 @@
 import logging
+from http import HTTPStatus
 
 from flask import Response, make_response
 from flask.typing import ResponseValue
@@ -9,7 +10,9 @@ from flask_security.views import logout
 from monkey_island.cc.flask_utils import AbstractResource, responses
 from monkey_island.cc.services.authentication_service import AccountRole
 
+from ..account_role import AccountRole
 from ..authentication_facade import AuthenticationFacade
+from ..user import User
 
 logger = logging.getLogger(__name__)
 
@@ -36,4 +39,11 @@ class Logout(AbstractResource):
         if not isinstance(response, Response):
             return responses.make_response_to_invalid_request()
 
+        if response.status_code == HTTPStatus.OK:
+            self._remove_agent_user(current_user)
+
         return make_response(response)
+
+    def _remove_agent_user(self, user: User):
+        if user.has_role(AccountRole.AGENT.name):
+            self._authentication_facade.remove_user(user.username)

--- a/monkey/monkey_island/cc/services/authentication_service/flask_resources/logout.py
+++ b/monkey/monkey_island/cc/services/authentication_service/flask_resources/logout.py
@@ -9,10 +9,9 @@ from flask_security.views import logout
 
 from monkey_island.cc.flask_utils import AbstractResource, responses
 from monkey_island.cc.services.authentication_service import AccountRole
-
-from ..account_role import AccountRole
-from ..authentication_facade import AuthenticationFacade
-from ..user import User
+from monkey_island.cc.services.authentication_service.authentication_facade import (
+    AuthenticationFacade,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -30,8 +29,11 @@ class Logout(AbstractResource):
     @auth_token_required
     @roles_accepted(AccountRole.AGENT.name, AccountRole.ISLAND_INTERFACE.name)
     def post(self):
+        user_is_agent = False
         try:
             self._authentication_facade.revoke_all_tokens_for_user(current_user)
+            username = current_user.username
+            user_is_agent = current_user.has_role(AccountRole.AGENT.name)
             response: ResponseValue = logout()
         except Exception:
             return responses.make_response_to_invalid_request()
@@ -40,10 +42,7 @@ class Logout(AbstractResource):
             return responses.make_response_to_invalid_request()
 
         if response.status_code == HTTPStatus.OK:
-            self._remove_agent_user(current_user)
+            if user_is_agent:
+                self._authentication_facade.remove_user(username)
 
         return make_response(response)
-
-    def _remove_agent_user(self, user: User):
-        if user.has_role(AccountRole.AGENT.name):
-            self._authentication_facade.remove_user(user.username)

--- a/monkey/monkey_island/cc/services/authentication_service/register_event_handlers.py
+++ b/monkey/monkey_island/cc/services/authentication_service/register_event_handlers.py
@@ -1,0 +1,36 @@
+from common import DIContainer
+from common.agent_events import AbstractAgentEvent, AgentShutdownEvent
+from common.event_queue import IAgentEventQueue
+from common.types import AgentID
+from monkey_island.cc.event_queue import IIslandEventQueue, IslandEventTopic
+
+from .authentication_facade import AuthenticationFacade
+
+
+def register_event_handlers(container: DIContainer, authentication_facade: AuthenticationFacade):
+    agent_event_queue = container.resolve(IAgentEventQueue)
+    island_event_queue = container.resolve(IIslandEventQueue)
+
+    agent_event_queue.subscribe_type(
+        AgentShutdownEvent, unregister_agent_on_shutdown(authentication_facade)
+    )
+    island_event_queue.subscribe(
+        IslandEventTopic.AGENT_TIMED_OUT, unregister_agent_on_timeout(authentication_facade)
+    )
+
+
+class unregister_agent_on_shutdown:
+    def __init__(self, authentication_facade: AuthenticationFacade):
+        self._authentication_facade = authentication_facade
+
+    def __call__(self, event: AbstractAgentEvent):
+        agent_id = event.source
+        self._authentication_facade.remove_user(str(agent_id))
+
+
+class unregister_agent_on_timeout:
+    def __init__(self, authentication_facade: AuthenticationFacade):
+        self._authentication_facade = authentication_facade
+
+    def __call__(self, agent_id: AgentID):
+        self._authentication_facade.remove_user(str(agent_id))

--- a/monkey/monkey_island/cc/services/authentication_service/register_event_handlers.py
+++ b/monkey/monkey_island/cc/services/authentication_service/register_event_handlers.py
@@ -10,13 +10,13 @@ from .authentication_facade import AuthenticationFacade
 def register_event_handlers(container: DIContainer, authentication_facade: AuthenticationFacade):
     agent_event_queue = container.resolve(IAgentEventQueue)
     island_event_queue = container.resolve(IIslandEventQueue)
-    agent_remover = AgentRemover(authentication_facade)
+    agent_remover = AgentUserRemover(authentication_facade)
 
     agent_event_queue.subscribe_type(AgentShutdownEvent, agent_remover.remove_on_shutdown)
     island_event_queue.subscribe(IslandEventTopic.AGENT_TIMED_OUT, agent_remover.remove_on_timeout)
 
 
-class AgentRemover:
+class AgentUserRemover:
     def __init__(self, authentication_facade: AuthenticationFacade):
         self._authentication_facade = authentication_facade
 

--- a/monkey/monkey_island/cc/services/authentication_service/setup.py
+++ b/monkey/monkey_island/cc/services/authentication_service/setup.py
@@ -5,7 +5,9 @@ from flask_limiter import Limiter
 from flask_security import Security
 
 from common import DIContainer
-from monkey_island.cc.event_queue import IIslandEventQueue
+from common.agent_events import AbstractAgentEvent, AgentShutdownEvent
+from common.event_queue import IAgentEventQueue
+from monkey_island.cc.event_queue import IIslandEventQueue, IslandEventTopic
 from monkey_island.cc.server_utils.encryption import ILockableEncryptor
 
 from . import IOTPGenerator
@@ -17,6 +19,11 @@ from .mongo_otp_repository import MongoOTPRepository
 from .token_generator import TokenGenerator
 from .token_parser import TokenParser
 
+# TODO:
+# - Subscribe to the agent timeout event
+# - Subscribe to the agent shutdown event
+# - Handle the events by removing the agent user from the datastore
+
 
 def setup_authentication(api, app: Flask, container: DIContainer, data_dir: Path, limiter: Limiter):
     security = configure_flask_security(app, data_dir)
@@ -25,6 +32,7 @@ def setup_authentication(api, app: Flask, container: DIContainer, data_dir: Path
     otp_generator = AuthenticationServiceOTPGenerator(authentication_facade)
     container.register_instance(IOTPGenerator, otp_generator)
 
+    _register_event_handlers(container, authentication_facade)
     register_resources(api, authentication_facade, otp_generator, limiter)
 
     # revoke all old tokens so that the user has to log in again on startup
@@ -50,3 +58,32 @@ def _build_authentication_facade(container: DIContainer, security: Security):
         token_parser,
         container.resolve(MongoOTPRepository),
     )
+
+
+def _register_event_handlers(container: DIContainer, authentication_facade: AuthenticationFacade):
+    agent_event_queue = container.resolve(IAgentEventQueue)
+    island_event_queue = container.resolve(IIslandEventQueue)
+
+    agent_event_queue.subscribe_type(
+        AgentShutdownEvent, unregister_agent_on_shutdown(authentication_facade)
+    )
+    island_event_queue.subscribe(
+        IslandEventTopic.AGENT_TIMED_OUT, unregister_agent_on_timeout(authentication_facade)
+    )
+
+
+class unregister_agent_on_shutdown:
+    def __init__(self, authentication_facade: AuthenticationFacade):
+        self._authentication_facade = authentication_facade
+
+    def __call__(self, event: AbstractAgentEvent):
+        agent_id = event.source
+        self._authentication_facade.remove_user(str(agent_id))
+
+
+class unregister_agent_on_timeout:
+    def __init__(self, authentication_facade: AuthenticationFacade):
+        self._authentication_facade = authentication_facade
+
+    def __call__(self, agent_id: str):
+        self._authentication_facade.remove_user(agent_id)

--- a/monkey/monkey_island/cc/services/authentication_service/setup.py
+++ b/monkey/monkey_island/cc/services/authentication_service/setup.py
@@ -7,6 +7,7 @@ from flask_security import Security
 from common import DIContainer
 from common.agent_events import AbstractAgentEvent, AgentShutdownEvent
 from common.event_queue import IAgentEventQueue
+from common.types import AgentID
 from monkey_island.cc.event_queue import IIslandEventQueue, IslandEventTopic
 from monkey_island.cc.server_utils.encryption import ILockableEncryptor
 
@@ -18,11 +19,6 @@ from .flask_resources import register_resources
 from .mongo_otp_repository import MongoOTPRepository
 from .token_generator import TokenGenerator
 from .token_parser import TokenParser
-
-# TODO:
-# - Subscribe to the agent timeout event
-# - Subscribe to the agent shutdown event
-# - Handle the events by removing the agent user from the datastore
 
 
 def setup_authentication(api, app: Flask, container: DIContainer, data_dir: Path, limiter: Limiter):
@@ -85,5 +81,5 @@ class unregister_agent_on_timeout:
     def __init__(self, authentication_facade: AuthenticationFacade):
         self._authentication_facade = authentication_facade
 
-    def __call__(self, agent_id: str):
-        self._authentication_facade.remove_user(agent_id)
+    def __call__(self, agent_id: AgentID):
+        self._authentication_facade.remove_user(str(agent_id))

--- a/monkey/tests/unit_tests/monkey_island/cc/island_event_handlers/test_agent_heartbeat_monitor.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/island_event_handlers/test_agent_heartbeat_monitor.py
@@ -80,13 +80,13 @@ def test_multiple_agents(
     assert agent_2.stop_time == datetime.fromtimestamp(200, tz=pytz.UTC)
     assert agent_3.stop_time == agent_3.start_time
     assert mock_island_event_queue.publish.call_count == 3
-    assert mock_island_event_queue.publish.called_with(
-        IslandEventTopic.AGENT_TIMED_OUT, agent_id=AGENT_ID_1
+    mock_island_event_queue.publish.assert_any_call(
+        IslandEventTopic.AGENT_TIMED_OUT, agent_id=AGENT_ID_3
     )
-    assert mock_island_event_queue.publish.called_with(
+    mock_island_event_queue.publish.assert_any_call(
         IslandEventTopic.AGENT_TIMED_OUT, agent_id=AGENT_ID_2
     )
-    assert mock_island_event_queue.publish.called_with(
+    mock_island_event_queue.publish.assert_any_call(
         IslandEventTopic.AGENT_TIMED_OUT, agent_id=AGENT_ID_3
     )
 

--- a/monkey/tests/unit_tests/monkey_island/cc/island_event_handlers/test_agent_heartbeat_monitor.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/island_event_handlers/test_agent_heartbeat_monitor.py
@@ -1,5 +1,6 @@
 import time
 from datetime import datetime, timedelta
+from unittest.mock import MagicMock
 from uuid import UUID
 
 import pytest
@@ -7,6 +8,7 @@ import pytz
 from tests.monkey_island import InMemoryAgentRepository
 
 from common import AgentHeartbeat
+from monkey_island.cc.event_queue import IIslandEventQueue, IslandEventTopic
 from monkey_island.cc.island_event_handlers import AgentHeartbeatMonitor
 from monkey_island.cc.models import Agent
 
@@ -44,16 +46,23 @@ AGENT_ALREADY_STOPPED = Agent(
 
 
 @pytest.fixture
+def mock_island_event_queue() -> IIslandEventQueue:
+    return MagicMock(spec=IIslandEventQueue)
+
+
+@pytest.fixture
 def in_memory_agent_repository():
     return InMemoryAgentRepository()
 
 
 @pytest.fixture
-def agent_heartbeat_handler(in_memory_agent_repository):
-    return AgentHeartbeatMonitor(in_memory_agent_repository)
+def agent_heartbeat_handler(in_memory_agent_repository, mock_island_event_queue):
+    return AgentHeartbeatMonitor(in_memory_agent_repository, mock_island_event_queue)
 
 
-def test_multiple_agents(agent_heartbeat_handler, in_memory_agent_repository):
+def test_multiple_agents(
+    agent_heartbeat_handler, in_memory_agent_repository, mock_island_event_queue
+):
     in_memory_agent_repository.upsert_agent(AGENT_1)
     in_memory_agent_repository.upsert_agent(AGENT_2)
     in_memory_agent_repository.upsert_agent(AGENT_3)
@@ -70,17 +79,34 @@ def test_multiple_agents(agent_heartbeat_handler, in_memory_agent_repository):
     assert agent_1.stop_time == datetime.fromtimestamp(110, tz=pytz.UTC)
     assert agent_2.stop_time == datetime.fromtimestamp(200, tz=pytz.UTC)
     assert agent_3.stop_time == agent_3.start_time
+    assert mock_island_event_queue.publish.call_count == 3
+    assert mock_island_event_queue.publish.called_with(
+        IslandEventTopic.AGENT_TIMED_OUT, agent_id=AGENT_ID_1
+    )
+    assert mock_island_event_queue.publish.called_with(
+        IslandEventTopic.AGENT_TIMED_OUT, agent_id=AGENT_ID_2
+    )
+    assert mock_island_event_queue.publish.called_with(
+        IslandEventTopic.AGENT_TIMED_OUT, agent_id=AGENT_ID_3
+    )
 
 
-def test_no_heartbeat_received(agent_heartbeat_handler, in_memory_agent_repository):
+def test_no_heartbeat_received(
+    agent_heartbeat_handler, in_memory_agent_repository, mock_island_event_queue
+):
     in_memory_agent_repository.upsert_agent(AGENT_1)
 
     agent_heartbeat_handler.set_unresponsive_agents_stop_time()
 
     assert in_memory_agent_repository.get_agent_by_id(AGENT_ID_1).stop_time == AGENT_1.start_time
+    mock_island_event_queue.publish.assert_called_once_with(
+        IslandEventTopic.AGENT_TIMED_OUT, agent_id=AGENT_ID_1
+    )
 
 
-def test_agent_shutdown_unexpectedly(agent_heartbeat_handler, in_memory_agent_repository):
+def test_agent_shutdown_unexpectedly(
+    agent_heartbeat_handler, in_memory_agent_repository, mock_island_event_queue
+):
     last_heartbeat = datetime.fromtimestamp(8675309, tz=pytz.UTC)
     in_memory_agent_repository.upsert_agent(AGENT_1)
     agent_heartbeat_handler.handle_agent_heartbeat(
@@ -90,10 +116,13 @@ def test_agent_shutdown_unexpectedly(agent_heartbeat_handler, in_memory_agent_re
     agent_heartbeat_handler.set_unresponsive_agents_stop_time()
 
     assert in_memory_agent_repository.get_agent_by_id(AGENT_ID_1).stop_time == last_heartbeat
+    mock_island_event_queue.publish.assert_called_once_with(
+        IslandEventTopic.AGENT_TIMED_OUT, agent_id=AGENT_ID_1
+    )
 
 
 def test_leave_stop_time_if_heartbeat_arrives_late(
-    agent_heartbeat_handler, in_memory_agent_repository
+    agent_heartbeat_handler, in_memory_agent_repository, mock_island_event_queue
 ):
     in_memory_agent_repository.upsert_agent(AGENT_ALREADY_STOPPED)
     expected_stop_time = AGENT_ALREADY_STOPPED.stop_time
@@ -108,9 +137,12 @@ def test_leave_stop_time_if_heartbeat_arrives_late(
         in_memory_agent_repository.get_agent_by_id(AGENT_ID_ALREADY_STOPPED).stop_time
         == expected_stop_time
     )
+    assert not mock_island_event_queue.publish.called
 
 
-def test_use_latest_heartbeat(agent_heartbeat_handler, in_memory_agent_repository):
+def test_use_latest_heartbeat(
+    agent_heartbeat_handler, in_memory_agent_repository, mock_island_event_queue
+):
     last_heartbeat = datetime.fromtimestamp(8675309, tz=pytz.UTC)
     in_memory_agent_repository.upsert_agent(AGENT_1)
     agent_heartbeat_handler.handle_agent_heartbeat(AGENT_ID_1, AgentHeartbeat(timestamp=1000))
@@ -121,9 +153,14 @@ def test_use_latest_heartbeat(agent_heartbeat_handler, in_memory_agent_repositor
     agent_heartbeat_handler.set_unresponsive_agents_stop_time()
 
     assert in_memory_agent_repository.get_agent_by_id(AGENT_ID_1).stop_time == last_heartbeat
+    mock_island_event_queue.publish.assert_called_once_with(
+        IslandEventTopic.AGENT_TIMED_OUT, agent_id=AGENT_ID_1
+    )
 
 
-def test_heartbeat_not_expired(agent_heartbeat_handler, in_memory_agent_repository):
+def test_heartbeat_not_expired(
+    agent_heartbeat_handler, in_memory_agent_repository, mock_island_event_queue
+):
     in_memory_agent_repository.upsert_agent(AGENT_1)
     agent_heartbeat_handler.handle_agent_heartbeat(
         AGENT_ID_1, AgentHeartbeat(timestamp=time.time())
@@ -132,3 +169,4 @@ def test_heartbeat_not_expired(agent_heartbeat_handler, in_memory_agent_reposito
     agent_heartbeat_handler.set_unresponsive_agents_stop_time()
 
     assert in_memory_agent_repository.get_agent_by_id(AGENT_ID_1).stop_time is None
+    assert not mock_island_event_queue.publish.called

--- a/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/flask_resources/test_logout.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/flask_resources/test_logout.py
@@ -52,9 +52,7 @@ def test_logout_failed(
     assert not mock_authentication_facade.remove_user.called
 
 
-def test_logout_successful(
-    monkeypatch, make_logout_request, mock_authentication_facade: AuthenticationFacade
-):
+def test_logout_successful(monkeypatch, make_logout_request):
     monkeypatch.setattr(
         FLASK_LOGOUT_IMPORT,
         lambda: Response(
@@ -65,11 +63,18 @@ def test_logout_successful(
     response = make_logout_request("")
 
     assert response.status_code == HTTPStatus.OK
-    assert not mock_authentication_facade.remove_user.called
 
 
+@pytest.mark.parametrize(
+    "role, expect_remove_user_called",
+    [(AccountRole.AGENT.name, True), (AccountRole.ISLAND_INTERFACE.name, False)],
+)
 def test_logout__removes_agent_user(
-    monkeypatch, make_logout_request, mock_authentication_facade: AuthenticationFacade
+    monkeypatch,
+    make_logout_request,
+    role: AccountRole,
+    expect_remove_user_called: bool,
+    mock_authentication_facade: AuthenticationFacade,
 ):
     monkeypatch.setattr(
         FLASK_LOGOUT_IMPORT,
@@ -78,8 +83,8 @@ def test_logout__removes_agent_user(
         ),
     )
     mock_user = MagicMock(spec=User)
-    mock_user.username = "test_agent_user"
-    mock_user.has_role = lambda role: role == AccountRole.AGENT.name
+    mock_user.username = "test_user"
+    mock_user.has_role = lambda r: r == role
     monkeypatch.setattr(
         "monkey_island.cc.services.authentication_service.flask_resources.logout.current_user",
         mock_user,
@@ -88,4 +93,7 @@ def test_logout__removes_agent_user(
     response = make_logout_request("")
 
     assert response.status_code == HTTPStatus.OK
-    mock_authentication_facade.remove_user.assert_called_once_with(mock_user.username)
+    if expect_remove_user_called:
+        mock_authentication_facade.remove_user.assert_called_once_with(mock_user.username)
+    else:
+        assert not mock_authentication_facade.remove_user.called

--- a/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/test_authentication_service.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/test_authentication_service.py
@@ -182,6 +182,25 @@ def test_generate_new_token_pair__fails_if_token_invalid(
         authentication_facade.generate_new_token_pair(refresh_token)
 
 
+def test_remove_user__removes_user(
+    mock_user_datastore: UserDatastore, authentication_facade: AuthenticationFacade
+):
+    user = User(username=USERNAME, password=PASSWORD, fs_uniquifier="a")
+    mock_user_datastore.find_user.return_value = user
+
+    authentication_facade.remove_user(user.username)
+
+    mock_user_datastore.delete_user.assert_called_once_with(user)
+
+
+def test_remove_user__does_nothing_if_user_does_not_exist(
+    mock_user_datastore: UserDatastore, authentication_facade: AuthenticationFacade
+):
+    mock_user_datastore.find_user = MagicMock(return_value=None)
+
+    authentication_facade.remove_user(USERNAME)
+
+
 def test_revoke_all_tokens_for_all_users(
     mock_user_datastore: UserDatastore,
     authentication_facade: AuthenticationFacade,

--- a/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/test_authentication_service.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/test_authentication_service.py
@@ -193,7 +193,7 @@ def test_remove_user__removes_user(
     mock_user_datastore.delete_user.assert_called_once_with(user)
 
 
-def test_remove_user__does_nothing_if_user_does_not_exist(
+def test_remove_user__is_idempotent(
     mock_user_datastore: UserDatastore, authentication_facade: AuthenticationFacade
 ):
     mock_user_datastore.find_user = MagicMock(return_value=None)


### PR DESCRIPTION
# What does this PR do?

Fixes part of #3078 by removing users for agents that have shut down or timed out.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [x] Any other testing performed?
    > Manually tested agent user removed after agent shutdown and when agent times out
    > Ran the logout BB test to test that the agent user is removed after agent logs out
* [ ] If applicable, add screenshots or log transcripts of the feature working
