### PR TITLE
Island: Use SHA256 to hash OTPs

### DIFF
--- a/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/test_mongo_otp_repository.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/test_mongo_otp_repository.py
@@ -11,7 +11,6 @@ from monkey_island.cc.repositories import (
     StorageError,
     UnknownRecordError,
 )
-from monkey_island.cc.server_utils.encryption import ILockableEncryptor
 from monkey_island.cc.services.authentication_service.i_otp_repository import IOTPRepository
 from monkey_island.cc.services.authentication_service.mongo_otp_repository import MongoOTPRepository
 
@@ -35,10 +34,8 @@ def mongo_client() -> mongomock.MongoClient:
 
 
 @pytest.fixture
-def otp_repository(
-    mongo_client: mongomock.MongoClient, repository_encryptor: ILockableEncryptor
-) -> IOTPRepository:
-    return MongoOTPRepository(mongo_client, repository_encryptor)
+def otp_repository(mongo_client: mongomock.MongoClient) -> IOTPRepository:
+    return MongoOTPRepository(mongo_client)
 
 
 @pytest.fixture
@@ -59,7 +56,7 @@ def error_raising_mongo_client() -> mongomock.MongoClient:
 def error_raising_otp_repository(
     error_raising_mongo_client, repository_encryptor
 ) -> IOTPRepository:
-    return MongoOTPRepository(error_raising_mongo_client, repository_encryptor)
+    return MongoOTPRepository(error_raising_mongo_client)
 
 
 def test_insert_otp(otp_repository: IOTPRepository):


### PR DESCRIPTION
# What does this PR do?

Fixes a bug in MongoOTPRepository

The encryption algorithm is not deterministic, making searching impossible. Salted SHA256 is considered to be secure enough for one-time passwords with a 2-minute TTL.

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [x] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [x] Any other testing performed?
    > Tested locally with a hard-coded OTP and Postman
* [ ] If applicable, add screenshots or log transcripts of the feature working
