### PR TITLE
3078 invalidate tokens on startup

### DIFF
--- a/monkey/monkey_island/cc/services/authentication_service/authentication_facade.py
+++ b/monkey/monkey_island/cc/services/authentication_service/authentication_facade.py
@@ -129,7 +129,7 @@ class AuthenticationFacade:
     def _otp_ttl_elapsed(self, otp: OTP) -> bool:
         return self._otp_repository.get_expiration(otp) < time.monotonic()
 
-    def invalidate_all_otps(self):
+    def revoke_all_otps(self):
         self._otp_repository.reset()
 
     def create_user(

--- a/monkey/monkey_island/cc/services/authentication_service/authentication_facade.py
+++ b/monkey/monkey_island/cc/services/authentication_service/authentication_facade.py
@@ -126,6 +126,12 @@ class AuthenticationFacade:
             except UnknownRecordError:
                 return False
 
+    def _otp_ttl_elapsed(self, otp: OTP) -> bool:
+        return self._otp_repository.get_expiration(otp) < time.monotonic()
+
+    def invalidate_all_otps(self):
+        self._otp_repository.reset()
+
     def create_user(
         self, username: str, password: str, roles: Sequence[str], email: str = "dummy@dummy.com"
     ) -> User:
@@ -135,9 +141,6 @@ class AuthenticationFacade:
             roles=roles,
             email=email,
         )
-
-    def _otp_ttl_elapsed(self, otp: OTP) -> bool:
-        return self._otp_repository.get_expiration(otp) < time.monotonic()
 
     def handle_successful_registration(self, username: str, password: str):
         self._reset_island_data()

--- a/monkey/monkey_island/cc/services/authentication_service/setup.py
+++ b/monkey/monkey_island/cc/services/authentication_service/setup.py
@@ -29,6 +29,7 @@ def setup_authentication(api, app: Flask, container: DIContainer, data_dir: Path
 
     # revoke all old tokens so that the user has to log in again on startup
     authentication_facade.revoke_all_tokens_for_all_users()
+    authentication_facade.invalidate_all_otps()
 
 
 def _build_authentication_facade(container: DIContainer, security: Security):

--- a/monkey/monkey_island/cc/services/authentication_service/setup.py
+++ b/monkey/monkey_island/cc/services/authentication_service/setup.py
@@ -29,7 +29,7 @@ def setup_authentication(api, app: Flask, container: DIContainer, data_dir: Path
 
     # revoke all old tokens so that the user has to log in again on startup
     authentication_facade.revoke_all_tokens_for_all_users()
-    authentication_facade.invalidate_all_otps()
+    authentication_facade.revoke_all_otps()
 
 
 def _build_authentication_facade(container: DIContainer, security: Security):


### PR DESCRIPTION
# What does this PR do?

Fixes part of #3078 by invalidating OTPs on Island startup.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
