### PR TITLE
3078 rate limit users

### DIFF
--- a/monkey/monkey_island/cc/services/authentication_service/flask_resources/refresh_authentication_token.py
+++ b/monkey/monkey_island/cc/services/authentication_service/flask_resources/refresh_authentication_token.py
@@ -4,7 +4,6 @@ from threading import Lock
 
 from flask import make_response
 from flask_limiter import Limiter, RateLimitExceeded
-from flask_limiter.util import get_remote_address
 from flask_login import current_user
 from flask_security import auth_token_required
 
@@ -38,7 +37,7 @@ class RefreshAuthenticationToken(AbstractResource):
             if RefreshAuthenticationToken.limiter is None:
                 RefreshAuthenticationToken.limiter = limiter.limit(
                     f"{MAX_REFRESH_AUTHENTICATION_TOKEN_REQUESTS_PER_SECOND}/second",
-                    key_func=get_remote_address,
+                    key_func=lambda: current_user.username,
                     per_method=True,
                 )
 


### PR DESCRIPTION
# What does this PR do?

Fixes part of #3078 by rate limiting endpoints by user instead of IP.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
    - Added a BB test
* [x] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by running the BB test testing the OTP endpoint
* [ ] If applicable, add screenshots or log transcripts of the feature working
