### PR TITLE
Hadoop port filtering improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ file.
 The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+### Added
+- `PortScanData.open` property. #3238
+
 ## [2.1.0] - 2023-04-19
 ### Added
 - Logout button. #3063

--- a/monkey/agent_plugins/exploiters/hadoop/manifest.yaml
+++ b/monkey/agent_plugins/exploiters/hadoop/manifest.yaml
@@ -7,7 +7,7 @@ target_operating_systems:
   - linux
   - windows
 title: Hadoop/YARN Exploiter
-version: 1.0.0
+version: 2.0.0
 description: >-
   Remote code execution on Hadoop server with YARN and default settings.
 

--- a/monkey/agent_plugins/exploiters/hadoop/src/hadoop_exploiter.py
+++ b/monkey/agent_plugins/exploiters/hadoop/src/hadoop_exploiter.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable, Sequence
+from typing import Callable, Sequence, Set
 
 from common.types import AgentID, Event, NetworkPort, NetworkService, PortStatus
 from infection_monkey.exploit import IAgentOTPProvider
@@ -122,7 +122,7 @@ class HadoopExploiter:
 
 def _build_potential_urls(target_host: TargetHost, options: HadoopOptions) -> Sequence[str]:
     # Note: Currently using a set, so ordering is not preserved
-    ports = set(_filter_out_closed_ports(options.target_ports, target_host))
+    ports = _filter_out_closed_ports(options.target_ports, target_host)
     if options.try_all_discovered_http_ports:
         ports.update(_get_open_http_ports(target_host))
 
@@ -134,13 +134,8 @@ def _build_potential_urls(target_host: TargetHost, options: HadoopOptions) -> Se
 
 def _filter_out_closed_ports(
     ports: Sequence[NetworkPort], target_host: TargetHost
-) -> Sequence[NetworkPort]:
-    closed_ports = [
-        port
-        for port, psd in target_host.ports_status.tcp_ports.items()
-        if psd.status == PortStatus.CLOSED
-    ]
-    return [port for port in ports if port not in closed_ports]
+) -> Set[NetworkPort]:
+    return {port for port in ports if port not in target_host.ports_status.tcp_ports.closed}
 
 
 def _get_open_http_ports(target_host: TargetHost) -> Sequence[NetworkPort]:

--- a/monkey/agent_plugins/exploiters/hadoop/src/hadoop_exploiter.py
+++ b/monkey/agent_plugins/exploiters/hadoop/src/hadoop_exploiter.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Callable, Sequence, Set
 
-from common.types import AgentID, Event, NetworkPort, NetworkService, PortStatus
+from common.types import AgentID, Event, NetworkPort, NetworkService
 from infection_monkey.exploit import IAgentOTPProvider
 from infection_monkey.exploit.tools import HTTPBytesServer
 from infection_monkey.exploit.tools.web_tools import build_urls
@@ -139,11 +139,8 @@ def _filter_out_closed_ports(
 
 
 def _get_open_http_ports(target_host: TargetHost) -> Sequence[NetworkPort]:
-    return [
-        port
-        for port, psd in target_host.ports_status.tcp_ports.items()
-        if psd.status == PortStatus.OPEN and psd.service == NetworkService.HTTP
-    ]
+    tcp_ports = target_host.ports_status.tcp_ports
+    return [port for port in tcp_ports.open if tcp_ports[port].service == NetworkService.HTTP]
 
 
 def _stop_agent_binary_http_server(

--- a/monkey/infection_monkey/i_puppet/target_host.py
+++ b/monkey/infection_monkey/i_puppet/target_host.py
@@ -18,11 +18,16 @@ class PortScanDataDict(UserDict[NetworkPort, PortScanData]):
         super().__setitem__(key, value)
 
     @property
+    def open(self) -> Set[NetworkPort]:
+        return self._filter_ports_by_status(PortStatus.OPEN)
+
+    @property
     def closed(self) -> Set[NetworkPort]:
+        return self._filter_ports_by_status(PortStatus.CLOSED)
+
+    def _filter_ports_by_status(self, status: PortStatus) -> Set[NetworkPort]:
         return {
-            port
-            for port, port_scan_data in self.data.items()
-            if port_scan_data.status == PortStatus.CLOSED
+            port for port, port_scan_data in self.data.items() if port_scan_data.status == status
         }
 
 

--- a/monkey/tests/unit_tests/infection_monkey/i_puppet/test_target_host.py
+++ b/monkey/tests/unit_tests/infection_monkey/i_puppet/test_target_host.py
@@ -70,3 +70,17 @@ def test_closed_tcp_ports():
     )
 
     assert tcp_ports.closed == expected_closed_ports
+
+
+def test_open_tcp_ports():
+    expected_open_ports = {1, 3}
+    tcp_ports = PortScanDataDict(
+        {
+            NetworkPort(1): PortScanData(port=1, status=PortStatus.OPEN),
+            NetworkPort(2): PortScanData(port=2, status=PortStatus.CLOSED),
+            NetworkPort(3): PortScanData(port=3, status=PortStatus.OPEN),
+            NetworkPort(4): PortScanData(port=4, status=PortStatus.CLOSED),
+        }
+    )
+
+    assert tcp_ports.open == expected_open_ports


### PR DESCRIPTION
# What does this PR do?

Adds `open` property to `PortScanDataDict`
Reimplements some Hadoop methods using the `open` and `closed` properties from `PortScanDataDict`

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing?
* [x] Was the CHANGELOG.md updated to reflect the changes?
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Do all unit tests pass?
* [x] Do all end-to-end tests pass?
* [ ] ~Any other testing performed?~
