### PR TITLE
Fix data dir plugin overwrite

### DIFF
--- a/monkey/common/utils/windows_permissions.py
+++ b/monkey/common/utils/windows_permissions.py
@@ -20,6 +20,9 @@ def get_security_descriptor_for_owner_only_permissions():
     dacl.SetEntriesInAcl(entries)
 
     security_descriptor = win32security.SECURITY_DESCRIPTOR()
+    security_descriptor.SetSecurityDescriptorControl(
+        win32security.SE_DACL_PROTECTED, win32security.SE_DACL_PROTECTED
+    )
     security_descriptor.SetSecurityDescriptorDacl(1, dacl, 0)
 
     return security_descriptor

--- a/monkey/monkey_island/.gitignore
+++ b/monkey/monkey_island/.gitignore
@@ -1,0 +1,2 @@
+# Built plugins
+plugins/

--- a/monkey/monkey_island/cc/setup/data_dir.py
+++ b/monkey/monkey_island/cc/setup/data_dir.py
@@ -107,6 +107,13 @@ def _copy_plugins_into_data_dir(data_dir_path: Path):
 
     for plugin_tar_file in plugin_tar_files:
         plugin_dest_path = plugins_dir / plugin_tar_file.name
+        if plugin_dest_path.exists():
+            logger.info(
+                "Skipping plugin tar file copy: "
+                f"destination file {plugin_dest_path} already exists."
+            )
+            continue
+
         try:
             shutil.copy2(plugin_tar_file, plugin_dest_path)
         except FileNotFoundError:

--- a/monkey/monkey_island/cc/setup/data_dir.py
+++ b/monkey/monkey_island/cc/setup/data_dir.py
@@ -115,6 +115,7 @@ def _copy_plugins_into_data_dir(data_dir_path: Path):
             continue
 
         try:
+            logger.info(f"Copying plugin tar file: {plugin_tar_file} -> {plugin_dest_path}")
             shutil.copy2(plugin_tar_file, plugin_dest_path)
         except FileNotFoundError:
             logger.exception(

--- a/monkey/monkey_island/cc/setup/data_dir.py
+++ b/monkey/monkey_island/cc/setup/data_dir.py
@@ -95,20 +95,23 @@ def _data_dir_version_mismatch_exists(data_dir_path: Path) -> bool:
 
 
 def _copy_plugins_into_data_dir(data_dir_path: Path):
-    plugin_path = Path(MONKEY_ISLAND_ABS_PATH) / PLUGIN_DIR_NAME
+    plugin_source_dir = Path(MONKEY_ISLAND_ABS_PATH) / PLUGIN_DIR_NAME
     try:
-        plugins_destination_path = _create_plugins_dir(data_dir_path)
-        plugin_tar_paths = list(plugin_path.glob("*.tar"))
+        plugins_dir = _create_plugins_dir(data_dir_path)
+        plugin_tar_files = list(plugin_source_dir.glob("*.tar"))
     except Exception:
-        logger.exception(f"An error occured while creating plugins data directory: {plugin_path}")
+        logger.exception(
+            f"An error occured while creating plugins data directory: {plugin_source_dir}"
+        )
         return
 
-    for plugin_tar_path in plugin_tar_paths:
+    for plugin_tar_file in plugin_tar_files:
+        plugin_dest_path = plugins_dir / plugin_tar_file.name
         try:
-            shutil.copy2(plugin_tar_path, plugins_destination_path)
+            shutil.copy2(plugin_tar_file, plugin_dest_path)
         except FileNotFoundError:
             logger.exception(
-                f"An error occured while copying plugin {plugin_tar_path} "
+                f"An error occured while copying plugin {plugin_tar_file} "
                 f"to the data directory: {data_dir_path}"
             )
 

--- a/monkey/tests/monkey_island/utils.py
+++ b/monkey/tests/monkey_island/utils.py
@@ -1,4 +1,4 @@
-from pathlib import WindowsPath
+from pathlib import PosixPath, WindowsPath
 
 from common.utils.environment import is_windows_os
 
@@ -41,7 +41,7 @@ def _get_acl_and_sid_from_path(path: WindowsPath):
     return acl, sid
 
 
-def assert_linux_permissions(path: str):
+def assert_linux_permissions(path: PosixPath):
     st = os.stat(path)
 
     expected_mode = stat.S_IRWXU

--- a/monkey/tests/unit_tests/monkey_island/cc/setup/test_data_dir.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/setup/test_data_dir.py
@@ -181,3 +181,21 @@ def test_plugins_in_plugin_dir_not_overwitten(
     setup_data_dir(temp_data_dir_path)
 
     assert plugin_dir_plugin.read_text() == original_plugin_contents
+
+
+def test_setup_plugin_dir_existing_dir_permissions(temp_data_dir_path):
+    if is_windows_os():
+        assert_permissions = assert_windows_permissions
+    else:
+        assert_permissions = assert_linux_permissions
+
+    plugin_dir_path = temp_data_dir_path / PLUGIN_DIR_NAME
+    temp_data_dir_path.mkdir()
+    plugin_dir_path.mkdir()
+
+    assert plugin_dir_path.is_dir()
+    with pytest.raises(AssertionError):
+        assert_permissions(plugin_dir_path)
+
+    setup_data_dir(plugin_dir_path)
+    assert_permissions(plugin_dir_path)

--- a/monkey/tests/unit_tests/monkey_island/cc/setup/test_data_dir.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/setup/test_data_dir.py
@@ -157,3 +157,27 @@ def test_plugins_copied_to_plugin_dir(monkeypatch, tmp_path, temp_data_dir_path)
 
     setup_data_dir(temp_data_dir_path)
     assert (temp_data_dir_path / PLUGIN_DIR_NAME / test_plugin.name).read_text() == plugin_contents
+
+
+def test_plugins_in_plugin_dir_not_overwitten(
+    monkeypatch, tmp_path, temp_data_dir_path, temp_version_file_path
+):
+    temp_data_dir_path.mkdir()
+    temp_version_file_path.write_text(current_version)
+
+    test_plugin_name = "test_plugin.tar"
+    original_plugin_contents = "original plugin"
+    plugin_dir = temp_data_dir_path / PLUGIN_DIR_NAME
+    plugin_dir.mkdir()
+    plugin_dir_plugin = plugin_dir / test_plugin_name
+    plugin_dir_plugin.write_text(original_plugin_contents)
+
+    plugin_src_dir = tmp_path / PLUGIN_DIR_NAME
+    plugin_src_dir.mkdir()
+    new_plugin = plugin_src_dir / test_plugin_name
+    new_plugin.write_text("new plugin")
+    monkeypatch.setattr("monkey_island.cc.setup.data_dir.MONKEY_ISLAND_ABS_PATH", tmp_path)
+
+    setup_data_dir(temp_data_dir_path)
+
+    assert plugin_dir_plugin.read_text() == original_plugin_contents


### PR DESCRIPTION
# What does this PR do?

Prevents plugins in the `data_dir` from being overwritten on Island startup

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing?
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
