### PR TITLE
3198 Packerize the tunneling 9, 10 images

### DIFF
--- a/envs/monkey_zoo/docs/zoo_network.md
+++ b/envs/monkey_zoo/docs/zoo_network.md
@@ -125,7 +125,7 @@ This document describes Infection Monkey’s test network.
 <tbody>
 <tr class="odd">
 <td>OS:</td>
-<td><strong>Ubuntu 16.04.05 x64</strong></td>
+<td><strong>Ubuntu 18.04.6 x64</strong></td>
 </tr>
 <tr class="even">
 <td>Software:</td>

--- a/envs/monkey_zoo/docs/zoo_network.md
+++ b/envs/monkey_zoo/docs/zoo_network.md
@@ -161,7 +161,7 @@ This document describes Infection Monkey’s test network.
 <tbody>
 <tr class="odd">
 <td>OS:</td>
-<td><strong>Ubuntu 16.04.05 x64</strong></td>
+<td><strong>Ubuntu 18.04.6 x64</strong></td>
 </tr>
 <tr class="even">
 <td>Software:</td>

--- a/envs/monkey_zoo/packer/setup_tunneling_10.yml
+++ b/envs/monkey_zoo/packer/setup_tunneling_10.yml
@@ -1,0 +1,20 @@
+---
+- name: Configure Tunneling-10
+  hosts: all
+  remote_user: root
+
+  tasks:
+    - name: Add m0nk3y user
+      user:
+        name: m0nk3y
+        password: "{{ '3Q=(Ge(+&w]*' | password_hash('sha512') }}"
+        groups:
+          - sudo
+        append: yes
+    - name: Enable Password Authentication
+      lineinfile:
+        dest: /etc/ssh/sshd_config
+        regexp: '^PasswordAuthentication.*no'
+        line: "PasswordAuthentication yes"
+        state: present
+        backup: yes

--- a/envs/monkey_zoo/packer/setup_tunneling_9.yml
+++ b/envs/monkey_zoo/packer/setup_tunneling_9.yml
@@ -1,0 +1,20 @@
+---
+- name: Configure Tunneling-9
+  hosts: all
+  remote_user: root
+
+  tasks:
+    - name: Add m0nk3y user
+      user:
+        name: m0nk3y
+        password: "{{ '`))jU7L(w}' | password_hash('sha512') }}"
+        groups:
+          - sudo
+        append: yes
+    - name: Enable Password Authentication
+      lineinfile:
+        dest: /etc/ssh/sshd_config
+        regexp: '^PasswordAuthentication.*no'
+        line: "PasswordAuthentication yes"
+        state: present
+        backup: yes

--- a/envs/monkey_zoo/packer/tunneling.pkr.hcl
+++ b/envs/monkey_zoo/packer/tunneling.pkr.hcl
@@ -28,12 +28,28 @@ source "googlecompute" "tunneling-9" {
     account_file = "${var.account_file}"
 }
 
+source "googlecompute" "tunneling-10" {
+    image_name = "tunneling-10"
+    project_id = "${var.project_id}"
+    source_image = "${var.source_image}"
+    zone = "${var.zone}"
+    disk_size = 10
+    machine_type = "${var.machine_type}"
+    ssh_username = "root"
+    account_file = "${var.account_file}"
+}
+
 build {
     sources = [
-        "source.googlecompute.tunneling-9"
+        "source.googlecompute.tunneling-9",
+        "source.googlecompute.tunneling-10"
     ]
     provisioner "ansible" {
         only = ["googlecompute.tunneling-9"]
         playbook_file = "./packer/setup_tunneling_9.yml"
+    }
+    provisioner "ansible" {
+        only = ["googlecompute.tunneling-10"]
+        playbook_file = "./packer/setup_tunneling_10.yml"
     }
 }

--- a/envs/monkey_zoo/packer/tunneling.pkr.hcl
+++ b/envs/monkey_zoo/packer/tunneling.pkr.hcl
@@ -1,0 +1,39 @@
+variable "project_id" {
+    type = string
+}
+variable "zone" {
+    type = string
+    default = "europe-west3-a"
+}
+variable "machine_type" {
+    type = string
+    default = "n1-standard-2"
+}
+variable "source_image" {
+    type = string
+    default = "ubuntu-1804-bionic-v20230418"
+}
+variable "account_file" {
+    type = string
+}
+
+source "googlecompute" "tunneling-9" {
+    image_name = "tunneling-9"
+    project_id = "${var.project_id}"
+    source_image = "${var.source_image}"
+    zone = "${var.zone}"
+    disk_size = 10
+    machine_type = "${var.machine_type}"
+    ssh_username = "root"
+    account_file = "${var.account_file}"
+}
+
+build {
+    sources = [
+        "source.googlecompute.tunneling-9"
+    ]
+    provisioner "ansible" {
+        only = ["googlecompute.tunneling-9"]
+        playbook_file = "./packer/setup_tunneling_9.yml"
+    }
+}

--- a/envs/monkey_zoo/terraform/monkey_zoo.tf
+++ b/envs/monkey_zoo/terraform/monkey_zoo.tf
@@ -146,10 +146,9 @@ resource "google_compute_instance" "tunneling-9" {
   }
 }
 
-resource "google_compute_instance_from_template" "tunneling-10" {
-  name                     = "${local.resource_prefix}tunneling-10"
-  source_instance_template = local.default_ubuntu
-  machine_type             = "n1-standard-2"
+resource "google_compute_instance" "tunneling-10" {
+  name         = "${local.resource_prefix}tunneling-10"
+  machine_type = "n1-standard-2"
   boot_disk {
     initialize_params {
       image = data.google_compute_image.tunneling-10.self_link

--- a/envs/monkey_zoo/terraform/monkey_zoo.tf
+++ b/envs/monkey_zoo/terraform/monkey_zoo.tf
@@ -123,10 +123,9 @@ resource "google_compute_instance_from_template" "hadoop-3" {
   }
 }
 
-resource "google_compute_instance_from_template" "tunneling-9" {
-  name                     = "${local.resource_prefix}tunneling-9"
-  source_instance_template = local.default_ubuntu
-  machine_type             = "n1-standard-2"
+resource "google_compute_instance" "tunneling-9" {
+  name         = "${local.resource_prefix}tunneling-9"
+  machine_type = "n1-standard-2"
   boot_disk {
     initialize_params {
       image = data.google_compute_image.tunneling-9.self_link


### PR DESCRIPTION
# What does this PR do?

Fixes #3198.

Adds packer scripts for the tunneling-9 and tunneling-10 machines.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [x] Any other testing performed?
    > Tested by running the depth-4 test in the test1 zoo using the generated images
* [ ] If applicable, add screenshots or log transcripts of the feature working
