### PR TITLE
3167 load credential collector plugins

### DIFF
--- a/monkey/infection_monkey/plugin/credentials_collector_plugin_factory.py
+++ b/monkey/infection_monkey/plugin/credentials_collector_plugin_factory.py
@@ -1,0 +1,27 @@
+from typing import Callable
+
+from serpentarium import SingleUsePlugin
+
+from common.event_queue import IAgentEventPublisher
+from common.types import AgentID
+
+from .i_plugin_factory import IPluginFactory
+
+
+class CredentialsCollectorPluginFactory(IPluginFactory):
+    def __init__(
+        self,
+        agent_id: AgentID,
+        agent_event_publisher: IAgentEventPublisher,
+        create_plugin: Callable[..., SingleUsePlugin],
+    ):
+        self._agent_id = agent_id
+        self._agent_event_publisher = agent_event_publisher
+        self._create_plugin = create_plugin
+
+    def create(self, plugin_name: str) -> SingleUsePlugin:
+        return self._create_plugin(
+            plugin_name=plugin_name,
+            agent_id=self._agent_id,
+            agent_event_publisher=self._agent_event_publisher,
+        )

--- a/monkey/infection_monkey/plugin/exploiter_plugin_factory.py
+++ b/monkey/infection_monkey/plugin/exploiter_plugin_factory.py
@@ -1,0 +1,42 @@
+from typing import Callable
+
+from serpentarium import SingleUsePlugin
+
+from common.event_queue import IAgentEventPublisher
+from common.types import AgentID
+from infection_monkey.exploit import IAgentBinaryRepository, IAgentOTPProvider
+from infection_monkey.network import TCPPortSelector
+from infection_monkey.propagation_credentials_repository import IPropagationCredentialsRepository
+
+from .i_plugin_factory import IPluginFactory
+
+
+class ExploiterPluginFactory(IPluginFactory):
+    def __init__(
+        self,
+        agent_id: AgentID,
+        agent_binary_repository: IAgentBinaryRepository,
+        agent_event_publisher: IAgentEventPublisher,
+        propagation_credentials_repository: IPropagationCredentialsRepository,
+        tcp_port_selector: TCPPortSelector,
+        otp_provider: IAgentOTPProvider,
+        create_plugin: Callable[..., SingleUsePlugin],
+    ):
+        self._agent_id = agent_id
+        self._agent_binary_repository = agent_binary_repository
+        self._agent_event_publisher = agent_event_publisher
+        self._propagation_credentials_repository = propagation_credentials_repository
+        self._tcp_port_selector = tcp_port_selector
+        self._otp_provider = otp_provider
+        self._create_plugin = create_plugin
+
+    def create(self, plugin_name: str) -> SingleUsePlugin:
+        return self._create_plugin(
+            plugin_name=plugin_name,
+            agent_id=self._agent_id,
+            agent_binary_repository=self._agent_binary_repository,
+            agent_event_publisher=self._agent_event_publisher,
+            propagation_credentials_repository=self._propagation_credentials_repository,
+            tcp_port_selector=self._tcp_port_selector,
+            otp_provider=self._otp_provider,
+        )

--- a/monkey/infection_monkey/plugin/i_plugin_factory.py
+++ b/monkey/infection_monkey/plugin/i_plugin_factory.py
@@ -1,0 +1,19 @@
+from abc import ABC, abstractmethod
+
+from serpentarium import SingleUsePlugin
+
+
+class IPluginFactory(ABC):
+    """
+    Abstract base class for factories that create plugins for specific `AgentPluginType`s
+    """
+
+    @abstractmethod
+    def create(self, plugin_name: str) -> SingleUsePlugin:
+        """
+        Create a plugin with the given name
+
+        :param plugin_name: The name of the plugin to create
+        :return: A plugin with the given name
+        """
+        pass

--- a/monkey/infection_monkey/plugin/multiprocessing_plugin_wrapper.py
+++ b/monkey/infection_monkey/plugin/multiprocessing_plugin_wrapper.py
@@ -1,0 +1,42 @@
+import threading
+from logging import getLogger
+from typing import Any
+
+from serpentarium import MultiUsePlugin, PluginLoader
+
+logger = getLogger(__name__)
+
+# NOTE: This should probably get moved to serpentarium.
+class MultiprocessingPluginWrapper(MultiUsePlugin):
+    """
+    Wraps a MultiprocessingPlugin so it can be used like a MultiUsePlugin
+    """
+
+    process_start_lock = threading.Lock()
+
+    def __init__(self, *, plugin_loader: PluginLoader, plugin_name: str, **kwargs):
+        self._plugin_loader = plugin_loader
+        self._name = plugin_name
+        self._constructor_kwargs = kwargs
+
+    def run(self, **kwargs) -> Any:
+        logger.debug(f"Constructing a new instance of {self._name}")
+        plugin = self._plugin_loader.load_multiprocessing_plugin(
+            plugin_name=self._name, **self._constructor_kwargs
+        )
+
+        # HERE BE DRAGONS! multiprocessing.Process.start() is not thread-safe on Linux when used
+        # with the "spawn" method. See https://github.com/pyinstaller/pyinstaller/issues/7410 for
+        # more details.
+        # UPDATE: This has been resolved in PyInstaller 5.8.0. Consider removing this lock, but
+        # leaving a comment here for future reference.
+        with MultiprocessingPluginWrapper.process_start_lock:
+            logger.debug("Invoking plugin.start()")
+            plugin.start(**kwargs)
+
+        plugin.join()
+        return plugin.return_value
+
+    @property
+    def name(self) -> str:
+        return self._name

--- a/monkey/infection_monkey/puppet/plugin_registry.py
+++ b/monkey/infection_monkey/puppet/plugin_registry.py
@@ -3,39 +3,26 @@ from copy import copy
 from threading import RLock
 from typing import Any, Dict
 
-from serpentarium import PluginLoader, PluginThreadName, SingleUsePlugin
+from serpentarium import PluginThreadName, SingleUsePlugin
 
 from common import OperatingSystem
 from common.agent_plugins import AgentPlugin, AgentPluginType
-from common.event_queue import IAgentEventPublisher
-from common.types import AgentID
-from infection_monkey.exploit import IAgentBinaryRepository, IAgentOTPProvider
 from infection_monkey.i_puppet import UnknownPluginError
 from infection_monkey.island_api_client import IIslandAPIClient, IslandAPIRequestError
-from infection_monkey.network import TCPPortSelector
-from infection_monkey.propagation_credentials_repository import IPropagationCredentialsRepository
+from infection_monkey.plugin.i_plugin_factory import IPluginFactory
 
 from . import PluginSourceExtractor
-from infection_monkey.plugin.multiprocessing_plugin_wrapper import MultiprocessingPluginWrapper
 
 logger = logging.getLogger()
 
 
-# TODO: We should add an ExploiterPluginFactor and pass that to this component instead of passing
-# all of the requirements for exploiters.
 class PluginRegistry:
     def __init__(
         self,
         operating_system: OperatingSystem,
         island_api_client: IIslandAPIClient,
         plugin_source_extractor: PluginSourceExtractor,
-        plugin_loader: PluginLoader,
-        agent_binary_repository: IAgentBinaryRepository,
-        agent_event_publisher: IAgentEventPublisher,
-        propagation_credentials_repository: IPropagationCredentialsRepository,
-        tcp_port_selector: TCPPortSelector,
-        otp_provider: IAgentOTPProvider,
-        agent_id: AgentID,
+        plugin_factories: Dict[AgentPluginType, IPluginFactory],
     ):
         """
         `self._registry` looks like -
@@ -51,14 +38,8 @@ class PluginRegistry:
         self._operating_system = operating_system
         self._island_api_client = island_api_client
         self._plugin_source_extractor = plugin_source_extractor
-        self._plugin_loader = plugin_loader
-        self._agent_binary_repository = agent_binary_repository
-        self._agent_event_publisher = agent_event_publisher
-        self._propagation_credentials_repository = propagation_credentials_repository
-        self._tcp_port_selector = tcp_port_selector
-        self._otp_provider = otp_provider
+        self._plugin_factories = plugin_factories
 
-        self._agent_id = agent_id
         self._lock = RLock()
 
     def get_plugin(self, plugin_type: AgentPluginType, plugin_name: str) -> Any:
@@ -74,18 +55,15 @@ class PluginRegistry:
     def _load_plugin_from_island(self, plugin_name: str, plugin_type: AgentPluginType):
         agent_plugin = self._download_plugin_from_island(plugin_name, plugin_type)
         self._plugin_source_extractor.extract_plugin_source(agent_plugin)
-        multiprocessing_plugin = MultiprocessingPluginWrapper(
-            plugin_loader=self._plugin_loader,
-            plugin_name=plugin_name,
-            reset_modules_cache=False,
-            main_thread_name=PluginThreadName.CALLING_THREAD,
-            agent_id=self._agent_id,
-            agent_binary_repository=self._agent_binary_repository,
-            agent_event_publisher=self._agent_event_publisher,
-            propagation_credentials_repository=self._propagation_credentials_repository,
-            tcp_port_selector=self._tcp_port_selector,
-            otp_provider=self._otp_provider,
-        )
+
+        if plugin_type in self._plugin_factories:
+            factory = self._plugin_factories[plugin_type]
+            multiprocessing_plugin = factory.create(plugin_name)
+        else:
+            raise UnknownPluginError(
+                "Loading of custom plugins has not been implemented for plugin type "
+                f"'{plugin_type.value}'"
+            )
 
         self.load_plugin(plugin_type, plugin_name, multiprocessing_plugin)
 

--- a/monkey/tests/unit_tests/infection_monkey/puppet/test_puppet.py
+++ b/monkey/tests/unit_tests/infection_monkey/puppet/test_puppet.py
@@ -26,12 +26,6 @@ def mock_plugin_registry() -> PluginRegistry:
         MagicMock(),
         MagicMock(),
         MagicMock(),
-        MagicMock(),
-        MagicMock(),
-        MagicMock(),
-        MagicMock(),
-        MagicMock(),
-        AgentID("fd838244-385f-41b4-9904-495e3c7b644e"),
     )
 
 


### PR DESCRIPTION
# What does this PR do?

Fixes part of #3167.

Adds loading of Credentials Collectors to the PluginRegistry

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Do all unit tests pass?
* [x] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
