### PR TITLE
3198 remove sshguard

### DIFF
--- a/envs/monkey_zoo/README.md
+++ b/envs/monkey_zoo/README.md
@@ -27,7 +27,7 @@ scanning times in a real-world scenario and many more.
 Run envs/monkey_zoo/build_images.sh to build the images for the MonkeyZoo. These are the images from which the zoo will be deployed.
 
 Example:
-  ./build_images.sh --project my-gcp-project --account-file /path/to/account_file.json
+  ./build_images.sh --project my-gcp-project --account-file /path/to/gcp_key.json packer/tunneling.pkr.hcl
 
 ## MonkeyZoo network
 

--- a/envs/monkey_zoo/docs/zoo_setup.md
+++ b/envs/monkey_zoo/docs/zoo_setup.md
@@ -3,14 +3,25 @@
 ## Getting started:
 
 Requirements:
-1.  Have `terraform` installed (for installation instructions check this
-    [link](https://learn.hashicorp.com/tutorials/terraform/install-cli)).
-2.  Have a Google Cloud Platform account (upgraded if you want to test
-    whole network at once).
-3.  Have `gcloud` CLI installed (for installation instructions check this
-    [link](https://cloud.google.com/sdk/docs/install#linux))
-4.  Have `monkey/envs/monkey_zoo` folder downloaded as all the instructions are done
-    in there.
+
+- Have `monkey/envs/monkey_zoo` folder downloaded as it contains all the instructions.
+
+- For building images:
+    1.  Have `packer` installed.
+        [[Installation instructions](https://developer.hashicorp.com/packer/tutorials/docker-get-started/get-started-install-cli)]
+    2.  Have `ansible` installed.
+        [[Installation instructions](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-ansible)]
+
+- For deploying instances:
+    1.  Have `terraform` installed.
+        [[Installation instructions](https://learn.hashicorp.com/tutorials/terraform/install-cli)]
+
+- For using the Google Cloud Platform (GCP):
+    1.  Have a Google Cloud Platform account (upgraded if you want to test
+        whole network at once).
+    2.  Have `gcloud` CLI installed.
+        [[Installation instructions](https://cloud.google.com/sdk/docs/install#linux)]
+
 
 To deploy:
 1.  Configure service account for your project:
@@ -32,44 +43,62 @@ To deploy:
     c. Create and download its `Service account key` in JSON and place it in `monkey_zoo/gcp_keys` as `gcp_key.json`.
 
 2.  Get these permissions in our monkeyZoo production project (guardicore-22050661) for your service account.<br>
-    **Note: Ask monkey developers to add them. Check [Infection Monkey documentation](https://techdocs.akamai.com/infection-monkey/docs/welcome-infection-monkey) on how to recieve usage and support**.
+    **Note: Ask monkey developers to add them. Check [Infection Monkey documentation](https://techdocs.akamai.com/infection-monkey/docs/welcome-infection-monkey) on how to receive usage and support**.
 
         Compute Engine -> Compute image user
 
-3.  Change configurations located in the
+3.  (Optional) Generate images
+
+    To build the images, run the script located at `envs/monkey_zoo/build_images.sh`, providing it:
+        - The target project in which the images will be stored
+        - The account file, e.g. `gcp_key.json`
+        - The packer files to build
+
+    For example,
+
+        `build_images.sh -p guardicore-22050661 --account-file gcp_keys/gcp_key.json` packer/tunneling.pkr.hcl
+
+4.  Change configurations located in the
     ../monkey/envs/monkey\_zoo/terraform/config.tf file (don’t forget to
     link to your service account key file):
 
          provider "google" {
 
-         project = "test-000000" // Change to your project id
+           // Change to your project id
+           project = "test-000000"
 
-           region  = "europe-west3" // Change to your desired region or leave default
+           // Change to your desired region or leave default
+           region  = "europe-west3"
 
-           zone    = "europe-west3-b" // Change to your desired zone or leave default
+           // Change to your desired zone or leave default
+           zone    = "europe-west3-b"
 
-           credentials = "${file("../gcp_keys/gcp_key.json")}" // Change to the location and name of the service key.
-                                                               // If you followed instruction above leave it as is
-
+           // Change to the location and name of the service key. If you followed the instructions above, leave it as is
+           // The account must have permissions to use the service account in the below section
+           credentials = file("../gcp_keys/gcp_key.json")
          }
 
          locals {
 
-           resource_prefix = "" // All of the resources will have this prefix.
-                                // Only change if you want to have multiple zoo's in the same project
+           // All of the resources will have this prefix.
+           // Only change if you want to have multiple zoos in the same project
+           resource_prefix = ""
 
-           service_account_email="tester-monkeyZoo-user@testproject-000000.iam.gserviceaccount.com" // Service account email
+           // Service account email. This service account must have permissions to modify instances on your project.
+           service_account_email="tester-monkeyZoo-user@testproject-000000.iam.gserviceaccount.com"
 
-           monkeyzoo_project="guardicore-22050661" // Project where monkeyzoo images are kept. Leave as is.
-
+           // Project where monkeyzoo images are kept. Leave as is.
+           // If deploying images generated using the build_images.sh script,
+           // set to the same project provided to the -p option.
+           monkeyzoo_project="guardicore-22050661"
          }
 
-4.  Run terraform init
+5.  Deploy the zoo
 
-To deploy the network run:<br>
-`cd ../monkey/envs/monkey_zoo/terraform`<br>
-`terraform plan` (review the changes it will make on GCP)<br>
-`terraform apply` (adds machines to these networks)
+    `terraform init`<br>
+    `cd ../monkey/envs/monkey_zoo/terraform`<br>
+    `terraform plan` (review the changes it will make on GCP)<br>
+    `terraform apply` (adds machines to these networks)
 
 
 ## Using MonkeyZoo islands:

--- a/envs/monkey_zoo/packer/setup_tunneling_10.yml
+++ b/envs/monkey_zoo/packer/setup_tunneling_10.yml
@@ -18,3 +18,7 @@
         line: "PasswordAuthentication yes"
         state: present
         backup: yes
+    - name: Remove sshguard
+      apt:
+        name: sshguard
+        state: absent

--- a/envs/monkey_zoo/packer/setup_tunneling_9.yml
+++ b/envs/monkey_zoo/packer/setup_tunneling_9.yml
@@ -18,3 +18,7 @@
         line: "PasswordAuthentication yes"
         state: present
         backup: yes
+    - name: Remove sshguard
+      apt:
+        name: sshguard
+        state: absent


### PR DESCRIPTION
# What does this PR do?

Fixes #3198.

Removes sshguard, which was preventing brute-forcing over SSH, and causing our depth_4 test to fail.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
