### PR TITLE
3163 add identity filtering

### DIFF
--- a/monkey/agent_plugins/exploiters/smb/src/plugin.py
+++ b/monkey/agent_plugins/exploiters/smb/src/plugin.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Sequence
 from uuid import UUID
 
 # common imports
-from common.credentials import LMHash, NTHash, Password
+from common.credentials import LMHash, NTHash, Password, Username
 from common.event_queue import IAgentEventPublisher
 from common.types import Event
 from common.utils.code_utils import del_key
@@ -17,6 +17,7 @@ from infection_monkey.exploit.tools import (
     BruteForceExploiter,
     all_exploitation_ports_are_closed,
     generate_brute_force_credentials,
+    identity_type_filter,
     secret_type_filter,
 )
 from infection_monkey.exploit.tools.helpers import get_agent_dst_path
@@ -53,6 +54,7 @@ class Plugin:
         self._agent_binary_repository = agent_binary_repository
         credentials_generator = partial(
             generate_brute_force_credentials,
+            identity_filter=identity_type_filter([Username]),
             secret_filter=secret_type_filter([LMHash, NTHash, Password]),
         )
         self._credentials_provider = BruteForceCredentialsProvider(

--- a/monkey/agent_plugins/exploiters/wmi/src/plugin.py
+++ b/monkey/agent_plugins/exploiters/wmi/src/plugin.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Sequence
 from uuid import UUID
 
 # common imports
-from common.credentials import LMHash, NTHash, Password
+from common.credentials import LMHash, NTHash, Password, Username
 from common.event_queue import IAgentEventPublisher
 from common.types import Event
 from common.utils.code_utils import del_key
@@ -17,6 +17,7 @@ from infection_monkey.exploit.tools import (
     BruteForceExploiter,
     all_exploitation_ports_are_closed,
     generate_brute_force_credentials,
+    identity_type_filter,
     secret_type_filter,
 )
 from infection_monkey.exploit.tools.helpers import get_agent_dst_path
@@ -59,6 +60,7 @@ class Plugin:
         self._agent_binary_repository = agent_binary_repository
         credentials_generator = partial(
             generate_brute_force_credentials,
+            identity_filter=identity_type_filter([Username]),
             secret_filter=secret_type_filter([LMHash, NTHash, Password]),
         )
         self._credentials_provider = BruteForceCredentialsProvider(

--- a/monkey/infection_monkey/exploit/tools/__init__.py
+++ b/monkey/infection_monkey/exploit/tools/__init__.py
@@ -1,5 +1,9 @@
 from .http_bytes_server import HTTPBytesServer
-from .brute_force_credentials_generator import generate_brute_force_credentials, secret_type_filter
+from .brute_force_credentials_generator import (
+    generate_brute_force_credentials,
+    identity_type_filter,
+    secret_type_filter,
+)
 from .i_remote_access_client import (
     IRemoteAccessClient,
     RemoteAuthenticationError,

--- a/monkey/infection_monkey/exploit/tools/brute_force_credentials_generator.py
+++ b/monkey/infection_monkey/exploit/tools/brute_force_credentials_generator.py
@@ -15,6 +15,14 @@ from typing import (
 from common.credentials import Credentials, Identity, Secret
 
 
+class identity_type_filter:
+    def __init__(self, identity_types: Container[Type[Identity]]):
+        self.identity_types = identity_types
+
+    def __call__(self, identity: Optional[Identity]) -> TypeGuard[Identity]:
+        return type(identity) in self.identity_types
+
+
 class secret_type_filter:
     def __init__(self, secret_types: Container[Type[Secret]]):
         self.secret_types = secret_types

--- a/monkey/tests/unit_tests/infection_monkey/exploit/tools/test_brute_force_credentials_generator.py
+++ b/monkey/tests/unit_tests/infection_monkey/exploit/tools/test_brute_force_credentials_generator.py
@@ -3,8 +3,12 @@ from typing import Callable, Iterable, List, Set
 import pytest
 from tests.data_for_tests.propagation_credentials import IDENTITIES, SECRETS
 
-from common.credentials import Credentials, Identity, LMHash, NTHash, Password, Secret
-from infection_monkey.exploit.tools import generate_brute_force_credentials, secret_type_filter
+from common.credentials import Credentials, Identity, LMHash, NTHash, Password, Secret, Username
+from infection_monkey.exploit.tools import (
+    generate_brute_force_credentials,
+    identity_type_filter,
+    secret_type_filter,
+)
 
 
 def generate_and_compare_credentials(
@@ -248,3 +252,21 @@ def test_secret_type_filter(
     filtered_secrets: Iterable[Secret] = filter(secret_type_filter, SECRETS)
 
     assert list(filtered_secrets) == expected_secrets
+
+
+@pytest.mark.parametrize(
+    "identity_type_filter,expected_identities",
+    [
+        (
+            identity_type_filter([Username]),
+            [IDENTITIES[0], IDENTITIES[2]],
+        ),
+    ],
+)
+def test_identity_type_filter(
+    identity_type_filter: identity_type_filter,
+    expected_identities: List[Identity],
+):
+    filtered_secrets: Iterable[Identity] = filter(identity_type_filter, IDENTITIES)
+
+    assert list(filtered_secrets) == expected_identities

--- a/vulture_allowlist.py
+++ b/vulture_allowlist.py
@@ -136,6 +136,7 @@ User.roles
 User.get_by_id
 User.email
 
+identity_type_filter
 secret_type_filter
 
 # Remove after #3163


### PR DESCRIPTION
# What does this PR do?

Adds identity type filtering to SMB and WMI plugins

It's conceivable that different types of Identities are added, such as email addresses. This PR adds identity type filtering to brute-force exploiter plugins so that they don't crash if new identities are ever added.

ETE tests should be run before this is merged.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Is the TravisCI build passing?
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Do all unit tests pass?
* [x] Do all end-to-end tests pass?
