### PR TITLE
3168 verify credentials collectors os compatibility

### DIFF
--- a/monkey/common/__init__.py
+++ b/monkey/common/__init__.py
@@ -8,4 +8,7 @@ from . import base_models
 from .agent_registration_data import AgentRegistrationData
 from .agent_signals import AgentSignals
 from .agent_heartbeat import AgentHeartbeat
-from .hard_coded_manifests import HARD_CODED_EXPLOITER_MANIFESTS
+from .hard_coded_manifests import (
+    HARD_CODED_EXPLOITER_MANIFESTS,
+    HARD_CODED_CREDENTIALS_COLLECTOR_MANIFESTS,
+)

--- a/monkey/common/hard_coded_manifests/__init__.py
+++ b/monkey/common/hard_coded_manifests/__init__.py
@@ -1,2 +1,3 @@
 from .hard_coded_exploiter_manifests import HARD_CODED_EXPLOITER_MANIFESTS
 from .hard_coded_payloads_manifests import HARD_CODED_PAYLOADS_MANIFESTS
+from .hard_coded_credentials_collector_manifests import HARD_CODED_CREDENTIALS_COLLECTOR_MANIFESTS

--- a/monkey/infection_monkey/master/automated_master.py
+++ b/monkey/infection_monkey/master/automated_master.py
@@ -8,7 +8,7 @@ from egg_timer import EggTimer
 
 from infection_monkey.i_control_channel import IControlChannel, IslandCommunicationError
 from infection_monkey.i_master import IMaster
-from infection_monkey.i_puppet import IPuppet
+from infection_monkey.i_puppet import IPuppet, RejectedRequestError
 from infection_monkey.propagation_credentials_repository import (
     ILegacyPropagationCredentialsRepository,
 )
@@ -179,6 +179,9 @@ class AutomatedMaster(IMaster):
         for p in interruptible_iter(plugins, self._stop, interrupted_message):
             try:
                 callback(p, plugins[p])
+            except RejectedRequestError as err:
+                logger.info(f"Skipping plugin {p} of type {plugin_type}: {err}")
+                continue
             except Exception:
                 logger.exception(
                     f"Got unhandled exception when running {plugin_type} plugin {p}. "

--- a/monkey/infection_monkey/master/automated_master.py
+++ b/monkey/infection_monkey/master/automated_master.py
@@ -178,6 +178,7 @@ class AutomatedMaster(IMaster):
         interrupted_message = f"Received a stop signal, skipping remaining {plugin_type}s"
         for p in interruptible_iter(plugins, self._stop, interrupted_message):
             try:
+                logger.info(f'Trying to run plugin "{p}" of type "{plugin_type}"')
                 callback(p, plugins[p])
             except RejectedRequestError as err:
                 logger.info(f"Skipping plugin {p} of type {plugin_type}: {err}")

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -17,7 +17,11 @@ from pubsub.core import Publisher
 from serpentarium import PluginLoader, PluginThreadName
 from serpentarium.logging import configure_child_process_logger
 
-from common import HARD_CODED_EXPLOITER_MANIFESTS, OperatingSystem
+from common import (
+    HARD_CODED_CREDENTIALS_COLLECTOR_MANIFESTS,
+    HARD_CODED_EXPLOITER_MANIFESTS,
+    OperatingSystem,
+)
 from common.agent_event_serializers import (
     AgentEventSerializerRegistry,
     register_common_agent_event_serializers,
@@ -424,6 +428,7 @@ class InfectionMonkey:
             self._island_api_client,
             self._operating_system,
             HARD_CODED_EXPLOITER_MANIFESTS,
+            HARD_CODED_CREDENTIALS_COLLECTOR_MANIFESTS,
         )
         puppet = Puppet(
             self._agent_event_queue, plugin_registry, plugin_compatibility_verifier, self._agent_id

--- a/monkey/infection_monkey/puppet/plugin_compatibility_verifier.py
+++ b/monkey/infection_monkey/puppet/plugin_compatibility_verifier.py
@@ -20,11 +20,13 @@ class PluginCompatibilityVerifier:
         island_api_client: IIslandAPIClient,
         operating_system: OperatingSystem,
         exploiter_plugin_manifests: Mapping[str, AgentPluginManifest],
+        credentials_collector_plugin_manifests: Mapping[str, AgentPluginManifest] = {},
     ):
         self._island_api_client = island_api_client
         self._operating_system = operating_system
         self._plugin_manifests: Dict[AgentPluginType, Dict[str, AgentPluginManifest]] = {
-            AgentPluginType.EXPLOITER: dict(exploiter_plugin_manifests)
+            AgentPluginType.EXPLOITER: dict(exploiter_plugin_manifests),
+            AgentPluginType.CREDENTIALS_COLLECTOR: dict(credentials_collector_plugin_manifests),
         }
         self._cache_lock = threading.Lock()
 

--- a/monkey/infection_monkey/puppet/puppet.py
+++ b/monkey/infection_monkey/puppet/puppet.py
@@ -45,6 +45,17 @@ class Puppet(IPuppet):
     def run_credentials_collector(
         self, name: str, options: Dict, interrupt: Event
     ) -> Sequence[Credentials]:
+        compatible_with_local_os = (
+            self._plugin_compatibility_verifier.verify_local_operating_system_compatibility(
+                AgentPluginType.CREDENTIALS_COLLECTOR, name
+            )
+        )
+        if not compatible_with_local_os:
+            raise IncompatibleLocalOperatingSystemError(
+                f'The credentials collector, "{name}" is not compatible with the '
+                "local operating system"
+            )
+
         credentials_collector = self._plugin_registry.get_plugin(
             AgentPluginType.CREDENTIALS_COLLECTOR, name
         )


### PR DESCRIPTION
# What does this PR do?

Issue #3168

Adds OS compatibility verification for credentials collectors

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by running manually on Linux.
*  [x] If applicable, add screenshots or log transcripts of the feature working
```
2023-04-28 16:51:19,030 [33260:CredentialsCollectorThread:INFO] automated_master._run_plugins.175: Running credentials collectors
2023-04-28 16:51:19,030 [33260:CredentialsCollectorThread:DEBUG] automated_master._run_plugins.176: Found 2 credentials collector(s) to run
2023-04-28 16:51:19,030 [33260:CredentialsCollectorThread:INFO] automated_master._run_plugins.181: Trying to run plugin "MimikatzCollector" of type "credentials collector"
2023-04-28 16:51:19,030 [33260:CredentialsCollectorThread:INFO] automated_master._run_plugins.184: Skipping plugin MimikatzCollector of type credentials collector: The credentials collector, "MimikatzCollector" is not compatible with the local operating system
2023-04-28 16:51:19,030 [33260:CredentialsCollectorThread:INFO] automated_master._run_plugins.181: Trying to run plugin "SSHCollector" of type "credentials collector"
2023-04-28 16:51:19,030 [33260:CredentialsCollectorThread:INFO] ssh_credential_collector.run.23: Started scanning for SSH credentials
```