### PR TITLE
SNMP: Add class to generate community strings

### DIFF
--- a/monkey/agent_plugins/exploiters/snmp/src/community_string_generator.py
+++ b/monkey/agent_plugins/exploiters/snmp/src/community_string_generator.py
@@ -42,10 +42,15 @@ def _select_credentials_components(
             secrets.append(credentials.secret)
 
     for credential in chain(
-        filter(identity_type_filter, dict.fromkeys(identities)),
-        filter(secret_type_filter, dict.fromkeys(secrets)),
+        filter(identity_type_filter, _deduplicate(identities)),
+        filter(secret_type_filter, _deduplicate(secrets)),
     ):
         yield credential
+
+
+def _deduplicate(iterable: Iterable[CredentialsComponent]) -> Iterable[CredentialsComponent]:
+    # Using dict.fromkeys() instead of set() because dicts preserve order
+    return dict.fromkeys(iterable).keys()
 
 
 def _credentials_component_to_community_string(credential: CredentialsComponent) -> str:

--- a/monkey/agent_plugins/exploiters/snmp/src/community_string_generator.py
+++ b/monkey/agent_plugins/exploiters/snmp/src/community_string_generator.py
@@ -1,59 +1,50 @@
 from itertools import chain
 from typing import Callable, Iterable, List
 
-from common.credentials import Identity, Password, Secret, Username
+from common.credentials import Credentials, Identity, Password, Secret, Username
 from infection_monkey.exploit.tools import identity_type_filter, secret_type_filter
-from infection_monkey.propagation_credentials_repository import IPropagationCredentialsRepository
 
 
-class CommunityStringGenerator:
+def generate_community_strings(credentials: Iterable[Credentials]) -> Iterable[str]:
     """
-    Generates community strings from the credentials in the repository
-    """
+    Yields community strings from credentials
 
-    def __init__(
-        self,
-        propagation_credentials_repository: IPropagationCredentialsRepository,
+    :param credentials: The credentials from which to generate community strings
+    :return: An iterable of potential community strings
+    """
+    for credential in _generate_credentials(
+        credentials,
+        identity_type_filter=identity_type_filter([Username]),
+        secret_type_filter=secret_type_filter([Password]),
     ):
-        self._propagation_credentials_repository = propagation_credentials_repository
+        yield _credential_to_community_string(credential)
 
-    def generate_community_strings(self) -> Iterable[str]:
-        """
-        Yields community strings from the credentials in the repository
 
-        :return: An iterable of potential community strings
-        """
-        for credential in self._generate_credentials(
-            identity_type_filter=identity_type_filter([Username]),
-            secret_type_filter=secret_type_filter([Password]),
-        ):
-            yield self._credential_to_community_string(credential)
+def _generate_credentials(
+    input_credentials: Iterable[Credentials],
+    identity_type_filter: Callable[[Identity], bool] = lambda identity: True,
+    secret_type_filter: Callable[[Identity], bool] = lambda secret: True,
+) -> Iterable[Identity | Secret]:
+    identities: List[Identity] = []
+    secrets: List[Secret] = []
 
-    def _generate_credentials(
-        self,
-        identity_type_filter: Callable[[Identity], bool] = lambda identity: True,
-        secret_type_filter: Callable[[Identity], bool] = lambda secret: True,
-    ) -> Iterable[Identity | Secret]:
-        propagation_credentials = self._propagation_credentials_repository.get_credentials()
-        identities: List[Identity] = []
-        secrets: List[Secret] = []
+    for credentials in input_credentials:
+        if credentials.identity:
+            identities.append(credentials.identity)
+        if credentials.secret:
+            secrets.append(credentials.secret)
 
-        for credentials in propagation_credentials:
-            if credentials.identity:
-                identities.append(credentials.identity)
-            if credentials.secret:
-                secrets.append(credentials.secret)
+    for credential in chain(
+        filter(identity_type_filter, dict.fromkeys(identities)),
+        filter(secret_type_filter, dict.fromkeys(secrets)),
+    ):
+        yield credential
 
-        for credential in chain(
-            filter(identity_type_filter, dict.fromkeys(identities)),
-            filter(secret_type_filter, dict.fromkeys(secrets)),
-        ):
-            yield credential
 
-    def _credential_to_community_string(self, credential: Identity | Secret) -> str:
-        if isinstance(credential, Username):
-            return credential.username
-        elif isinstance(credential, Password):
-            return credential.password.get_secret_value()
-        else:
-            raise TypeError(f"Unexpected credential type: {type(credential)}")
+def _credential_to_community_string(credential: Identity | Secret) -> str:
+    if isinstance(credential, Username):
+        return credential.username
+    elif isinstance(credential, Password):
+        return credential.password.get_secret_value()
+    else:
+        raise TypeError(f"Unexpected credential type: {type(credential)}")

--- a/monkey/agent_plugins/exploiters/snmp/src/community_string_generator.py
+++ b/monkey/agent_plugins/exploiters/snmp/src/community_string_generator.py
@@ -19,15 +19,15 @@ def generate_community_strings(credentials: Iterable[Credentials]) -> Iterable[s
     :param credentials: The credentials from which to generate community strings
     :return: An iterable of potential community strings
     """
-    for credential in _generate_credentials(
+    for credential in _select_credentials_components(
         credentials,
         identity_type_filter=identity_type_filter([Username]),
         secret_type_filter=secret_type_filter([Password]),
     ):
-        yield _credential_to_community_string(credential)
+        yield _credentials_component_to_community_string(credential)
 
 
-def _generate_credentials(
+def _select_credentials_components(
     input_credentials: Iterable[Credentials],
     identity_type_filter: Callable[[Identity], bool] = lambda identity: True,
     secret_type_filter: Callable[[Identity], bool] = lambda secret: True,
@@ -48,7 +48,7 @@ def _generate_credentials(
         yield credential
 
 
-def _credential_to_community_string(credential: CredentialsComponent) -> str:
+def _credentials_component_to_community_string(credential: CredentialsComponent) -> str:
     if isinstance(credential, Username):
         return credential.username
     elif isinstance(credential, Password):

--- a/monkey/agent_plugins/exploiters/snmp/src/community_string_generator.py
+++ b/monkey/agent_plugins/exploiters/snmp/src/community_string_generator.py
@@ -1,0 +1,59 @@
+from itertools import chain
+from typing import Callable, Iterable, List
+
+from common.credentials import Identity, Password, Secret, Username
+from infection_monkey.exploit.tools import identity_type_filter, secret_type_filter
+from infection_monkey.propagation_credentials_repository import IPropagationCredentialsRepository
+
+
+class CommunityStringGenerator:
+    """
+    Generates community strings from the credentials in the repository
+    """
+
+    def __init__(
+        self,
+        propagation_credentials_repository: IPropagationCredentialsRepository,
+    ):
+        self._propagation_credentials_repository = propagation_credentials_repository
+
+    def generate_community_strings(self) -> Iterable[str]:
+        """
+        Yields community strings from the credentials in the repository
+
+        :return: An iterable of potential community strings
+        """
+        for credential in self._generate_credentials(
+            identity_type_filter=identity_type_filter([Username]),
+            secret_type_filter=secret_type_filter([Password]),
+        ):
+            yield self._credential_to_community_string(credential)
+
+    def _generate_credentials(
+        self,
+        identity_type_filter: Callable[[Identity], bool] = lambda identity: True,
+        secret_type_filter: Callable[[Identity], bool] = lambda secret: True,
+    ) -> Iterable[Identity | Secret]:
+        propagation_credentials = self._propagation_credentials_repository.get_credentials()
+        identities: List[Identity] = []
+        secrets: List[Secret] = []
+
+        for credentials in propagation_credentials:
+            if credentials.identity:
+                identities.append(credentials.identity)
+            if credentials.secret:
+                secrets.append(credentials.secret)
+
+        for credential in chain(
+            filter(identity_type_filter, dict.fromkeys(identities)),
+            filter(secret_type_filter, dict.fromkeys(secrets)),
+        ):
+            yield credential
+
+    def _credential_to_community_string(self, credential: Identity | Secret) -> str:
+        if isinstance(credential, Username):
+            return credential.username
+        elif isinstance(credential, Password):
+            return credential.password.get_secret_value()
+        else:
+            raise TypeError(f"Unexpected credential type: {type(credential)}")

--- a/monkey/agent_plugins/exploiters/snmp/src/community_string_generator.py
+++ b/monkey/agent_plugins/exploiters/snmp/src/community_string_generator.py
@@ -1,7 +1,14 @@
 from itertools import chain
 from typing import Callable, Iterable, List
 
-from common.credentials import Credentials, Identity, Password, Secret, Username
+from common.credentials import (
+    Credentials,
+    CredentialsComponent,
+    Identity,
+    Password,
+    Secret,
+    Username,
+)
 from infection_monkey.exploit.tools import identity_type_filter, secret_type_filter
 
 
@@ -24,7 +31,7 @@ def _generate_credentials(
     input_credentials: Iterable[Credentials],
     identity_type_filter: Callable[[Identity], bool] = lambda identity: True,
     secret_type_filter: Callable[[Identity], bool] = lambda secret: True,
-) -> Iterable[Identity | Secret]:
+) -> Iterable[CredentialsComponent]:
     identities: List[Identity] = []
     secrets: List[Secret] = []
 
@@ -41,7 +48,7 @@ def _generate_credentials(
         yield credential
 
 
-def _credential_to_community_string(credential: Identity | Secret) -> str:
+def _credential_to_community_string(credential: CredentialsComponent) -> str:
     if isinstance(credential, Username):
         return credential.username
     elif isinstance(credential, Password):

--- a/monkey/agent_plugins/exploiters/snmp/src/community_string_generator.py
+++ b/monkey/agent_plugins/exploiters/snmp/src/community_string_generator.py
@@ -36,9 +36,9 @@ def _select_credentials_components(
     secrets: List[Secret] = []
 
     for credentials in input_credentials:
-        if credentials.identity:
+        if credentials.identity is not None:
             identities.append(credentials.identity)
-        if credentials.secret:
+        if credentials.secret is not None:
             secrets.append(credentials.secret)
 
     for credential in chain(

--- a/monkey/common/credentials/__init__.py
+++ b/monkey/common/credentials/__init__.py
@@ -5,4 +5,4 @@ from .ssh_keypair import SSHKeypair
 from .username import Username
 from .encoding import get_plaintext, SecretEncodingConfig
 
-from .credentials import Credentials, Identity, Secret
+from .credentials import Credentials, CredentialsComponent, Identity, Secret

--- a/monkey/common/credentials/credentials.py
+++ b/monkey/common/credentials/credentials.py
@@ -6,8 +6,9 @@ from ..base_models import InfectionMonkeyBaseModel, InfectionMonkeyModelConfig
 from . import LMHash, NTHash, Password, SSHKeypair, Username
 from .encoding import SecretEncodingConfig
 
-Secret = Union[Password, LMHash, NTHash, SSHKeypair]
 Identity = Username
+Secret = Union[Password, LMHash, NTHash, SSHKeypair]
+CredentialsComponent = Union[Identity, Secret]
 
 
 class Credentials(InfectionMonkeyBaseModel):

--- a/monkey/tests/unit_tests/agent_plugins/exploiters/snmp/test_community_string_generator.py
+++ b/monkey/tests/unit_tests/agent_plugins/exploiters/snmp/test_community_string_generator.py
@@ -1,0 +1,119 @@
+from unittest.mock import MagicMock
+
+import pytest
+from agent_plugins.exploiters.snmp.src.community_string_generator import CommunityStringGenerator
+
+from common.credentials import Credentials, LMHash, Password, SSHKeypair, Username
+from infection_monkey.propagation_credentials_repository import IPropagationCredentialsRepository
+
+USERNAME_A_STR = "a"
+USERNAME_B_STR = "b"
+USERNAME_C_STR = "c"
+USERNAME_A = Username(username=USERNAME_A_STR)
+USERNAME_B = Username(username=USERNAME_B_STR)
+USERNAME_C = Username(username=USERNAME_C_STR)
+LMHASH_A_STR = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+LMHASH_A = LMHash(lm_hash=LMHASH_A_STR)
+NTHASH_A_STR = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+NTHASH_A = LMHash(lm_hash=NTHASH_A_STR)
+PASSWORD_A_STR = "a"
+PASSWORD_B_STR = "b"
+PASSWORD_C_STR = "c"
+PASSWORD_A = Password(password=PASSWORD_A_STR)
+PASSWORD_B = Password(password=PASSWORD_B_STR)
+PASSWORD_C = Password(password=PASSWORD_C_STR)
+SSHKEYPAIR_A = SSHKeypair(private_key="a", public_key="b")
+
+CREDENTIALS = [
+    Credentials(identity=USERNAME_A, secret=PASSWORD_A),
+    Credentials(identity=USERNAME_B, secret=None),
+    Credentials(identity=None, secret=PASSWORD_B),
+    Credentials(identity=USERNAME_C, secret=PASSWORD_C),
+]
+
+
+@pytest.fixture
+def mock_credentials_repository():
+    repository = MagicMock(spec=IPropagationCredentialsRepository)
+    repository.get_credentials.return_value = CREDENTIALS
+    return repository
+
+
+def test_ordering(mock_credentials_repository):
+    # All identities should come before all secrets
+    # All identities should be in the same order as the input credentials
+    # All secrets should be in the same order as the input credentials
+    mock_credentials_repository.get_credentials.return_value = CREDENTIALS
+    expected_result = [
+        USERNAME_A_STR,
+        USERNAME_B_STR,
+        USERNAME_C_STR,
+        PASSWORD_A_STR,
+        PASSWORD_B_STR,
+        PASSWORD_C_STR,
+    ]
+
+    generator = CommunityStringGenerator(mock_credentials_repository)
+
+    assert list(generator.generate_community_strings()) == expected_result
+
+
+def test_identities_are_filtered(mock_credentials_repository):
+    # The only identity type allowed is Username
+    mock_credentials_repository.get_credentials.return_value = [
+        Credentials(identity=USERNAME_A, secret=PASSWORD_A),
+        Credentials(identity=None, secret=PASSWORD_B),
+    ]
+    expected_result = [USERNAME_A_STR, PASSWORD_A_STR, PASSWORD_B_STR]
+    generator = CommunityStringGenerator(mock_credentials_repository)
+
+    result = list(generator.generate_community_strings())
+
+    assert result == expected_result
+
+
+def test_secrets_are_filtered(mock_credentials_repository):
+    # The only secret type allowed is Password
+    mock_credentials_repository.get_credentials.return_value = [
+        Credentials(identity=None, secret=PASSWORD_A),
+        Credentials(identity=USERNAME_A, secret=LMHASH_A),
+        Credentials(identity=USERNAME_B, secret=PASSWORD_B),
+        Credentials(identity=None, secret=NTHASH_A),
+        Credentials(identity=None, secret=SSHKEYPAIR_A),
+    ]
+    expected_result = [USERNAME_A_STR, USERNAME_B_STR, PASSWORD_A_STR, PASSWORD_B_STR]
+    generator = CommunityStringGenerator(mock_credentials_repository)
+
+    result = list(generator.generate_community_strings())
+
+    assert result == expected_result
+
+
+def test_identities_are_unique(mock_credentials_repository):
+    mock_credentials_repository.get_credentials.return_value = [
+        Credentials(identity=USERNAME_A, secret=None),
+        Credentials(identity=USERNAME_A, secret=PASSWORD_A),
+        Credentials(identity=USERNAME_B, secret=None),
+        Credentials(identity=USERNAME_B, secret=None),
+    ]
+    expected_result = [USERNAME_A_STR, USERNAME_B_STR, PASSWORD_A_STR]
+    generator = CommunityStringGenerator(mock_credentials_repository)
+
+    result = list(generator.generate_community_strings())
+
+    assert result == expected_result
+
+
+def test_secrets_are_unique(mock_credentials_repository):
+    mock_credentials_repository.get_credentials.return_value = [
+        Credentials(identity=None, secret=PASSWORD_A),
+        Credentials(identity=USERNAME_A, secret=PASSWORD_A),
+        Credentials(identity=None, secret=PASSWORD_B),
+        Credentials(identity=None, secret=PASSWORD_B),
+    ]
+    expected_result = [USERNAME_A_STR, PASSWORD_A_STR, PASSWORD_B_STR]
+    generator = CommunityStringGenerator(mock_credentials_repository)
+
+    result = list(generator.generate_community_strings())
+
+    assert result == expected_result

--- a/monkey/tests/unit_tests/agent_plugins/exploiters/snmp/test_community_string_generator.py
+++ b/monkey/tests/unit_tests/agent_plugins/exploiters/snmp/test_community_string_generator.py
@@ -1,10 +1,6 @@
-from unittest.mock import MagicMock
-
-import pytest
-from agent_plugins.exploiters.snmp.src.community_string_generator import CommunityStringGenerator
+from agent_plugins.exploiters.snmp.src.community_string_generator import generate_community_strings
 
 from common.credentials import Credentials, LMHash, Password, SSHKeypair, Username
-from infection_monkey.propagation_credentials_repository import IPropagationCredentialsRepository
 
 USERNAME_A_STR = "a"
 USERNAME_B_STR = "b"
@@ -24,26 +20,17 @@ PASSWORD_B = Password(password=PASSWORD_B_STR)
 PASSWORD_C = Password(password=PASSWORD_C_STR)
 SSHKEYPAIR_A = SSHKeypair(private_key="a", public_key="b")
 
-CREDENTIALS = [
-    Credentials(identity=USERNAME_A, secret=PASSWORD_A),
-    Credentials(identity=USERNAME_B, secret=None),
-    Credentials(identity=None, secret=PASSWORD_B),
-    Credentials(identity=USERNAME_C, secret=PASSWORD_C),
-]
 
-
-@pytest.fixture
-def mock_credentials_repository():
-    repository = MagicMock(spec=IPropagationCredentialsRepository)
-    repository.get_credentials.return_value = CREDENTIALS
-    return repository
-
-
-def test_ordering(mock_credentials_repository):
+def test_ordering():
     # All identities should come before all secrets
     # All identities should be in the same order as the input credentials
     # All secrets should be in the same order as the input credentials
-    mock_credentials_repository.get_credentials.return_value = CREDENTIALS
+    credentials = [
+        Credentials(identity=USERNAME_A, secret=PASSWORD_A),
+        Credentials(identity=USERNAME_B, secret=None),
+        Credentials(identity=None, secret=PASSWORD_B),
+        Credentials(identity=USERNAME_C, secret=PASSWORD_C),
+    ]
     expected_result = [
         USERNAME_A_STR,
         USERNAME_B_STR,
@@ -53,28 +40,25 @@ def test_ordering(mock_credentials_repository):
         PASSWORD_C_STR,
     ]
 
-    generator = CommunityStringGenerator(mock_credentials_repository)
-
-    assert list(generator.generate_community_strings()) == expected_result
+    assert list(generate_community_strings(credentials)) == expected_result
 
 
-def test_identities_are_filtered(mock_credentials_repository):
+def test_identities_are_filtered():
     # The only identity type allowed is Username
-    mock_credentials_repository.get_credentials.return_value = [
+    credentials = [
         Credentials(identity=USERNAME_A, secret=PASSWORD_A),
         Credentials(identity=None, secret=PASSWORD_B),
     ]
     expected_result = [USERNAME_A_STR, PASSWORD_A_STR, PASSWORD_B_STR]
-    generator = CommunityStringGenerator(mock_credentials_repository)
 
-    result = list(generator.generate_community_strings())
+    result = list(generate_community_strings(credentials))
 
     assert result == expected_result
 
 
-def test_secrets_are_filtered(mock_credentials_repository):
+def test_secrets_are_filtered():
     # The only secret type allowed is Password
-    mock_credentials_repository.get_credentials.return_value = [
+    credentials = [
         Credentials(identity=None, secret=PASSWORD_A),
         Credentials(identity=USERNAME_A, secret=LMHASH_A),
         Credentials(identity=USERNAME_B, secret=PASSWORD_B),
@@ -82,38 +66,35 @@ def test_secrets_are_filtered(mock_credentials_repository):
         Credentials(identity=None, secret=SSHKEYPAIR_A),
     ]
     expected_result = [USERNAME_A_STR, USERNAME_B_STR, PASSWORD_A_STR, PASSWORD_B_STR]
-    generator = CommunityStringGenerator(mock_credentials_repository)
 
-    result = list(generator.generate_community_strings())
+    result = list(generate_community_strings(credentials))
 
     assert result == expected_result
 
 
-def test_identities_are_unique(mock_credentials_repository):
-    mock_credentials_repository.get_credentials.return_value = [
+def test_identities_are_unique():
+    credentials = [
         Credentials(identity=USERNAME_A, secret=None),
         Credentials(identity=USERNAME_A, secret=PASSWORD_A),
         Credentials(identity=USERNAME_B, secret=None),
         Credentials(identity=USERNAME_B, secret=None),
     ]
     expected_result = [USERNAME_A_STR, USERNAME_B_STR, PASSWORD_A_STR]
-    generator = CommunityStringGenerator(mock_credentials_repository)
 
-    result = list(generator.generate_community_strings())
+    result = list(generate_community_strings(credentials))
 
     assert result == expected_result
 
 
-def test_secrets_are_unique(mock_credentials_repository):
-    mock_credentials_repository.get_credentials.return_value = [
+def test_secrets_are_unique():
+    credentials = [
         Credentials(identity=None, secret=PASSWORD_A),
         Credentials(identity=USERNAME_A, secret=PASSWORD_A),
         Credentials(identity=None, secret=PASSWORD_B),
         Credentials(identity=None, secret=PASSWORD_B),
     ]
     expected_result = [USERNAME_A_STR, PASSWORD_A_STR, PASSWORD_B_STR]
-    generator = CommunityStringGenerator(mock_credentials_repository)
 
-    result = list(generator.generate_community_strings())
+    result = list(generate_community_strings(credentials))
 
     assert result == expected_result


### PR DESCRIPTION
# What does this PR do?

Fixes part of #3234.

Add a class to generate community strings from credentials

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
