### PR TITLE
Fix broken UT on Flask upgrade

### DIFF
--- a/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/flask_resources/test_agent_otp_login.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/flask_resources/test_agent_otp_login.py
@@ -62,7 +62,7 @@ def test_invalid_json(flask_client):
 
     response = flask_client.post(url, data=invalid_json, follow_redirects=True)
 
-    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.status_code == HTTPStatus.UNSUPPORTED_MEDIA_TYPE
 
 
 def test_unauthorized(mock_authentication_facade, agent_otp_login):

--- a/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/flask_resources/test_agent_otp_login.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/flask_resources/test_agent_otp_login.py
@@ -56,7 +56,18 @@ def test_invalid_request(agent_otp_login, data):
     assert response.status_code == HTTPStatus.BAD_REQUEST
 
 
-def test_invalid_json(flask_client):
+def test_invalid_json__json_content_type(flask_client):
+    url = get_url_for_resource(AgentOTPLogin)
+    invalid_json = "{'key1': 'value1', 'key2: 'value2'}"
+
+    response = flask_client.post(
+        url, data=invalid_json, follow_redirects=True, content_type="application/json"
+    )
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_invalid_json__no_content_type(flask_client):
     url = get_url_for_resource(AgentOTPLogin)
     invalid_json = "{'key1': 'value1', 'key2: 'value2'}"
 

--- a/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/flask_resources/test_agent_otp_login.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/authentication_service/flask_resources/test_agent_otp_login.py
@@ -14,13 +14,13 @@ from monkey_island.cc.services.authentication_service.user import User
 
 AGENT_ID = UUID("9614480d-471b-4568-86b5-cb922a34ed8a")
 
+AGENT_OTP_LOGIN_URL = get_url_for_resource(AgentOTPLogin)
+
 
 @pytest.fixture
 def agent_otp_login(flask_client):
-    url = get_url_for_resource(AgentOTPLogin)
-
     def _agent_otp_login(request_body):
-        return flask_client.post(url, json=request_body, follow_redirects=True)
+        return flask_client.post(AGENT_OTP_LOGIN_URL, json=request_body, follow_redirects=True)
 
     return _agent_otp_login
 
@@ -56,22 +56,22 @@ def test_invalid_request(agent_otp_login, data):
     assert response.status_code == HTTPStatus.BAD_REQUEST
 
 
-def test_invalid_json__json_content_type(flask_client):
-    url = get_url_for_resource(AgentOTPLogin)
-    invalid_json = "{'key1': 'value1', 'key2: 'value2'}"
+INVALID_JSON = "{'key1': 'value1', 'key2: 'value2'}"
 
+
+def test_invalid_json__json_content_type(flask_client):
     response = flask_client.post(
-        url, data=invalid_json, follow_redirects=True, content_type="application/json"
+        AGENT_OTP_LOGIN_URL,
+        data=INVALID_JSON,
+        follow_redirects=True,
+        content_type="application/json",
     )
 
     assert response.status_code == HTTPStatus.BAD_REQUEST
 
 
 def test_invalid_json__no_content_type(flask_client):
-    url = get_url_for_resource(AgentOTPLogin)
-    invalid_json = "{'key1': 'value1', 'key2: 'value2'}"
-
-    response = flask_client.post(url, data=invalid_json, follow_redirects=True)
+    response = flask_client.post(AGENT_OTP_LOGIN_URL, data=INVALID_JSON, follow_redirects=True)
 
     assert response.status_code == HTTPStatus.UNSUPPORTED_MEDIA_TYPE
 


### PR DESCRIPTION
# What does this PR do?

Fixes a broken UT
```
FAILED tests/unit_tests/monkey_island/cc/services/authentication_service/flask_resources/test_agent_otp_login.py::test_invalid_json - assert 415 == <HTTPStatus.BAD_REQUEST: 400>
```

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [x]  Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [x] Do all unit tests pass?
* [ ] ~Do all end-to-end tests pass?~
* [ ] ~Any other testing performed?~
    > ~Tested by {Running the Monkey locally with relevant config/running Island/...}~
* [ ] ~If applicable, add screenshots or log transcripts of the feature working~
