### PR TITLE
3244 enable random hash in agent

### DIFF
--- a/envs/monkey_zoo/blackbox/test_configurations/noop.py
+++ b/envs/monkey_zoo/blackbox/test_configurations/noop.py
@@ -6,6 +6,7 @@ from common.agent_configuration import (
     ExploitationOptionsConfiguration,
     ICMPScanConfiguration,
     NetworkScanConfiguration,
+    PolymorphismConfiguration,
     PropagationConfiguration,
     ScanTargetConfiguration,
     TCPScanConfiguration,
@@ -37,11 +38,16 @@ _propagation_configuration = PropagationConfiguration(
     exploitation=_exploitation_configuration,
 )
 
+_polymorphism_configuration = PolymorphismConfiguration(
+    randomize_agent_hash=False,
+)
+
 _agent_configuration = AgentConfiguration(
     keep_tunnel_open_time=0,
     credentials_collectors={},
     payloads={},
     propagation=_propagation_configuration,
+    polymorphism=_polymorphism_configuration,
 )
 _propagation_credentials: Tuple[Credentials, ...] = tuple()
 

--- a/monkey/common/agent_configuration/__init__.py
+++ b/monkey/common/agent_configuration/__init__.py
@@ -1,13 +1,14 @@
 from .agent_configuration import AgentConfiguration
 from .agent_sub_configurations import (
-    PluginConfiguration,
-    ScanTargetConfiguration,
-    ICMPScanConfiguration,
-    TCPScanConfiguration,
-    NetworkScanConfiguration,
-    ExploitationOptionsConfiguration,
     ExploitationConfiguration,
+    ExploitationOptionsConfiguration,
+    ICMPScanConfiguration,
+    NetworkScanConfiguration,
+    PluginConfiguration,
+    PolymorphismConfiguration,
     PropagationConfiguration,
+    ScanTargetConfiguration,
+    TCPScanConfiguration,
 )
 from .default_agent_configuration import (
     DEFAULT_AGENT_CONFIGURATION,

--- a/monkey/common/agent_configuration/agent_sub_configurations.py
+++ b/monkey/common/agent_configuration/agent_sub_configurations.py
@@ -249,11 +249,11 @@ class PolymorphismConfiguration(MutableInfectionMonkeyBaseModel):
     A configuration for polymorphism
 
     Attributes:
-        :param randomized_agent_hash: If true, the Agent will emulate the property of polymorphism
+        :param randomize_agent_hash: If true, the Agent will emulate the property of polymorphism
                                       that all copies have unique hashes
     """
 
-    randomized_agent_hash: bool = Field(
+    randomize_agent_hash: bool = Field(
         title="Randomize Agent hash",
         description="Emulate the property of polymorphic (or metamorphic) malware that all "
         "copies have unique hashes.",

--- a/monkey/common/agent_configuration/default_agent_configuration.py
+++ b/monkey/common/agent_configuration/default_agent_configuration.py
@@ -93,7 +93,7 @@ DEFAULT_AGENT_CONFIGURATION = AgentConfiguration(
     credentials_collectors=CREDENTIALS_COLLECTORS,
     payloads=PAYLOAD_CONFIGURATION,
     propagation=PROPAGATION_CONFIGURATION,
-    polymorphism=PolymorphismConfiguration(randomized_agent_hash=False),
+    polymorphism=PolymorphismConfiguration(randomize_agent_hash=False),
 )
 
 DEFAULT_RANSOMWARE_AGENT_CONFIGURATION = deepcopy(DEFAULT_AGENT_CONFIGURATION)

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -467,7 +467,7 @@ class InfectionMonkey:
             manager=self._manager,
         )
 
-        if agent_configuration.polymorphism.randomized_agent_hash:
+        if agent_configuration.polymorphism.randomize_agent_hash:
             agent_binary_repository = PolymorphicAgentBinaryRepositoryDecorator(
                 agent_binary_repository
             )

--- a/monkey/monkey_island/cc/ui/src/components/configuration-components/UiSchema.js
+++ b/monkey/monkey_island/cc/ui/src/components/configuration-components/UiSchema.js
@@ -117,7 +117,7 @@ export default function UiSchema(props) {
       }
     },
     polymorphism: {
-      randomized_agent_hash: {
+      randomize_agent_hash: {
         'ui:widget': CheckboxWithMessage
       }
     }

--- a/monkey/monkey_island/cc/ui/src/services/configuration/polymorphism.js
+++ b/monkey/monkey_island/cc/ui/src/services/configuration/polymorphism.js
@@ -1,7 +1,7 @@
 const POLYMORPHISM_SCHEMA = {
   'title': 'Polymorphism',
   'properties': {
-    'randomized_agent_hash': {
+    'randomize_agent_hash': {
       'title': 'Randomize Agent hash',
       'type': 'boolean',
       'default': false

--- a/monkey/tests/common/example_agent_configuration.py
+++ b/monkey/tests/common/example_agent_configuration.py
@@ -46,7 +46,7 @@ CREDENTIALS_COLLECTORS: Dict[str, Dict] = {
     "credentials_collectors": {"SSHCollector": {}, "MimikatzCollector": {}}
 }
 
-POLYMORPHISM_CONFIGURATION = {"randomized_agent_hash": False}
+POLYMORPHISM_CONFIGURATION = {"randomize_agent_hash": False}
 
 AGENT_CONFIGURATION = {
     "keep_tunnel_open_time": 30,

--- a/monkey/tests/unit_tests/infection_monkey/island_api_client/configuration_validation_constants.py
+++ b/monkey/tests/unit_tests/infection_monkey/island_api_client/configuration_validation_constants.py
@@ -308,15 +308,15 @@ SCHEMA = {
         },
         "PolymorphismConfiguration": {
             "title": "PolymorphismConfiguration",
-            "description": "A configuration for polymorphism\n\nAttributes:\n    :param randomized_agent_hash: If true, the Agent will emulate the property of polymorphism that all copies have unique hashes",
+            "description": "A configuration for polymorphism\n\nAttributes:\n    :param randomize_agent_hash: If true, the Agent will emulate the property of polymorphism that all copies have unique hashes",
             "type": "object",
             "properties": {
-                "randomized_agent_hash": {
+                "randomize_agent_hash": {
                     "title": "Randomize Agent hash",
                     "default": False,
                 },
             },
-            "required": ["randomized_agent_hash"],
+            "required": ["randomize_agent_hash"],
             "additionalProperties": False,
         },
     },


### PR DESCRIPTION
# What does this PR do?

Issue #3244
Enables randomized binary hash in the agent.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [x] Do all unit tests pass?
* [ ] ~Do all end-to-end tests pass?~
* [x] Any other testing performed?
    > Tested by manually by running a single BB test and checking the hashes of the binaries.
* [ ] If applicable, add screenshots or log transcripts of the feature working
