### PR TITLE
Agent: Add preferred_ports to TCPPortSelector.get_free_tcp_port

### DIFF
--- a/monkey/infection_monkey/network/info.py
+++ b/monkey/infection_monkey/network/info.py
@@ -1,10 +1,11 @@
 import socket
 import struct
 from dataclasses import dataclass
+from itertools import chain
 from multiprocessing.context import BaseContext
 from multiprocessing.managers import DictProxy, SyncManager
 from random import shuffle  # noqa: DUO102
-from typing import Iterator, List, Optional, Set, Tuple
+from typing import Iterable, Iterator, List, Optional, Sequence, Set, Tuple
 
 import psutil
 from egg_timer import EggTimer
@@ -125,13 +126,18 @@ class TCPPortSelector:
         self._lock = context.Lock()
 
     def get_free_tcp_port(
-        self, min_range: int = 1024, max_range: int = 65535, lease_time_sec: float = 30
+        self,
+        min_range: int = 1024,
+        max_range: int = 65535,
+        lease_time_sec: float = 30,
+        preferred_ports: Sequence[NetworkPort] = [],
     ) -> Optional[NetworkPort]:
         """
         Get a free TCP port that a new server can listen on
 
-        This function will attempt to provide a well-known port that the caller can listen on. If no
-        well-known ports are available, a random port will be selected.
+        This function will first check if any of the preferred ports are available. If not, it will
+        attempt to provide a well-known port that the caller can listen on. If no well-known ports
+        are available, a random port will be selected.
 
         :param min_range: The smallest port number a random port can be chosen from, defaults to
                           1024
@@ -139,6 +145,7 @@ class TCPPortSelector:
                           65535
         :param lease_time_sec: The amount of time a port should be reserved for if the OS does not
                                report it as in use, defaults to 30 seconds
+        :param preferred_ports: A sequence of ports that should be tried first
         :return: The selected port, or None if no ports are available
         """
         with self._lock:
@@ -146,16 +153,21 @@ class TCPPortSelector:
                 NetworkPort(conn.laddr[1]) for conn in psutil.net_connections()  # type: ignore
             }
 
-            common_port = self._get_free_common_port(ports_in_use, lease_time_sec)
-            if common_port is not None:
-                return common_port
+            port = self._get_first_free_port(
+                ports_in_use, chain(preferred_ports, COMMON_PORTS), lease_time_sec
+            )
+            if port is not None:
+                return port
 
             return self._get_free_random_port(ports_in_use, min_range, max_range, lease_time_sec)
 
-    def _get_free_common_port(
-        self, ports_in_use: Set[NetworkPort], lease_time_sec: float
+    def _get_first_free_port(
+        self,
+        ports_in_use: Set[NetworkPort],
+        ports_to_check: Iterable[NetworkPort],
+        lease_time_sec: float,
     ) -> Optional[NetworkPort]:
-        for port in COMMON_PORTS:
+        for port in ports_to_check:
             if self._port_is_available(port, ports_in_use):
                 self._reserve_port(port, lease_time_sec)
                 return port


### PR DESCRIPTION
# What does this PR do?

Fixes part of #3410.

Allows preferred ports to be provided to TCPPortSelector.get_free_tcp_port.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
