### PR TITLE
Log4Shell: Use HTTPAgentBinaryServerRegistrar

### DIFF
--- a/monkey/agent_plugins/exploiters/log4shell/manifest.yml
+++ b/monkey/agent_plugins/exploiters/log4shell/manifest.yml
@@ -7,7 +7,7 @@ target_operating_systems:
   - linux
   - windows
 title: Log4Shell Exploiter
-version: 1.0.1
+version: 2.0.0
 description: >-
   Exploits a software vulnerability (CVE-2021-44228) in Apache Log4j, a Java
   logging framework. Exploitation is attempted on the following services —

--- a/monkey/agent_plugins/exploiters/log4shell/src/log4shell_exploiter.py
+++ b/monkey/agent_plugins/exploiters/log4shell/src/log4shell_exploiter.py
@@ -1,10 +1,15 @@
 import logging
-from typing import Callable, Sequence, Set
+from typing import Sequence, Set
 
 from common import OperatingSystem
 from common.common_consts.timeouts import LONG_REQUEST_TIMEOUT
 from common.types import AgentID, Event, NetworkPort, SocketAddress
 from infection_monkey.exploit import IAgentOTPProvider
+from infection_monkey.exploit.http_agent_binary_server import use_agent_binary
+from infection_monkey.exploit.i_http_agent_binary_server_registrar import (
+    IHTTPAgentBinaryServerRegistrar,
+    ReservationID,
+)
 from infection_monkey.exploit.tools import HTTPBytesServer
 from infection_monkey.i_puppet import ExploiterResultData, TargetHost
 from infection_monkey.network import TCPPortSelector
@@ -24,8 +29,6 @@ logger = logging.getLogger(__name__)
 
 SERVER_SHUTDOWN_TIMEOUT = LONG_REQUEST_TIMEOUT
 
-AgentBinaryServerFactory = Callable[[TargetHost], HTTPBytesServer]
-
 
 class Log4ShellExploiter:
     def __init__(
@@ -33,13 +36,13 @@ class Log4ShellExploiter:
         agent_id: AgentID,
         log4shell_exploit_client: Log4ShellExploitClient,
         tcp_port_selector: TCPPortSelector,
-        start_agent_binary_server: AgentBinaryServerFactory,
+        http_agent_binary_server_registrar: IHTTPAgentBinaryServerRegistrar,
         otp_provider: IAgentOTPProvider,
     ):
         self._agent_id = agent_id
         self._log4shell_exploit_client = log4shell_exploit_client
         self._tcp_port_selector = tcp_port_selector
-        self._start_agent_binary_server = start_agent_binary_server
+        self._http_agent_binary_server_registrar = http_agent_binary_server_registrar
         self._otp_provider = otp_provider
 
     def exploit_host(
@@ -66,7 +69,9 @@ class Log4ShellExploiter:
 
         try:
             logger.debug("Starting the Agent binary server")
-            agent_binary_http_server = self._start_agent_binary_server(self._host)
+            download_ticket = self._http_agent_binary_server_registrar.reserve_download(
+                target_host.operating_system, target_host.ip, use_agent_binary
+            )
         except Exception as err:
             msg = (
                 "An unexpected exception occurred while attempting to start the Agent binary HTTP "
@@ -80,7 +85,7 @@ class Log4ShellExploiter:
             self._host,
             servers,
             current_depth,
-            agent_binary_http_server.download_url,
+            download_ticket.download_url,
             self._otp_provider.get_otp(),
         )
 
@@ -94,7 +99,9 @@ class Log4ShellExploiter:
             )
             logger.exception(msg)
 
-            _stop_agent_binary_http_server(agent_binary_http_server)
+            _clear_agent_binary_reservation(
+                self._http_agent_binary_server_registrar, download_ticket.id
+            )
 
             return ExploiterResultData(error_message=msg)
 
@@ -108,7 +115,9 @@ class Log4ShellExploiter:
             )
             logger.exception(msg)
 
-            _stop_agent_binary_http_server(agent_binary_http_server)
+            _clear_agent_binary_reservation(
+                self._http_agent_binary_server_registrar, download_ticket.id
+            )
             self._stop_exploit_class_http_server()
 
             return ExploiterResultData(error_message=msg)
@@ -117,7 +126,7 @@ class Log4ShellExploiter:
             logger.debug(f"Running Log4Shell against host: {self._host.ip}")
             return self._exploit_ports(
                 options,
-                agent_binary_http_server.bytes_downloaded,
+                download_ticket.download_completed,
                 interrupt,
                 ports_to_try,
                 command,
@@ -130,7 +139,9 @@ class Log4ShellExploiter:
             logger.exception(msg)
             return ExploiterResultData(error_message=msg)
         finally:
-            _stop_agent_binary_http_server(agent_binary_http_server)
+            _clear_agent_binary_reservation(
+                self._http_agent_binary_server_registrar, download_ticket.id
+            )
             self._stop_exploit_class_http_server()
             self._stop_ldap_server()
 
@@ -231,9 +242,14 @@ class Log4ShellExploiter:
             logger.exception("An unexpected error occurred while stopping the LDAP server")
 
 
-def _stop_agent_binary_http_server(agent_binary_http_server: HTTPBytesServer):
+def _clear_agent_binary_reservation(
+    http_agent_binary_server_registrar: IHTTPAgentBinaryServerRegistrar,
+    reservation_id: ReservationID,
+):
     try:
-        logger.debug("Stopping the Agent binary server")
-        agent_binary_http_server.stop(SERVER_SHUTDOWN_TIMEOUT)
+        logger.debug("Clearing the Agent binary download reservation")
+        http_agent_binary_server_registrar.clear_reservation(reservation_id)
     except Exception:
-        logger.exception("An unexpected error occurred while stopping the HTTP server")
+        logger.exception(
+            "An unexpected error occurred while clearing the Agent binary download reservation"
+        )

--- a/monkey/agent_plugins/exploiters/log4shell/src/plugin.py
+++ b/monkey/agent_plugins/exploiters/log4shell/src/plugin.py
@@ -1,5 +1,4 @@
 import logging
-from functools import partial
 from pprint import pformat
 from typing import Any, Dict, List, Sequence, Set
 
@@ -9,9 +8,11 @@ from common.types import AgentID, Event, NetworkPort
 from common.utils.code_utils import del_key
 
 # dependencies to get rid of or internalize
-from infection_monkey.exploit import IAgentBinaryRepository, IAgentOTPProvider
+from infection_monkey.exploit import IAgentOTPProvider
+from infection_monkey.exploit.i_http_agent_binary_server_registrar import (
+    IHTTPAgentBinaryServerRegistrar,
+)
 from infection_monkey.exploit.tools import filter_out_closed_ports, get_open_http_ports
-from infection_monkey.exploit.tools.http_agent_binary_server import start_agent_binary_server
 from infection_monkey.i_puppet import ExploiterResultData, TargetHost
 from infection_monkey.network import TCPPortSelector
 
@@ -43,7 +44,7 @@ class Plugin:
         plugin_name: str,
         agent_id: AgentID,
         agent_event_publisher: IAgentEventPublisher,
-        agent_binary_repository: IAgentBinaryRepository,
+        http_agent_binary_server_registrar: IHTTPAgentBinaryServerRegistrar,
         tcp_port_selector: TCPPortSelector,
         otp_provider: IAgentOTPProvider,
         **kwargs,
@@ -51,17 +52,12 @@ class Plugin:
         log4shell_exploit_client = Log4ShellExploitClient(
             plugin_name, agent_id, agent_event_publisher
         )
-        agent_binary_server_factory = partial(
-            start_agent_binary_server,
-            agent_binary_repository=agent_binary_repository,
-            tcp_port_selector=tcp_port_selector,
-        )
 
         self._log4shell_exploiter = Log4ShellExploiter(
             agent_id=agent_id,
             log4shell_exploit_client=log4shell_exploit_client,
             tcp_port_selector=tcp_port_selector,
-            start_agent_binary_server=agent_binary_server_factory,
+            http_agent_binary_server_registrar=http_agent_binary_server_registrar,
             otp_provider=otp_provider,
         )
 

--- a/monkey/tests/unit_tests/agent_plugins/exploiters/log4shell/test_log4shell_exploiter.py
+++ b/monkey/tests/unit_tests/agent_plugins/exploiters/log4shell/test_log4shell_exploiter.py
@@ -13,6 +13,9 @@ from agent_plugins.exploiters.log4shell.src.plugin import get_ports_to_try
 from common import OperatingSystem
 from common.types import NetworkPort, NetworkProtocol, NetworkService, PortStatus
 from infection_monkey.exploit import IAgentOTPProvider
+from infection_monkey.exploit.i_http_agent_binary_server_registrar import (
+    IHTTPAgentBinaryServerRegistrar,
+)
 from infection_monkey.exploit.tools import HTTPBytesServer
 from infection_monkey.i_puppet import ExploiterResultData, PortScanData, TargetHost
 from infection_monkey.network import TCPPortSelector
@@ -80,8 +83,8 @@ def mock_log4shell_exploit_client() -> Log4ShellExploitClient:
 
 
 @pytest.fixture
-def mock_start_agent_binary_server(mock_bytes_server) -> HTTPBytesServer:
-    return MagicMock(return_value=mock_bytes_server)
+def mock_http_agent_binary_server_registrar() -> IHTTPAgentBinaryServerRegistrar:
+    return MagicMock(spec=IHTTPAgentBinaryServerRegistrar)
 
 
 @pytest.fixture
@@ -103,7 +106,7 @@ def log4shell_exploiter(
     monkeypatch,
     mock_log4shell_exploit_client: Log4ShellExploitClient,
     mock_port_selector: TCPPortSelector,
-    mock_start_agent_binary_server: Callable[[TargetHost], HTTPBytesServer],
+    mock_http_agent_binary_server_registrar: IHTTPAgentBinaryServerRegistrar,
     mock_otp_provider: IAgentOTPProvider,
     mock_ldap_server: LDAPExploitServer,
     mock_bytes_server: HTTPBytesServer,
@@ -121,7 +124,7 @@ def log4shell_exploiter(
         AGENT_ID,
         mock_log4shell_exploit_client,
         mock_port_selector,
-        mock_start_agent_binary_server,
+        mock_http_agent_binary_server_registrar,
         mock_otp_provider,
     )
 
@@ -145,22 +148,27 @@ def exploit_host(
     return _inner
 
 
-def test_exploit_host__succeeds(exploit_host, mock_log4shell_exploit_client, mock_bytes_server):
+def test_exploit_host__succeeds(
+    exploit_host,
+    mock_log4shell_exploit_client,
+    mock_http_agent_binary_server_registrar,
+):
     mock_log4shell_exploit_client.exploit.return_value = (True, True)
     result = exploit_host()
 
-    assert mock_bytes_server.stop.called
+    assert mock_http_agent_binary_server_registrar.reserve_download.called
+    assert mock_http_agent_binary_server_registrar.clear_reservation.called
     assert result.exploitation_success
     assert result.propagation_success
 
 
-def test_exploit_host__fails_if_agent_binary_server_fails_to_start(
-    exploit_host, mock_start_agent_binary_server, mock_bytes_server
+def test_exploit_host__fails_if_agent_binary_reservation_fails(
+    exploit_host, mock_http_agent_binary_server_registrar
 ):
-    mock_start_agent_binary_server.side_effect = Exception()
+    mock_http_agent_binary_server_registrar.reserve_download.side_effect = Exception()
     result = exploit_host()
 
-    assert not mock_bytes_server.stop.called
+    assert not mock_http_agent_binary_server_registrar.clear_reservation.called
     assert not result.exploitation_success
     assert not result.propagation_success
 
@@ -181,15 +189,15 @@ def test_exploit_host__fails_if_ldap_server_fails_to_start(target_host, log4shel
     assert not result.propagation_success
 
 
-def test_exploit_host__success_returned_on_bytes_server_stop_fail(
-    exploit_host, mock_log4shell_exploit_client, mock_bytes_server
+def test_exploit_host__success_returned_if_clear_reservation_fails(
+    exploit_host, mock_log4shell_exploit_client, mock_http_agent_binary_server_registrar
 ):
     mock_log4shell_exploit_client.exploit.return_value = (True, True)
-    mock_bytes_server.stop.side_effect = Exception()
+    mock_http_agent_binary_server_registrar.clear_reservation.side_effect = Exception()
 
     result = exploit_host()
 
-    assert mock_bytes_server.stop.called
+    assert mock_http_agent_binary_server_registrar.clear_reservation.called
     assert result.exploitation_success
     assert result.propagation_success
 
@@ -230,12 +238,12 @@ def test_exploit_host__fails_when_no_target_ports(
 
 
 def test_exploit_host__fails_on_log4shell_exception(
-    mock_log4shell_exploit_client, exploit_host, mock_bytes_server
+    mock_log4shell_exploit_client, exploit_host, mock_http_agent_binary_server_registrar
 ):
     mock_log4shell_exploit_client.exploit.side_effect = Exception()
     result = exploit_host()
 
-    assert mock_bytes_server.stop.called
+    assert mock_http_agent_binary_server_registrar.clear_reservation.called
     assert not result.exploitation_success
     assert not result.propagation_success
 

--- a/monkey/tests/unit_tests/agent_plugins/exploiters/log4shell/test_log4shell_plugin.py
+++ b/monkey/tests/unit_tests/agent_plugins/exploiters/log4shell/test_log4shell_plugin.py
@@ -68,6 +68,7 @@ def plugin(monkeypatch) -> Plugin:
         agent_id=AGENT_ID,
         agent_event_publisher=MagicMock(),
         agent_binary_repository=MagicMock(),
+        http_agent_binary_server_registrar=MagicMock(),
         tcp_port_selector=MagicMock(),
         otp_provider=MagicMock(),
     )
@@ -109,6 +110,7 @@ def test_run__exploit_host_raises_exception(monkeypatch, plugin: Plugin):
         agent_id=AGENT_ID,
         agent_event_publisher=MagicMock(),
         agent_binary_repository=MagicMock(),
+        http_agent_binary_server_registrar=MagicMock(),
         tcp_port_selector=MagicMock(),
         otp_provider=MagicMock(),
     )


### PR DESCRIPTION
# What does this PR do?

Fixes part of #3410.

Updates the Log4Shell exploiter to use the `HTTPAgentBinaryServer`

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [x] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [x] Any other testing performed?
    > Tested by running log4shell exploiter in the zoo environment
* [ ] If applicable, add screenshots or log transcripts of the feature working
