### PR TITLE
3410 use shared http server snmp

### DIFF
--- a/monkey/agent_plugins/exploiters/snmp/manifest.yaml
+++ b/monkey/agent_plugins/exploiters/snmp/manifest.yaml
@@ -6,7 +6,7 @@ supported_operating_systems:
 target_operating_systems:
   - linux
 title: SNMP Exploiter
-version: 1.0.2
+version: 2.0.0
 description: Attempts remote command execution over SNMP using known credentials.
 safe: true
 remediation_suggestion: >-

--- a/monkey/agent_plugins/exploiters/snmp/src/plugin.py
+++ b/monkey/agent_plugins/exploiters/snmp/src/plugin.py
@@ -10,14 +10,17 @@ from common.utils.code_utils import del_key
 
 # dependencies to get rid of or internalize
 from infection_monkey.exploit import IAgentBinaryRepository, IAgentOTPProvider
+from infection_monkey.exploit.i_http_agent_binary_server_registrar import (
+    IHTTPAgentBinaryServerRegistrar,
+)
 from infection_monkey.exploit.tools import all_udp_ports_are_closed
 from infection_monkey.exploit.tools.helpers import get_agent_dst_path
-from infection_monkey.exploit.tools.http_agent_binary_server import start_dropper_script_server
 from infection_monkey.i_puppet import ExploiterResultData, TargetHost
 from infection_monkey.model import MONKEY_ARG
 from infection_monkey.network import TCPPortSelector
 from infection_monkey.propagation_credentials_repository import IPropagationCredentialsRepository
 from infection_monkey.utils.commands import build_monkey_commandline_parameters
+from infection_monkey.utils.script_dropper import build_bash_dropper
 
 from .community_string_generator import generate_community_strings
 from .snmp_client import SNMPClient
@@ -49,6 +52,7 @@ class Plugin:
         agent_id: AgentID,
         agent_event_publisher: IAgentEventPublisher,
         agent_binary_repository: IAgentBinaryRepository,
+        http_agent_binary_server_registrar: IHTTPAgentBinaryServerRegistrar,
         propagation_credentials_repository: IPropagationCredentialsRepository,
         tcp_port_selector: TCPPortSelector,
         otp_provider: IAgentOTPProvider,
@@ -58,6 +62,7 @@ class Plugin:
         self._agent_id = agent_id
         self._agent_event_publisher = agent_event_publisher
         self._agent_binary_repository = agent_binary_repository
+        self._http_agent_binary_server_registrar = http_agent_binary_server_registrar
         self._propagation_credentials_repository = propagation_credentials_repository
         self._tcp_port_selector = tcp_port_selector
         self._otp_provider = otp_provider
@@ -119,22 +124,17 @@ class Plugin:
         exploit_client = SNMPExploitClient(
             self._agent_id, self._agent_event_publisher, self._plugin_name, snmp_client
         )
+        destination_path = get_agent_dst_path(target_host)
         args = [MONKEY_ARG]
         args.extend(
             build_monkey_commandline_parameters(
                 parent=self._agent_id, servers=servers, depth=current_depth + 1
             )
         )
-        dropper_script_server_factory = partial(
-            start_dropper_script_server,
-            target_host=target_host,
-            agent_binary_repository=self._agent_binary_repository,
-            tcp_port_selector=self._tcp_port_selector,
-            destination_path=get_agent_dst_path(target_host),
-            args=args,
-        )
+        dropper_transform = partial(build_bash_dropper, destination_path, args)
         return SNMPExploiter(
             exploit_client,
-            dropper_script_server_factory,
+            self._http_agent_binary_server_registrar,
+            dropper_transform,
             self._otp_provider,
         )

--- a/monkey/agent_plugins/exploiters/snmp/src/snmp_exploiter.py
+++ b/monkey/agent_plugins/exploiters/snmp/src/snmp_exploiter.py
@@ -1,10 +1,13 @@
 from logging import getLogger
-from pathlib import PurePath
-from typing import Callable, Iterable
+from typing import Iterable
 
 from common.types import Event
 from infection_monkey.exploit import IAgentOTPProvider
-from infection_monkey.exploit.tools import HTTPBytesServer
+from infection_monkey.exploit.i_http_agent_binary_server_registrar import (
+    AgentBinaryTransform,
+    IHTTPAgentBinaryServerRegistrar,
+    ReservationID,
+)
 from infection_monkey.i_puppet import ExploiterResultData, TargetHost
 from infection_monkey.utils.threading import interruptible_iter
 
@@ -14,18 +17,18 @@ from .snmp_options import SNMPOptions
 
 logger = getLogger(__name__)
 
-DropperScriptServerFactory = Callable[[], HTTPBytesServer]
-
 
 class SNMPExploiter:
     def __init__(
         self,
         exploit_client: SNMPExploitClient,
-        dropper_script_server_factory: DropperScriptServerFactory,
+        http_agent_binary_server_registrar: IHTTPAgentBinaryServerRegistrar,
+        transform_agent_binary: AgentBinaryTransform,
         otp_provider: IAgentOTPProvider,
     ):
         self._exploit_client = exploit_client
-        self._dropper_script_server_factory = dropper_script_server_factory
+        self._http_agent_binary_server_registrar = http_agent_binary_server_registrar
+        self._transform_agent_binary = transform_agent_binary
         self._otp_provider = otp_provider
 
     def exploit_host(
@@ -38,7 +41,9 @@ class SNMPExploiter:
         try:
             logger.debug("Starting the agent binary server")
 
-            agent_binary_http_server = self._dropper_script_server_factory()
+            download_ticket = self._http_agent_binary_server_registrar.reserve_download(
+                host.operating_system, host.ip, self._transform_agent_binary
+            )
         except Exception as err:
             msg = (
                 "An unexpected exception occurred while attempting to start the agent binary HTTP "
@@ -51,7 +56,7 @@ class SNMPExploiter:
 
         command = build_snmp_command(
             host,
-            agent_binary_http_server.download_url,
+            download_ticket.download_url,
             self._otp_provider.get_otp(),
         )
 
@@ -61,7 +66,7 @@ class SNMPExploiter:
                 options,
                 community_strings,
                 command,
-                agent_binary_http_server.bytes_downloaded,
+                download_ticket.download_completed,
                 interrupt,
             )
         except Exception as err:
@@ -71,7 +76,9 @@ class SNMPExploiter:
                 exploitation_success=False, propagation_success=False, error_message=msg
             )
         finally:
-            _stop_agent_binary_http_server(agent_binary_http_server)
+            _clear_agent_binary_reservation(
+                self._http_agent_binary_server_registrar, download_ticket.id
+            )
 
     def _brute_force_exploit_host(
         self,
@@ -102,9 +109,13 @@ class SNMPExploiter:
         return exploit_result
 
 
-def _stop_agent_binary_http_server(agent_binary_http_server: HTTPBytesServer):
+def _clear_agent_binary_reservation(
+    agent_binary_http_registrar: IHTTPAgentBinaryServerRegistrar, reservation_id: ReservationID
+):
     try:
-        logger.debug("Stopping the agent binary server")
-        agent_binary_http_server.stop()
+        logger.debug("Clearing the agent binary download reservation")
+        agent_binary_http_registrar.clear_reservation(reservation_id)
     except Exception:
-        logger.exception("An unexpected error occurred while stopping the HTTP server")
+        logger.exception(
+            "An unexpected error occurred while clearing the agent binary download reservation"
+        )

--- a/monkey/infection_monkey/exploit/tools/http_agent_binary_server.py
+++ b/monkey/infection_monkey/exploit/tools/http_agent_binary_server.py
@@ -1,14 +1,9 @@
-from pathlib import PurePath
-from typing import Sequence
-
-from common import OperatingSystem
 from common.types import SocketAddress
 from infection_monkey.exploit import IAgentBinaryRepository
 from infection_monkey.exploit.tools import HTTPBytesServer
 from infection_monkey.i_puppet import TargetHost
 from infection_monkey.network import TCPPortSelector
 from infection_monkey.network.tools import get_interface_to_target
-from infection_monkey.utils.script_dropper import build_bash_dropper
 
 
 def start_agent_binary_server(
@@ -32,36 +27,6 @@ def start_agent_binary_server(
     agent_binary = agent_binary_repository.get_agent_binary(target_host.operating_system).read()
 
     return start_http_bytes_server(target_host, agent_binary, tcp_port_selector)
-
-
-def start_dropper_script_server(
-    target_host: TargetHost,
-    agent_binary_repository: IAgentBinaryRepository,
-    tcp_port_selector: TCPPortSelector,
-    destination_path: PurePath,
-    args: Sequence[str],
-) -> HTTPBytesServer:
-    """
-    Starts an HTTP server that serves the dropper script
-
-    :param target_host: The host for whom to serve the dropper script
-    :param agent_binary_repository: The repository that contains the agent binary
-    :param tcp_port_selector: The TCP port selector to use
-    :param destination_path: The destination path into which to drop the agent payload
-    :param args: The arguments to pass to the agent payload
-
-    :return: The started HTTPBytesServer that serves the provided data
-    """
-    if target_host.operating_system is None:
-        raise ValueError("The operating system of the target host is unknown")
-
-    if target_host.operating_system is OperatingSystem.WINDOWS:
-        raise NotImplementedError("Windows is not supported, yet")
-
-    agent_binary = agent_binary_repository.get_agent_binary(target_host.operating_system).read()
-    dropper_script = build_bash_dropper(destination_path, args, agent_binary)
-
-    return start_http_bytes_server(target_host, dropper_script, tcp_port_selector)
 
 
 def start_http_bytes_server(

--- a/monkey/tests/unit_tests/agent_plugins/exploiters/snmp/test_snmp_exploiter.py
+++ b/monkey/tests/unit_tests/agent_plugins/exploiters/snmp/test_snmp_exploiter.py
@@ -1,7 +1,6 @@
 from ipaddress import IPv4Address
-from pathlib import PurePath
 from threading import Event
-from typing import Callable, Sequence
+from typing import Callable
 from unittest.mock import MagicMock
 
 import pytest
@@ -11,7 +10,10 @@ from agent_plugins.exploiters.snmp.src.snmp_options import SNMPOptions
 
 from common import OperatingSystem
 from infection_monkey.exploit import IAgentOTPProvider
-from infection_monkey.exploit.tools import HTTPBytesServer
+from infection_monkey.exploit.i_http_agent_binary_server_registrar import (
+    AgentBinaryTransform,
+    IHTTPAgentBinaryServerRegistrar,
+)
 from infection_monkey.i_puppet import ExploiterResultData, TargetHost
 
 TARGET_IP = IPv4Address("1.1.1.1")
@@ -25,12 +27,14 @@ def target_host() -> TargetHost:
 
 
 @pytest.fixture
-def mock_bytes_server() -> HTTPBytesServer:
-    mock_bytes_server = MagicMock(spec=HTTPBytesServer)
-    mock_bytes_server.download_url = DOWNLOAD_URL
-    mock_bytes_server.bytes_downloaded = Event()
-    mock_bytes_server.bytes_downloaded.set()
-    return mock_bytes_server
+def mock_http_agent_binary_server_registrar() -> IHTTPAgentBinaryServerRegistrar:
+    mock_registrar = MagicMock(spec=IHTTPAgentBinaryServerRegistrar)
+    return mock_registrar
+
+
+@pytest.fixture
+def mock_agent_binary_transform() -> AgentBinaryTransform:
+    return MagicMock()
 
 
 @pytest.fixture
@@ -38,11 +42,6 @@ def mock_snmp_exploit_client() -> SNMPExploitClient:
     mock_snmp_exploit_client = MagicMock(spec=SNMPExploitClient)
     mock_snmp_exploit_client.exploit_host.return_value = (False, False)
     return mock_snmp_exploit_client
-
-
-@pytest.fixture
-def mock_start_dropper_script_server(mock_bytes_server) -> HTTPBytesServer:
-    return MagicMock(return_value=mock_bytes_server)
 
 
 @pytest.fixture
@@ -55,14 +54,14 @@ def mock_otp_provider():
 @pytest.fixture
 def snmp_exploiter(
     mock_snmp_exploit_client: SNMPExploitClient,
-    mock_start_dropper_script_server: Callable[
-        [TargetHost, PurePath, Sequence[str]], HTTPBytesServer
-    ],
+    mock_http_agent_binary_server_registrar: IHTTPAgentBinaryServerRegistrar,
+    mock_agent_binary_transform: AgentBinaryTransform,
     mock_otp_provider: IAgentOTPProvider,
 ) -> SNMPExploiter:
     return SNMPExploiter(
         mock_snmp_exploit_client,
-        mock_start_dropper_script_server,
+        mock_http_agent_binary_server_registrar,
+        mock_agent_binary_transform,
         mock_otp_provider,
     )
 
@@ -82,46 +81,51 @@ def exploit_host(
     return _inner
 
 
-def test_exploit_host__succeeds(exploit_host, mock_snmp_exploit_client, mock_bytes_server):
+def test_exploit_host__succeeds(
+    exploit_host,
+    mock_snmp_exploit_client,
+    mock_http_agent_binary_server_registrar,
+):
     mock_snmp_exploit_client.exploit_host.return_value = (True, True)
     result = exploit_host()
 
-    assert mock_bytes_server.stop.called
+    assert mock_http_agent_binary_server_registrar.clear_reservation.called
+    assert mock_http_agent_binary_server_registrar.reserve_download.called
     assert result.exploitation_success
     assert result.propagation_success
 
 
-def test_exploit_host__fails_if_server_fails_to_start(
-    exploit_host, mock_start_dropper_script_server, mock_bytes_server
+def test_exploit_host__fails_if_reserve_download_fails(
+    exploit_host, mock_http_agent_binary_server_registrar
 ):
-    mock_start_dropper_script_server.side_effect = Exception()
+    mock_http_agent_binary_server_registrar.reserve_download.side_effect = Exception()
     result = exploit_host()
 
-    assert not mock_bytes_server.stop.called
+    assert not mock_http_agent_binary_server_registrar.clear_reservation.called
     assert not result.exploitation_success
     assert not result.propagation_success
 
 
 def test_exploit_host__success_returned_on_server_stop_fail(
-    exploit_host, mock_snmp_exploit_client, mock_bytes_server
+    exploit_host, mock_snmp_exploit_client, mock_http_agent_binary_server_registrar
 ):
     mock_snmp_exploit_client.exploit_host.return_value = (True, True)
-    mock_bytes_server.stop.side_effect = Exception()
+    mock_http_agent_binary_server_registrar.clear_reservation.side_effect = Exception()
 
     result = exploit_host()
 
-    assert mock_bytes_server.stop.called
+    assert mock_http_agent_binary_server_registrar.clear_reservation.called
     assert result.exploitation_success
     assert result.propagation_success
 
 
 def test_exploit_host__fails_on_snmp_exception(
-    mock_snmp_exploit_client, exploit_host, mock_bytes_server
+    mock_snmp_exploit_client, exploit_host, mock_http_agent_binary_server_registrar
 ):
     mock_snmp_exploit_client.exploit_host.side_effect = Exception()
     result = exploit_host()
 
-    assert mock_bytes_server.stop.called
+    assert mock_http_agent_binary_server_registrar.clear_reservation.called
     assert not result.exploitation_success
     assert not result.propagation_success
 


### PR DESCRIPTION
# What does this PR do?

Fixes part of #3410.

Updates SNMP exploiter to use the `HTTPAgentBinaryServer`

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [x] Any other testing performed?
    > Tested by running in the zoo environment
* [ ] If applicable, add screenshots or log transcripts of the feature working
