### PR TITLE
3415 use agent plugin service

### DIFF
--- a/monkey/monkey_island/cc/resources/exploitations/monkey_exploitation.py
+++ b/monkey/monkey_island/cc/resources/exploitations/monkey_exploitation.py
@@ -3,11 +3,8 @@ from dataclasses import asdict
 from flask_security import auth_token_required, roles_accepted
 
 from monkey_island.cc.flask_utils import AbstractResource
-from monkey_island.cc.repositories import (
-    IAgentEventRepository,
-    IAgentPluginRepository,
-    IMachineRepository,
-)
+from monkey_island.cc.repositories import IAgentEventRepository, IMachineRepository
+from monkey_island.cc.services.agent_plugin_service import IAgentPluginService
 from monkey_island.cc.services.authentication_service import AccountRole
 from monkey_island.cc.services.reporting.exploitations.monkey_exploitation import (
     get_monkey_exploited,
@@ -21,11 +18,11 @@ class MonkeyExploitation(AbstractResource):
         self,
         event_repository: IAgentEventRepository,
         machine_repository: IMachineRepository,
-        agent_plugin_repository: IAgentPluginRepository,
+        agent_plugin_service: IAgentPluginService,
     ):
         self._event_repository = event_repository
         self._machine_repository = machine_repository
-        self._agent_plugin_repository = agent_plugin_repository
+        self._agent_plugin_service = agent_plugin_service
 
     @auth_token_required
     @roles_accepted(AccountRole.ISLAND_INTERFACE.name)
@@ -33,7 +30,7 @@ class MonkeyExploitation(AbstractResource):
         monkey_exploitations = [
             asdict(exploitation)
             for exploitation in get_monkey_exploited(
-                self._event_repository, self._machine_repository, self._agent_plugin_repository
+                self._event_repository, self._machine_repository, self._agent_plugin_service
             )
         ]
         return {"monkey_exploitations": monkey_exploitations}

--- a/monkey/monkey_island/cc/resources/ransomware_report.py
+++ b/monkey/monkey_island/cc/resources/ransomware_report.py
@@ -2,11 +2,8 @@ from flask import jsonify
 from flask_security import auth_token_required, roles_accepted
 
 from monkey_island.cc.flask_utils import AbstractResource
-from monkey_island.cc.repositories import (
-    IAgentEventRepository,
-    IAgentPluginRepository,
-    IMachineRepository,
-)
+from monkey_island.cc.repositories import IAgentEventRepository, IMachineRepository
+from monkey_island.cc.services.agent_plugin_service import IAgentPluginService
 from monkey_island.cc.services.authentication_service import AccountRole
 from monkey_island.cc.services.ransomware import ransomware_report
 
@@ -18,11 +15,11 @@ class RansomwareReport(AbstractResource):
         self,
         event_repository: IAgentEventRepository,
         machine_repository: IMachineRepository,
-        agent_plugin_repository: IAgentPluginRepository,
+        agent_plugin_service: IAgentPluginService,
     ):
         self._event_repository = event_repository
         self._machine_repository = machine_repository
-        self._agent_plugin_repository = agent_plugin_repository
+        self._agent_plugin_service = agent_plugin_service
 
     @auth_token_required
     @roles_accepted(AccountRole.ISLAND_INTERFACE.name)
@@ -30,7 +27,7 @@ class RansomwareReport(AbstractResource):
         return jsonify(
             {
                 "propagation_stats": ransomware_report.get_propagation_stats(
-                    self._event_repository, self._machine_repository, self._agent_plugin_repository
+                    self._event_repository, self._machine_repository, self._agent_plugin_service
                 ),
             }
         )

--- a/monkey/monkey_island/cc/services/agent_configuration_service/agent_configuration_schema_compiler.py
+++ b/monkey/monkey_island/cc/services/agent_configuration_service/agent_configuration_schema_compiler.py
@@ -9,7 +9,7 @@ from common.hard_coded_manifests import HARD_CODED_PAYLOADS_MANIFESTS
 from common.hard_coded_manifests.hard_coded_fingerprinter_manifests import (
     HARD_CODED_FINGERPRINTER_MANIFESTS,
 )
-from monkey_island.cc.repositories import IAgentPluginRepository
+from monkey_island.cc.services.agent_plugin_service import IAgentPluginService
 
 from .hard_coded_schemas import HARD_CODED_FINGERPRINTER_SCHEMAS, HARD_CODED_PAYLOADS_SCHEMAS
 
@@ -22,8 +22,8 @@ PLUGIN_PATH_IN_SCHEMA = {
 
 
 class AgentConfigurationSchemaCompiler:
-    def __init__(self, agent_plugin_repository: IAgentPluginRepository):
-        self._agent_plugin_repository = agent_plugin_repository
+    def __init__(self, agent_plugin_service: IAgentPluginService):
+        self._agent_plugin_service = agent_plugin_service
 
     def get_schema(self) -> Dict[str, Any]:
         try:
@@ -41,14 +41,12 @@ class AgentConfigurationSchemaCompiler:
         # proper plugins
         schema = self._add_hard_coded_plugins(schema)
 
-        config_schemas = deepcopy(
-            self._agent_plugin_repository.get_all_plugin_configuration_schemas()
-        )
+        config_schemas = deepcopy(self._agent_plugin_service.get_all_plugin_configuration_schemas())
 
         for plugin_type in config_schemas.keys():
             for plugin_name in config_schemas[plugin_type].keys():
                 config_schema = config_schemas[plugin_type][plugin_name]
-                plugin_manifest = self._agent_plugin_repository.get_all_plugin_manifests()[
+                plugin_manifest = self._agent_plugin_service.get_all_plugin_manifests()[
                     plugin_type
                 ][plugin_name]
                 config_schema.update(plugin_manifest.dict(simplify=True))

--- a/monkey/monkey_island/cc/services/initialize.py
+++ b/monkey/monkey_island/cc/services/initialize.py
@@ -100,7 +100,7 @@ def initialize_services(container: DIContainer, data_dir: Path):
         container.resolve(IAgentEventRepository),
         container.resolve(IMachineRepository),
         container.resolve(INodeRepository),
-        container.resolve(IAgentPluginRepository),
+        container.resolve(IAgentPluginService),
     )
 
 

--- a/monkey/monkey_island/cc/services/initialize.py
+++ b/monkey/monkey_island/cc/services/initialize.py
@@ -212,8 +212,8 @@ def _register_services(container: DIContainer):
     container.register_instance(AWSService, container.resolve(AWSService))
     container.register_instance(AgentSignalsService, container.resolve(AgentSignalsService))
     container.register_instance(IAgentBinaryService, build_agent_binary_service(container))
+    container.register_instance(IAgentPluginService, container.resolve(AgentPluginService))
     container.register_instance(
         IAgentConfigurationService, build_agent_configuration_service(container)
     )
-    container.register_instance(IAgentPluginService, container.resolve(AgentPluginService))
     container.register_instance(LocalMonkeyRunService, container.resolve(LocalMonkeyRunService))

--- a/monkey/monkey_island/cc/services/ransomware/ransomware_report.py
+++ b/monkey/monkey_island/cc/services/ransomware/ransomware_report.py
@@ -1,10 +1,7 @@
 from typing import Dict, List
 
-from monkey_island.cc.repositories import (
-    IAgentEventRepository,
-    IAgentPluginRepository,
-    IMachineRepository,
-)
+from monkey_island.cc.repositories import IAgentEventRepository, IMachineRepository
+from monkey_island.cc.services.agent_plugin_service import IAgentPluginService
 from monkey_island.cc.services.reporting.exploitations.monkey_exploitation import (
     MonkeyExploitation,
     get_monkey_exploited,
@@ -15,10 +12,10 @@ from monkey_island.cc.services.reporting.report import ReportService
 def get_propagation_stats(
     event_repository: IAgentEventRepository,
     machine_repository: IMachineRepository,
-    agent_plugin_repository: IAgentPluginRepository,
+    agent_plugin_service: IAgentPluginService,
 ) -> Dict:
     scanned = ReportService.get_scanned()
-    exploited = get_monkey_exploited(event_repository, machine_repository, agent_plugin_repository)
+    exploited = get_monkey_exploited(event_repository, machine_repository, agent_plugin_service)
 
     return {
         "num_scanned_nodes": len(scanned),

--- a/monkey/monkey_island/cc/services/reporting/exploitations/monkey_exploitation.py
+++ b/monkey/monkey_island/cc/services/reporting/exploitations/monkey_exploitation.py
@@ -6,11 +6,8 @@ from typing import Dict, List, Sequence
 from common.agent_events import ExploitationEvent
 from common.agent_plugins import AgentPluginManifest, AgentPluginType
 from monkey_island.cc.models import Machine
-from monkey_island.cc.repositories import (
-    IAgentEventRepository,
-    IAgentPluginRepository,
-    IMachineRepository,
-)
+from monkey_island.cc.repositories import IAgentEventRepository, IMachineRepository
+from monkey_island.cc.services.agent_plugin_service import IAgentPluginService
 
 logger = logging.getLogger(__name__)
 
@@ -26,11 +23,11 @@ class MonkeyExploitation:
 def get_monkey_exploited(
     event_repository: IAgentEventRepository,
     machine_repository: IMachineRepository,
-    agent_plugin_repository: IAgentPluginRepository,
+    agent_plugin_service: IAgentPluginService,
 ) -> List[MonkeyExploitation]:
     exploits = event_repository.get_events_by_type(ExploitationEvent)
     successful_exploits = [e for e in exploits if e.success]
-    plugin_manifests = agent_plugin_repository.get_all_plugin_manifests()
+    plugin_manifests = agent_plugin_service.get_all_plugin_manifests()
 
     exploited_machines = {
         machine_repository.get_machines_by_ip(e.target)[0] for e in successful_exploits

--- a/monkey/monkey_island/cc/services/reporting/report.py
+++ b/monkey/monkey_island/cc/services/reporting/report.py
@@ -26,12 +26,12 @@ from common.types import PortStatus
 from monkey_island.cc.models import CommunicationType, Machine
 from monkey_island.cc.repositories import (
     IAgentEventRepository,
-    IAgentPluginRepository,
     IAgentRepository,
     IMachineRepository,
     INodeRepository,
 )
 from monkey_island.cc.services import IAgentConfigurationService
+from monkey_island.cc.services.agent_plugin_service import IAgentPluginService
 from monkey_island.cc.services.reporting.exploitations.monkey_exploitation import (
     get_monkey_exploited,
 )
@@ -67,7 +67,7 @@ class ReportService:
     _agent_event_repository: Optional[IAgentEventRepository] = None
     _machine_repository: Optional[IMachineRepository] = None
     _node_repository: Optional[INodeRepository] = None
-    _agent_plugin_repository: Optional[IAgentPluginRepository] = None
+    _agent_plugin_service: Optional[IAgentPluginService] = None
     _report: Dict[str, Dict] = {}
     _report_generation_lock: Lock = Lock()
 
@@ -79,14 +79,14 @@ class ReportService:
         agent_event_repository: IAgentEventRepository,
         machine_repository: IMachineRepository,
         node_repository: INodeRepository,
-        agent_plugin_repository: IAgentPluginRepository,
+        agent_plugin_service: IAgentPluginService,
     ):
         cls._agent_repository = agent_repository
         cls._agent_configuration_service = agent_configuration_service
         cls._agent_event_repository = agent_event_repository
         cls._machine_repository = machine_repository
         cls._node_repository = node_repository
-        cls._agent_plugin_repository = agent_plugin_repository
+        cls._agent_plugin_service = agent_plugin_service
 
     # This should pull from Simulation entity
     @classmethod
@@ -450,7 +450,7 @@ class ReportService:
         scanned_nodes = ReportService.get_scanned()
         exploited_cnt = len(
             get_monkey_exploited(
-                cls._agent_event_repository, cls._machine_repository, cls._agent_plugin_repository
+                cls._agent_event_repository, cls._machine_repository, cls._agent_plugin_service
             )
         )
         return {
@@ -524,7 +524,7 @@ class ReportService:
 
     @classmethod
     def _get_exploiter_manifests(cls) -> Dict[str, AgentPluginManifest]:
-        exploiter_manifests = cls._agent_plugin_repository.get_all_plugin_manifests().get(  # type: ignore[union-attr] # noqa: E501
+        exploiter_manifests = cls._agent_plugin_service.get_all_plugin_manifests().get(  # type: ignore[union-attr] # noqa: E501
             AgentPluginType.EXPLOITER, {}
         )
         exploiter_manifests = deepcopy(exploiter_manifests)

--- a/monkey/tests/unit_tests/monkey_island/cc/services/agent_configuration_service/test_agent_configuration_schema_compiler.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/agent_configuration_service/test_agent_configuration_schema_compiler.py
@@ -10,6 +10,8 @@ from monkey_island.cc.repositories import IAgentPluginRepository
 from monkey_island.cc.services.agent_configuration_service.agent_configuration_schema_compiler import (  # noqa: E501
     AgentConfigurationSchemaCompiler,
 )
+from monkey_island.cc.services.agent_plugin_service import IAgentPluginService
+from monkey_island.cc.services.agent_plugin_service.agent_plugin_service import AgentPluginService
 
 
 @pytest.fixture
@@ -18,14 +20,19 @@ def agent_plugin_repository() -> IAgentPluginRepository:
 
 
 @pytest.fixture
+def agent_plugin_service(agent_plugin_repository: IAgentPluginRepository) -> IAgentPluginService:
+    return AgentPluginService(agent_plugin_repository)
+
+
+@pytest.fixture
 def config_schema_compiler(
-    agent_plugin_repository: IAgentPluginRepository,
+    agent_plugin_service: IAgentPluginService,
 ) -> AgentConfigurationSchemaCompiler:
-    return AgentConfigurationSchemaCompiler(agent_plugin_repository)
+    return AgentConfigurationSchemaCompiler(agent_plugin_service)
 
 
 def test_get_schema__adds_exploiter_plugins_to_schema(
-    config_schema_compiler, agent_plugin_repository
+    config_schema_compiler: AgentConfigurationSchemaCompiler, agent_plugin_repository
 ):
     agent_plugin_repository.save_plugin(FAKE_AGENT_PLUGIN_1)
     agent_plugin_repository.save_plugin(FAKE_AGENT_PLUGIN_2)

--- a/monkey/tests/unit_tests/monkey_island/cc/services/ransomware/test_ransomware_report.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/ransomware/test_ransomware_report.py
@@ -2,11 +2,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from monkey_island.cc.repositories import (
-    IAgentEventRepository,
-    IAgentPluginRepository,
-    IMachineRepository,
-)
+from monkey_island.cc.repositories import IAgentEventRepository, IMachineRepository
+from monkey_island.cc.services.agent_plugin_service import IAgentPluginService
 from monkey_island.cc.services.ransomware import ransomware_report
 from monkey_island.cc.services.reporting.exploitations.monkey_exploitation import MonkeyExploitation
 from monkey_island.cc.services.reporting.report import ReportService
@@ -25,8 +22,8 @@ def machine_repository() -> IMachineRepository:
 
 
 @pytest.fixture
-def agent_plugin_repository() -> IAgentPluginRepository:
-    return MagicMock(spec=IAgentPluginRepository)
+def agent_plugin_service() -> IAgentPluginService:
+    return MagicMock(spec=IAgentPluginService)
 
 
 @pytest.fixture
@@ -45,30 +42,30 @@ def patch_report_service_for_stats(monkeypatch):
 
 
 def test_get_propagation_stats__num_scanned(
-    patch_report_service_for_stats, event_repository, machine_repository, agent_plugin_repository
+    patch_report_service_for_stats, event_repository, machine_repository, agent_plugin_service
 ):
     stats = ransomware_report.get_propagation_stats(
-        event_repository, machine_repository, agent_plugin_repository
+        event_repository, machine_repository, agent_plugin_service
     )
 
     assert stats["num_scanned_nodes"] == 4
 
 
 def test_get_propagation_stats__num_exploited(
-    patch_report_service_for_stats, event_repository, machine_repository, agent_plugin_repository
+    patch_report_service_for_stats, event_repository, machine_repository, agent_plugin_service
 ):
     stats = ransomware_report.get_propagation_stats(
-        event_repository, machine_repository, agent_plugin_repository
+        event_repository, machine_repository, agent_plugin_service
     )
 
     assert stats["num_exploited_nodes"] == 3
 
 
 def test_get_propagation_stats__num_exploited_per_exploit(
-    patch_report_service_for_stats, event_repository, machine_repository, agent_plugin_repository
+    patch_report_service_for_stats, event_repository, machine_repository, agent_plugin_service
 ):
     stats = ransomware_report.get_propagation_stats(
-        event_repository, machine_repository, agent_plugin_repository
+        event_repository, machine_repository, agent_plugin_service
     )
 
     assert stats["num_exploited_per_exploit"]["SSH Exploiter"] == 2

--- a/monkey/tests/unit_tests/monkey_island/cc/services/reporting/test_report.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/reporting/test_report.py
@@ -29,11 +29,8 @@ from common.agent_events import (
 from common.agent_plugins import AgentPluginType
 from common.types import SocketAddress
 from monkey_island.cc.models import Agent, CommunicationType, Machine, Node
-from monkey_island.cc.repositories import (
-    IAgentEventRepository,
-    IAgentPluginRepository,
-    IAgentRepository,
-)
+from monkey_island.cc.repositories import IAgentEventRepository, IAgentRepository
+from monkey_island.cc.services.agent_plugin_service import IAgentPluginService
 from monkey_island.cc.services.reporting.report import ReportService
 
 EVENT_1 = AgentShutdownEvent(source=UUID("2d56f972-78a8-4026-9f47-2dfd550ee207"), timestamp=10)
@@ -233,15 +230,15 @@ def agent_event_repository() -> IAgentEventRepository:
 
 
 @pytest.fixture
-def mock_agent_plugin_repository() -> IAgentPluginRepository:
-    return MagicMock(spec=IAgentPluginRepository)
+def mock_agent_plugin_service() -> IAgentPluginService:
+    return MagicMock(spec=IAgentPluginService)
 
 
 @pytest.fixture(autouse=True)
 def report_service(
     agent_repository: IAgentRepository,
     agent_event_repository: IAgentEventRepository,
-    mock_agent_plugin_repository: IAgentPluginRepository,
+    mock_agent_plugin_service: IAgentPluginService,
 ):
     ReportService._machine_repository = MagicMock()
     ReportService._machine_repository.get_machines.return_value = MACHINES
@@ -251,7 +248,7 @@ def report_service(
     ReportService._node_repository.get_nodes.return_value = NODES
     ReportService._agent_event_repository = agent_event_repository
     ReportService._agent_configuration_service = InMemoryAgentConfigurationService()
-    ReportService._agent_plugin_repository = mock_agent_plugin_repository
+    ReportService._agent_plugin_service = mock_agent_plugin_service
 
 
 def test_get_scanned():


### PR DESCRIPTION
# What does this PR do?

Fixes part of #3415.

Updates users of `IAgentPluginRepository` to instead use `IAgentPluginService`.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] ~Is the TravisCI build passing?~
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [x] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
