### PR TITLE
Ransomware: Add InternalRansomwareOptions object

### DIFF
--- a/monkey/agent_plugins/payloads/ransomware/src/internal_ransomware_options.py
+++ b/monkey/agent_plugins/payloads/ransomware/src/internal_ransomware_options.py
@@ -1,0 +1,40 @@
+import logging
+from pathlib import Path
+from typing import Optional
+
+from common import OperatingSystem
+from common.utils.environment import get_os
+from common.utils.file_utils import InvalidPath, expand_path
+
+from .ransomware_options import RansomwareOptions
+
+logger = logging.getLogger(__name__)
+
+
+class InternalRansomwareOptions:
+    def __init__(self, options: RansomwareOptions):
+        self.file_extension: Optional[str] = options.file_extension
+        self.leave_readme: bool = options.leave_readme
+        self.target_directory: Optional[Path] = InternalRansomwareOptions._choose_target_directory(
+            options
+        )
+
+    @staticmethod
+    def _choose_target_directory(options: RansomwareOptions) -> Optional[Path]:
+        local_operating_system = get_os()
+
+        target_directory: str = (
+            options.linux_target_dir
+            if local_operating_system == OperatingSystem.LINUX
+            else options.windows_target_dir
+        )
+
+        if target_directory is None or target_directory == "":
+            return None
+
+        try:
+            return expand_path(target_directory)
+        except InvalidPath as e:
+            logger.debug(f"Target ransomware directory set to None: {e}")
+
+        return None

--- a/monkey/tests/unit_tests/agent_plugins/payloads/ransomware/test_internal_ransomware_options.py
+++ b/monkey/tests/unit_tests/agent_plugins/payloads/ransomware/test_internal_ransomware_options.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+from typing import Callable, Optional
+
+import pytest
+from agent_plugins.payloads.ransomware.src import internal_ransomware_options
+from agent_plugins.payloads.ransomware.src.internal_ransomware_options import (
+    InternalRansomwareOptions,
+)
+from agent_plugins.payloads.ransomware.src.ransomware_options import RansomwareOptions
+from tests.utils import raise_
+
+from common import OperatingSystem
+from common.utils.environment import get_os
+from common.utils.file_utils import InvalidPath
+
+LINUX_DIR = "/tmp/test"
+WINDOWS_DIR = "C:\\tmp\\test"
+
+RANSOMWARE_OPTIONS_OBJECT = RansomwareOptions(
+    file_extension=".encrypted",
+    linux_target_dir=LINUX_DIR,
+    windows_target_dir=WINDOWS_DIR,
+    leave_readme=True,
+)
+
+
+@pytest.mark.parametrize("file_extension", (".xyz", ".m0nk3y"))
+def test_file_extension(file_extension: str):
+    internal_options = InternalRansomwareOptions(RansomwareOptions(file_extension=file_extension))
+
+    assert internal_options.file_extension == file_extension
+
+
+@pytest.mark.parametrize("leave_readme", (True, False))
+def test_leave_readme(leave_readme: bool):
+    internal_options = InternalRansomwareOptions(RansomwareOptions(leave_readme=leave_readme))
+
+    assert internal_options.leave_readme == leave_readme
+
+
+def test_linux_target_dir(monkeypatch: Callable):
+    monkeypatch.setattr(internal_ransomware_options, "get_os", lambda: OperatingSystem.LINUX)
+
+    internal_options = InternalRansomwareOptions(RANSOMWARE_OPTIONS_OBJECT)
+    assert internal_options.target_directory == Path(LINUX_DIR)
+
+
+def test_windows_target_dir(monkeypatch: Callable):
+    monkeypatch.setattr(internal_ransomware_options, "get_os", lambda: OperatingSystem.WINDOWS)
+
+    internal_options = InternalRansomwareOptions(RANSOMWARE_OPTIONS_OBJECT)
+    assert internal_options.target_directory == Path(WINDOWS_DIR)
+
+
+def test_env_variables_in_target_dir_resolved(home_env_variable: str, patched_home_env: str):
+    path_with_env_variable = f"{home_env_variable}/ransomware_target"
+    if get_os() == OperatingSystem.LINUX:
+        options = RansomwareOptions(linux_target_dir=path_with_env_variable)
+    else:
+        options = RansomwareOptions(windows_target_dir=path_with_env_variable)
+
+    internal_options = InternalRansomwareOptions(options)
+
+    assert internal_options.target_directory == patched_home_env / "ransomware_target"
+
+
+@pytest.mark.parametrize("target_dir", (None, ""))
+def test_empty_target_dir(target_dir: Optional[str]):
+    options = RansomwareOptions(linux_target_dir=target_dir, windows_target_dir=target_dir)
+
+    internal_options = InternalRansomwareOptions(options)
+
+    assert internal_options.target_directory is None
+
+
+def test_invalid_target_dir(monkeypatch: Callable):
+    monkeypatch.setattr(
+        internal_ransomware_options, "expand_path", lambda _: raise_(InvalidPath("invalid"))
+    )
+
+    internal_options = InternalRansomwareOptions(RANSOMWARE_OPTIONS_OBJECT)
+
+    assert internal_options.target_directory is None


### PR DESCRIPTION
# What does this PR do?

Adds an internal representation of the Ransomware configuration that can be used by the ransomware plugin.

Issue #3391

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
