### PR TITLE
BB: Allow port 8080 on rdp-64

### DIFF
--- a/envs/monkey_zoo/packer/setup_rdp_64.yml
+++ b/envs/monkey_zoo/packer/setup_rdp_64.yml
@@ -16,6 +16,10 @@
           - Administrators
           - "Remote Desktop Users"
 
+    - name: Allow port 8080
+      win_command:
+        cmd: netsh advfirewall firewall add rule name="Allow Port 8080" dir=in action=allow protocol=TCP localport=8080
+
     - name: Change the hostname to rdp-64
       ansible.windows.win_hostname:
         name: rdp-64


### PR DESCRIPTION
# What does this PR do?

Fixes part of #3425.

Allow incoming traffic over port 8080 on rdp-64

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [x] Any other testing performed?
    > Tested by running RDP exploiter with an rdp-64 instance generated with this change
* [ ] If applicable, add screenshots or log transcripts of the feature working
