### PR TITLE
3425 rdp domain logic

### DIFF
--- a/monkey/agent_plugins/exploiters/rdp/Pipfile
+++ b/monkey/agent_plugins/exploiters/rdp/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 aardwolf = {git = "https://github.com/cakekoa/aardwolf.git", ref = "clipboard-file-copy"}
 egg_timer = "*"
+pywin32 = {version = "*", sys_platform = "== 'win32'"}
 
 [dev-packages]
 

--- a/monkey/agent_plugins/exploiters/rdp/Pipfile.lock
+++ b/monkey/agent_plugins/exploiters/rdp/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "04b2d380b6032cbe9417f5b323884a85d2e0d82292b02d423fc004b5ee2c5648"
+            "sha256": "3dcd71abbb257021700d242c9a32d6fa5881c31092034cc91a40580d84a395a2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -218,17 +218,38 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:d554a96d1a7d3ddaf7183104485bc19fd80543ad6ac5bdb6426719d766fb06c1",
-                "sha256:edb662d6fe322d6e990b1594b5feaeadf806803359e3d4d42f11e295e588f0ea"
+                "sha256:32c7c0b711493c72ff18a981d24f28aaf9c1fb7ed5e9667c9e84e3db623bdbfb",
+                "sha256:ede28a1a32462f5a9705e07aea48001a08f7cf81a021585011deba701581a0db"
             ],
             "markers": "python_full_version >= '3.6.8'",
-            "version": "==3.1.0"
+            "version": "==3.1.1"
         },
         "pyperclip": {
             "hashes": [
                 "sha256:105254a8b04934f0bc84e9c24eb360a591aaf6535c9def5f29d92af107a9bf57"
             ],
             "version": "==1.8.2"
+        },
+        "pywin32": {
+            "hashes": [
+                "sha256:06d3420a5155ba65f0b72f2699b5bacf3109f36acbe8923765c22938a69dfc8d",
+                "sha256:1c73ea9a0d2283d889001998059f5eaaba3b6238f767c9cf2833b13e6a685f65",
+                "sha256:37257794c1ad39ee9be652da0462dc2e394c8159dfd913a8a4e8eb6fd346da0e",
+                "sha256:383229d515657f4e3ed1343da8be101000562bf514591ff383ae940cad65458b",
+                "sha256:39b61c15272833b5c329a2989999dcae836b1eed650252ab1b7bfbe1d59f30f4",
+                "sha256:5821ec52f6d321aa59e2db7e0a35b997de60c201943557d108af9d4ae1ec7040",
+                "sha256:70dba0c913d19f942a2db25217d9a1b726c278f483a919f1abfed79c9cf64d3a",
+                "sha256:72c5f621542d7bdd4fdb716227be0dd3f8565c11b280be6315b06ace35487d36",
+                "sha256:84f4471dbca1887ea3803d8848a1616429ac94a4a8d05f4bc9c5dcfd42ca99c8",
+                "sha256:a7639f51c184c0272e93f244eb24dafca9b1855707d94c192d4a0b4c01e1100e",
+                "sha256:e25fd5b485b55ac9c057f67d94bc203f3f6595078d1fb3b458c9c28b7153a802",
+                "sha256:e4c092e2589b5cf0d365849e73e02c391c1349958c5ac3e9d5ccb9a28e017b3a",
+                "sha256:e65028133d15b64d2ed8f06dd9fbc268352478d4f9289e69c190ecd6818b6407",
+                "sha256:e8ac1ae3601bee6ca9f7cb4b5363bf1c0badb935ef243c4733ff9a393b1690c0"
+            ],
+            "index": "pypi",
+            "markers": "sys_platform == 'win32'",
+            "version": "==306"
         },
         "six": {
             "hashes": [

--- a/monkey/agent_plugins/exploiters/rdp/src/plugin.py
+++ b/monkey/agent_plugins/exploiters/rdp/src/plugin.py
@@ -4,10 +4,12 @@ from pprint import pformat
 from typing import Any, Dict, Sequence
 
 # common imports
+from common import OperatingSystem
 from common.agent_events import AgentEventTag
 from common.event_queue import IAgentEventPublisher
 from common.types import AgentID, Event
 from common.utils.code_utils import del_key
+from common.utils.environment import get_os
 
 # dependencies to get rid of or internalize
 from infection_monkey.exploit import IAgentBinaryRepository, IAgentOTPProvider
@@ -92,9 +94,11 @@ class Plugin:
             rdp_options,
             rdp_command_builder,
         )
+        running_from_windows = get_os() == OperatingSystem.WINDOWS
         credentials_generator = partial(
             generate_rdp_credentials,
             domains=rdp_options.domains,
+            running_from_windows=running_from_windows,
         )
         credentials_provider = BruteForceCredentialsProvider(
             self._propagation_credentials_repository, credentials_generator

--- a/monkey/agent_plugins/exploiters/rdp/src/rdp_credentials_generator.py
+++ b/monkey/agent_plugins/exploiters/rdp/src/rdp_credentials_generator.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Sequence
+from typing import Iterable, Sequence, Set
 
 from common.credentials import Credentials, LMHash, NTHash, Password, Username
 from infection_monkey.exploit.tools import (
@@ -9,21 +9,26 @@ from infection_monkey.exploit.tools import (
 
 
 def generate_rdp_credentials(
-    credentials: Sequence[Credentials], domains: Sequence[str]
+    credentials: Sequence[Credentials], domains: Sequence[str], running_from_windows: bool
 ) -> Sequence[Credentials]:
     brute_force_credentials = generate_brute_force_credentials(
         credentials,
         identity_filter=identity_type_filter([Username]),
         secret_filter=secret_type_filter([Password, LMHash, NTHash]),
     )
-    rdp_credentials = list(_add_domains_to_usernames(brute_force_credentials, domains))
+    rdp_credentials = list(
+        _add_domains_to_usernames(brute_force_credentials, domains, running_from_windows)
+    )
 
     return _remove_duplicate_credentials(rdp_credentials)
 
 
 def _add_domains_to_usernames(
-    credentials: Sequence[Credentials], domains: Sequence[str]
+    credentials: Sequence[Credentials], domains: Sequence[str], running_from_windows: bool
 ) -> Iterable[Credentials]:
+    local_domains = _get_domains(running_from_windows)
+    all_domains = [*domains, *local_domains]
+
     for credential in credentials:
         if credential.identity is None:
             continue
@@ -31,11 +36,26 @@ def _add_domains_to_usernames(
         if "\\" in credential.identity.username:
             yield credential
 
-        for domain in domains:
+        for domain in all_domains:
             yield Credentials(
                 identity=Username(username=f"{domain}\\{credential.identity.username}"),
                 secret=credential.secret,
             )
+
+
+def _get_domains(running_from_windows: bool) -> Set[str]:
+    domains = {"."}
+
+    if running_from_windows:
+        domains.add(_get_local_machine_domain())
+
+    return domains
+
+
+def _get_local_machine_domain() -> str:
+    import win32api
+
+    return win32api.GetUserNameEx(win32api.NameSamCompatible).split("\\")[0]
 
 
 def _remove_duplicate_credentials(credentials: Sequence[Credentials]) -> Sequence[Credentials]:

--- a/monkey/tests/unit_tests/agent_plugins/exploiters/rdp/test_rdp_credentials_generator.py
+++ b/monkey/tests/unit_tests/agent_plugins/exploiters/rdp/test_rdp_credentials_generator.py
@@ -1,6 +1,10 @@
+import sys
+from collections import namedtuple
 from copy import copy
 from typing import Sequence, Set, Type
+from unittest.mock import MagicMock
 
+import pytest
 from agent_plugins.exploiters.rdp.src.rdp_credentials_generator import generate_rdp_credentials
 from tests.data_for_tests.propagation_credentials import CREDENTIALS, PASSWORD_1
 
@@ -9,6 +13,24 @@ from common.credentials import Credentials, LMHash, NTHash, Password, Secret, Us
 TEST_CREDENTIALS = copy(CREDENTIALS)
 SECRET_TYPES: Set[Type[Secret]] = {Password, LMHash, NTHash}
 DOMAINS: Sequence[str] = ["TEST_DOMAIN_1", "TEST_DOMAIN_2"]
+
+LOCAL_DOMAIN = "LOCAL_DOMAIN"
+LOCAL_USER = "localuser"
+DomainUser = namedtuple("DomainUser", ["domain", "username"])
+
+
+@pytest.fixture(scope="module")
+def local_user() -> DomainUser:
+    return DomainUser(LOCAL_DOMAIN, LOCAL_USER)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def patch_win32api_get_user_name(local_user: DomainUser):
+    win32api = MagicMock()
+    win32api.GetUserNameEx = MagicMock(return_value=f"{local_user.domain}\\{local_user.username}")
+    win32api.NameSamCompatible = None
+
+    sys.modules["win32api"] = win32api
 
 
 def assert_correct_identity_types(credentials: Sequence[Credentials]):
@@ -40,18 +62,42 @@ def assert_domain_users_added(credentials: Sequence[Credentials], domains: Seque
 
 
 def test_brute_force_credentials_generation():
-    generated_credentials = generate_rdp_credentials(TEST_CREDENTIALS, DOMAINS)
+    generated_credentials = generate_rdp_credentials(
+        TEST_CREDENTIALS, DOMAINS, running_from_windows=False
+    )
 
     assert_correct_identity_types(generated_credentials)
     assert_correct_secret_types(generated_credentials)
     assert_domain_users_added(generated_credentials, DOMAINS)
-    assert len(generated_credentials) == 20
+    assert len(generated_credentials) == 30
+
+
+def test_brute_force_credentials_generation__pulls_local_domains_on_windows():
+    generated_credentials = generate_rdp_credentials(
+        TEST_CREDENTIALS, DOMAINS, running_from_windows=True
+    )
+
+    assert_correct_identity_types(generated_credentials)
+    assert_correct_secret_types(generated_credentials)
+    assert_domain_users_added(generated_credentials, [*DOMAINS, LOCAL_DOMAIN])
+    assert len(generated_credentials) == 40
 
 
 def test_brute_force_credentials_generation__no_domains():
-    generated_credentials = generate_rdp_credentials(TEST_CREDENTIALS, [])
+    generated_credentials = generate_rdp_credentials(
+        TEST_CREDENTIALS, [], running_from_windows=False
+    )
 
-    assert len(generated_credentials) == 0
+    assert len(generated_credentials) == 10
+
+
+def test_brute_force_credentials_generation__no_domains_still_uses_local_domains_on_windows():
+    generated_credentials = generate_rdp_credentials(
+        TEST_CREDENTIALS, [], running_from_windows=True
+    )
+
+    assert_domain_users_added(generated_credentials, [LOCAL_DOMAIN])
+    assert len(generated_credentials) == 20
 
 
 def test_usernames_with_domain():
@@ -60,6 +106,8 @@ def test_usernames_with_domain():
             identity=Username(username="domain\\testuser"), secret=Password(password=PASSWORD_1)
         )
     ]
-    generated_credentials = generate_rdp_credentials(input_credentials, [])
+    generated_credentials = generate_rdp_credentials(
+        input_credentials, [], running_from_windows=False
+    )
 
-    assert len(generated_credentials) == 1
+    assert len(generated_credentials) == 2


### PR DESCRIPTION
# What does this PR do?

Fixes part of #3425.

Considers local domains when generating credentials.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
