### PR TITLE
Cryptojacker fixes

### DIFF
--- a/monkey/agent_plugins/payloads/cryptojacker/src/bitcoin_mining_network_traffic_simulator.py
+++ b/monkey/agent_plugins/payloads/cryptojacker/src/bitcoin_mining_network_traffic_simulator.py
@@ -1,7 +1,20 @@
 from typing import Optional
 
+from common.event_queue import IAgentEventPublisher
+from common.types import AgentID, SocketAddress
+
 
 class BitcoinMiningNetworkTrafficSimulator:
+    def __init__(
+        self,
+        island_server_address: SocketAddress,
+        agent_id: AgentID,
+        agent_event_publisher: IAgentEventPublisher,
+    ):
+        self._island_server_address = island_server_address
+        self._agent_id = agent_id
+        self._agent_event_publisher = agent_event_publisher
+
     def start(self):
         pass
 

--- a/monkey/agent_plugins/payloads/cryptojacker/src/cpu_utilizer.py
+++ b/monkey/agent_plugins/payloads/cryptojacker/src/cpu_utilizer.py
@@ -1,11 +1,19 @@
 from typing import Optional
 
-from common.types import PercentLimited
+from common.event_queue import IAgentEventPublisher
+from common.types import AgentID, PercentLimited
 
 
 class CPUUtilizer:
-    def __init__(self, cpu_utilization: PercentLimited):
+    def __init__(
+        self,
+        cpu_utilization: PercentLimited,
+        agent_id: AgentID,
+        agent_event_publisher: IAgentEventPublisher,
+    ):
         self._cpu_utilization = cpu_utilization
+        self._agent_id = agent_id
+        self._agent_event_publisher = agent_event_publisher
 
     def start(self):
         pass

--- a/monkey/agent_plugins/payloads/cryptojacker/src/cryptojacker.py
+++ b/monkey/agent_plugins/payloads/cryptojacker/src/cryptojacker.py
@@ -2,8 +2,7 @@ import logging
 
 from egg_timer import EggTimer
 
-from common.event_queue import IAgentEventQueue
-from common.types import AgentID, Event, SocketAddress
+from common.types import Event
 
 from .bitcoin_mining_network_traffic_simulator import BitcoinMiningNetworkTrafficSimulator
 from .cpu_utilizer import CPUUtilizer
@@ -25,17 +24,11 @@ class Cryptojacker:
         cpu_utilizer: CPUUtilizer,
         memory_utilizer: MemoryUtilizer,
         bitcoin_mining_network_traffic_simulator: BitcoinMiningNetworkTrafficSimulator,
-        agent_id: AgentID,
-        agent_event_queue: IAgentEventQueue,
-        island_server_address: SocketAddress,
     ):
         self._options = options
         self._cpu_utilizer = cpu_utilizer
         self._memory_utilizer = memory_utilizer
         self._bitcoin_mining_network_traffic_simulator = bitcoin_mining_network_traffic_simulator
-        self._agent_id = agent_id
-        self._agent_event_queue = agent_event_queue
-        self._island_server_address = island_server_address
 
     def run(self, interrupt: Event):
         logger.info("Running cryptojacker payload")

--- a/monkey/agent_plugins/payloads/cryptojacker/src/cryptojacker_builder.py
+++ b/monkey/agent_plugins/payloads/cryptojacker/src/cryptojacker_builder.py
@@ -1,7 +1,7 @@
 import logging
 from pprint import pformat
 
-from common.event_queue import IAgentEventQueue
+from common.event_queue import IAgentEventPublisher
 from common.types import AgentID, PercentLimited, SocketAddress
 
 from .bitcoin_mining_network_traffic_simulator import BitcoinMiningNetworkTrafficSimulator
@@ -16,33 +16,46 @@ logger = logging.getLogger(__name__)
 def build_cryptojacker(
     options: CryptojackerOptions,
     agent_id: AgentID,
-    agent_event_queue: IAgentEventQueue,
+    agent_event_publisher: IAgentEventPublisher,
     island_server_address: SocketAddress,
 ):
     logger.debug(f"Cryptojacker configuration:\n{pformat(options)}")
 
-    cpu_utilizer = _build_cpu_utilizer(options.cpu_utilization)
-    memory_utilizer = _build_memory_utilizer(options.memory_utilization)
-    bitcoin_mining_network_traffic_simulator = _build_bitcoin_mining_network_traffic_simulator()
+    cpu_utilizer = _build_cpu_utilizer(options.cpu_utilization, agent_id, agent_event_publisher)
+    memory_utilizer = _build_memory_utilizer(
+        options.memory_utilization, agent_id, agent_event_publisher
+    )
+    bitcoin_mining_network_traffic_simulator = _build_bitcoin_mining_network_traffic_simulator(
+        island_server_address, agent_id, agent_event_publisher
+    )
 
     return Cryptojacker(
         options=options,
         cpu_utilizer=cpu_utilizer,
         memory_utilizer=memory_utilizer,
         bitcoin_mining_network_traffic_simulator=bitcoin_mining_network_traffic_simulator,
-        agent_id=agent_id,
-        agent_event_queue=agent_event_queue,
-        island_server_address=island_server_address,
     )
 
 
-def _build_cpu_utilizer(cpu_utilization: PercentLimited) -> CPUUtilizer:
-    return CPUUtilizer(cpu_utilization)
+def _build_cpu_utilizer(
+    cpu_utilization: PercentLimited, agent_id: AgentID, agent_event_publisher: IAgentEventPublisher
+) -> CPUUtilizer:
+    return CPUUtilizer(cpu_utilization, agent_id, agent_event_publisher)
 
 
-def _build_memory_utilizer(memory_utilization: PercentLimited) -> MemoryUtilizer:
-    return MemoryUtilizer(memory_utilization)
+def _build_memory_utilizer(
+    memory_utilization: PercentLimited,
+    agent_id: AgentID,
+    agent_event_publisher: IAgentEventPublisher,
+) -> MemoryUtilizer:
+    return MemoryUtilizer(memory_utilization, agent_id, agent_event_publisher)
 
 
-def _build_bitcoin_mining_network_traffic_simulator() -> BitcoinMiningNetworkTrafficSimulator:
-    return BitcoinMiningNetworkTrafficSimulator()
+def _build_bitcoin_mining_network_traffic_simulator(
+    island_server_address: SocketAddress,
+    agent_id: AgentID,
+    agent_event_publisher: IAgentEventPublisher,
+) -> BitcoinMiningNetworkTrafficSimulator:
+    return BitcoinMiningNetworkTrafficSimulator(
+        island_server_address, agent_id, agent_event_publisher
+    )

--- a/monkey/agent_plugins/payloads/cryptojacker/src/memory_utilizer.py
+++ b/monkey/agent_plugins/payloads/cryptojacker/src/memory_utilizer.py
@@ -1,11 +1,19 @@
 from typing import Optional
 
-from common.types import PercentLimited
+from common.event_queue import IAgentEventPublisher
+from common.types import AgentID, PercentLimited
 
 
 class MemoryUtilizer:
-    def __init__(self, memory_utilization: PercentLimited):
+    def __init__(
+        self,
+        memory_utilization: PercentLimited,
+        agent_id: AgentID,
+        agent_event_publisher: IAgentEventPublisher,
+    ):
         self._memory_utilization = memory_utilization
+        self._agent_id = agent_id
+        self._agent_event_publisher = agent_event_publisher
 
     def start(self):
         pass

--- a/monkey/agent_plugins/payloads/cryptojacker/src/plugin.py
+++ b/monkey/agent_plugins/payloads/cryptojacker/src/plugin.py
@@ -50,7 +50,7 @@ class Plugin:
             cryptojacker = build_cryptojacker(
                 options=cryptojacker_options,
                 agent_id=self._agent_id,
-                agent_event_queue=self._agent_event_publisher,
+                agent_event_publisher=self._agent_event_publisher,
                 island_server_address=self._island_server_address,
             )
         except Exception as err:


### PR DESCRIPTION
# What does this PR do?

- Fixes the Cryptojacker payload where `IAgentEventQueue` was expected when it should've been `IAgentEventPublisher`
- ~Removes `cpu_number` from `CPUConsumptionEvent` since [it isn't possible to find the CPU on which a process is running in Windows](https://psutil.readthedocs.io/en/latest/index.html#psutil.Process.cpu_num)~

Issue #3411 

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [x] Do all unit tests pass?
* [ ] ~Do all end-to-end tests pass?~
* [ ] ~Any other testing performed?~
    > ~Tested by {Running the Monkey locally with relevant config/running Island/...}~
* [ ] ~If applicable, add screenshots or log transcripts of the feature working~
