### PR TITLE
3425 win 2012

### DIFF
--- a/monkey/agent_plugins/exploiters/rdp/src/rdp_client.py
+++ b/monkey/agent_plugins/exploiters/rdp/src/rdp_client.py
@@ -34,6 +34,7 @@ class RDPClient:
         self._kb_layout = KeyboardLayoutManager().get_layout_by_shortname("enus")
         self._file_provider = InMemoryFileProvider()
         self._event_loop = asyncio.SelectorEventLoop()
+        self._save_screenshots = False
         asyncio.set_event_loop(self._event_loop)
 
     def connect(
@@ -145,6 +146,7 @@ class RDPClient:
         # Press "Enter" to move past the prompt
         await self._send_vk_keypress(VK_RETURN)
 
+        self._take_screenshot("05_before_copy.png")
         await self._copy_file_to_clipboard(dest.name, file)
 
         logger.debug(
@@ -152,6 +154,7 @@ class RDPClient:
             f"destination path: {dest}"
         )
         await self._remote_paste_file(timeout)
+        self._take_screenshot("06_after_paste.png")
 
         if not await self._remote_file_exists(dest):
             raise Exception(f"Failed to copy file to {dest}")
@@ -169,6 +172,7 @@ class RDPClient:
             await self._synchronize_clipboard()
             if remote_clipboard == RDP_HANDSHAKE:
                 return True
+        self._take_screenshot("01_screen_timeout.png")
 
         return False
 
@@ -182,17 +186,26 @@ class RDPClient:
         await self._synchronize_clipboard()
         await self._open_windows_run_dialog()
         await self._remote_paste()
+        self._take_screenshot("02_restart_file_explorer.png")
         await self._send_vk_keypress(VK_RETURN)
         await asyncio.sleep(1)  # Wait for file explorer to reload
+
+    def _take_screenshot(self, filename):
+        if self._save_screenshots and self._connection.desktop_buffer_has_data:
+            buffer = self._connection.get_desktop_buffer(VIDEO_FORMAT.PIL)
+            buffer.save(filename)
 
     async def _remote_open_folder(self, path: PurePath):
         path_str = str(PureWindowsPath(path))
         await self._open_windows_run_dialog()
         await self._send_keys(path_str)
+        self._take_screenshot("03_open_folder.png")
         await self._send_vk_keypress(VK_RETURN)
         # Wait for window to appear
         await asyncio.sleep(5)
+
         logger.debug(f"Opened file explorer window to: {path_str}")
+        self._take_screenshot("04_folder_opened.png")
 
     async def _remote_file_exists(self, path: PurePath) -> bool:
         path_str = str(PureWindowsPath(path))
@@ -200,6 +213,7 @@ class RDPClient:
         await self._open_windows_run_dialog()
         await self._connection.set_current_clipboard_text(verification_command)
         await self._synchronize_clipboard()
+        self._take_screenshot("07_file_exists.png")
         await self._remote_paste()
         await self._send_vk_keypress(VK_RETURN)
         result = await self._connection.get_current_clipboard_text()
@@ -302,11 +316,16 @@ class RDPClient:
         await self._connection.set_current_clipboard_text(command)
         await self._synchronize_clipboard()
 
+        # Because Copy/Paste using keyboard shortcuts is disabled by default in some
+        # versions of Windows, we use ALT+SPACE,EP which uses the Explorer Window menu
+        # to paste the command to Command Prompt
         alt = self._kb_layout.vk_to_scancode("VK_LMENU")
         space = self._kb_layout.vk_to_scancode("VK_SPACE")
         await self._send_keypress([alt, space])
         await asyncio.sleep(0.5)
         await self._send_keys("ep")
+
+        self._take_screenshot("08_command_pasted.png")
 
         await self._send_vk_keypress(VK_RETURN)
 

--- a/monkey/agent_plugins/exploiters/rdp/src/rdp_client.py
+++ b/monkey/agent_plugins/exploiters/rdp/src/rdp_client.py
@@ -272,8 +272,7 @@ class RDPClient:
     async def _execute_and_verify_command(self, command: str):
         verifiable_command = f"{command} && echo true | clip || echo false | clip"
         await self._open_windows_run_dialog()
-        await self._execute_command("cmd.exe")
-        await self._execute_command(verifiable_command)
+        await self._execute_command_in_shell(verifiable_command)
         result = await self._connection.get_current_clipboard_text()
 
         async with asyncio.timeout(10):
@@ -292,6 +291,23 @@ class RDPClient:
         await self._connection.set_current_clipboard_text(command)
         await self._synchronize_clipboard()
         await self._remote_paste()
+        await self._send_vk_keypress(VK_RETURN)
+
+    async def _execute_command_in_shell(self, command: str):
+        logger.debug("Executing command in shell...")
+
+        await self._execute_command("cmd.exe")
+        await asyncio.sleep(1)
+
+        await self._connection.set_current_clipboard_text(command)
+        await self._synchronize_clipboard()
+
+        alt = self._kb_layout.vk_to_scancode("VK_LMENU")
+        space = self._kb_layout.vk_to_scancode("VK_SPACE")
+        await self._send_keypress([alt, space])
+        await asyncio.sleep(0.5)
+        await self._send_keys("ep")
+
         await self._send_vk_keypress(VK_RETURN)
 
     async def _open_windows_run_dialog(self):


### PR DESCRIPTION
# What does this PR do?

Issue #3425 .

By default Copy/Paste via shortcuts it is not enabled in Windows Server 2012 and some other versions of Windows. We need to interactively paste the command in the Command Prompt using Alt+Space,e,p.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [x] Was the CHANGELOG.md updated to reflect the changes?
* [x] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Do all unit tests pass?
* [x] Do all end-to-end tests pass?
* [x] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [x] If applicable, add screenshots or log transcripts of the feature working

![image](https://github.com/guardicore/monkey/assets/15820737/c85b44c8-4b6b-4a27-b630-5e6f8cb887a0)
