### PR TITLE
UI: Fix a credential formatting bug in UI

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/configuration-components/ReformatHook.js
+++ b/monkey/monkey_island/cc/ui/src/components/configuration-components/ReformatHook.js
@@ -65,6 +65,7 @@ export function formatCredentialsForForm(credentialsData = []) {
     for (const existingRow of existingRows) {
       let canMutate = true;
 
+      if(!secret) break;
       for (const [key, value] of Object.entries(secret)) {
         const secretKey = REVERSED_SECRET_TYPES[key];
 


### PR DESCRIPTION
Bug happens when secret is null, so Object.entries can't process null parameter

# What does this PR do?

Fixes a bug:
![image](https://github.com/guardicore/monkey/assets/36815064/e3510681-31c7-4df3-8525-3769a167f92c)


Add any further explanations here.

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Any other testing performed?
    > Tested by adding empty secrets, reloading the webpage