### PR TITLE
3425 rdp ete test

### DIFF
--- a/envs/monkey_zoo/blackbox/gcp_test_machine_list.py
+++ b/envs/monkey_zoo/blackbox/gcp_test_machine_list.py
@@ -30,6 +30,8 @@ GCP_TEST_MACHINE_LIST = {
         "log4j-tomcat-51",
         "log4j-tomcat-52",
         "snmp-20",
+        "rdp-64",
+        "rdp-65",
     ],
 }
 
@@ -41,6 +43,8 @@ DEPTH_2_A = {
     "europe-west1-b": [
         "powershell-3-46",
         "powershell-3-44",
+        "rdp-64",
+        "rdp-65",
     ],
 }
 

--- a/envs/monkey_zoo/blackbox/test_configurations/depth_2_a.py
+++ b/envs/monkey_zoo/blackbox/test_configurations/depth_2_a.py
@@ -2,7 +2,7 @@ import dataclasses
 from typing import Dict, Mapping
 
 from common.agent_configuration import AgentConfiguration, PluginConfiguration
-from common.credentials import Credentials, Password, Username
+from common.credentials import Credentials, Password, Username, NTHash
 
 from .noop import noop_test_configuration
 from .utils import (
@@ -35,6 +35,7 @@ def _add_exploiters(agent_configuration: AgentConfiguration) -> AgentConfigurati
         },
         "SSH": {},
         "PowerShell": {},
+        "RDP": {},
     }
 
     return add_exploiters(agent_configuration, exploiters=exploiters)
@@ -46,6 +47,8 @@ def _add_subnets(agent_configuration: AgentConfiguration) -> AgentConfiguration:
         "10.2.2.12",
         "10.2.3.44",
         "10.2.3.46",
+        "10.2.3.64",
+        "10.2.3.65",
     ]
     return add_subnets(agent_configuration, subnets)
 
@@ -57,7 +60,7 @@ def _add_fingerprinters(agent_configuration: AgentConfiguration) -> AgentConfigu
 
 
 def _add_tcp_ports(agent_configuration: AgentConfiguration) -> AgentConfiguration:
-    ports = [22, 5985, 5986, 8080]
+    ports = [22, 3389, 5985, 5986, 8080]
     return add_tcp_ports(agent_configuration, ports)
 
 
@@ -75,6 +78,8 @@ test_agent_configuration = _add_http_ports(test_agent_configuration)
 CREDENTIALS = (
     Credentials(identity=Username(username="m0nk3y"), secret=None),
     Credentials(identity=None, secret=Password(password="^NgDvY59~8")),
+    Credentials(identity=None, secret=Password(password="P@ssw0rd!")),
+    Credentials(identity=None, secret=NTHash(nt_hash="68965ABB32F8CE46F7E40075FA5B623E")),
 )
 
 depth_2_a_test_configuration = dataclasses.replace(noop_test_configuration)

--- a/envs/monkey_zoo/terraform/firewalls.tf
+++ b/envs/monkey_zoo/terraform/firewalls.tf
@@ -322,3 +322,20 @@ resource "google_compute_firewall" "deny-rdp64-rdp65-to-others" {
 
   source_tags = ["rdp-64", "rdp-65"]
 }
+
+// We are disabling PowerShell because we want only RDP to run on these machines
+// and we can't do it via Packer because it uses WinRM to configure the instances
+resource "google_compute_firewall" "deny-powershell-on-rdp" {
+ name    = "deny-powershell-on-rdp"
+ network = google_compute_network.monkeyzoo.name
+
+ deny {
+    protocol = "tcp"
+    ports    = ["5985", "5986"]
+ }
+ direction = "INGRESS"
+ priority = "998"
+
+ source_ranges = ["0.0.0.0/0"]
+ target_tags   = ["rdp-64", "rdp-65"]
+}


### PR DESCRIPTION
# What does this PR do?

Fixes #3425 .

RDP machines are added to depth_2 grouped test.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [x] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Do all unit tests pass?
* [x] Do all end-to-end tests pass?
* [x] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [x] If applicable, add screenshots or log transcripts of the feature working

![image](https://github.com/guardicore/monkey/assets/15820737/34e612ec-52dd-4c54-a415-55cad612ee3f)
![image](https://github.com/guardicore/monkey/assets/15820737/8a25e4e5-36b9-4c12-8d4b-b85863954688)
