### PR TITLE
3422 add uninstall agent plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
 - `PUT /api/install-agent-plugin`. #3417
 - `GET /api/agent-plugins/installed/manifests`. #3424
 - `GET /api/agent-plugins/available/index`. #3420
+- `POST /api/uninstall-agent-plugin` # 3422
 
 ### Changed
 - Plugin source is now gzipped. #3392

--- a/monkey/monkey_island/cc/flask_utils/responses.py
+++ b/monkey/monkey_island/cc/flask_utils/responses.py
@@ -1,10 +1,14 @@
 from http import HTTPStatus
+from typing import Optional
 
 from flask import Response, make_response
 
 
-def make_response_to_invalid_request() -> Response:
+def make_response_to_invalid_request(message: Optional[str] = None) -> Response:
+    if message is None:
+        message = "Invalid request"
+
     return make_response(
-        {"message": "Invalid request"},
+        {"message": message},
         HTTPStatus.BAD_REQUEST,
     )

--- a/monkey/monkey_island/cc/services/agent_plugin_service/agent_plugin_service.py
+++ b/monkey/monkey_island/cc/services/agent_plugin_service/agent_plugin_service.py
@@ -93,4 +93,6 @@ class AgentPluginService(IAgentPluginService):
                 agent_plugin_type=plugin_type, agent_plugin_name=name
             )
         except Exception as err:
-            raise UninstallPluginError("Failed to uninstall the plugin") from err
+            raise UninstallPluginError(
+                f"Failed to uninstall the plugin {name} of " f"type {plugin_type}: {err}"
+            )

--- a/monkey/monkey_island/cc/services/agent_plugin_service/agent_plugin_service.py
+++ b/monkey/monkey_island/cc/services/agent_plugin_service/agent_plugin_service.py
@@ -86,3 +86,8 @@ class AgentPluginService(IAgentPluginService):
             return AgentPluginRepositoryIndex(**repository_index_yml)
         except Exception as err:
             raise RetrievalError("Failed to get agent plugin repository index") from err
+
+    def uninstall_agent_plugin(self, plugin_type: AgentPluginType, name: str):
+        self._agent_plugin_repository.remove_agent_plugin(
+            agent_plugin_type=plugin_type, agent_plugin_name=name
+        )

--- a/monkey/monkey_island/cc/services/agent_plugin_service/agent_plugin_service.py
+++ b/monkey/monkey_island/cc/services/agent_plugin_service/agent_plugin_service.py
@@ -16,7 +16,7 @@ from common.decorators import request_cache
 from monkey_island.cc.repositories import RetrievalError
 
 from . import IAgentPluginService
-from .errors import PluginInstallationError, UninstallPluginError
+from .errors import PluginInstallationError, PluginUninstallationError
 from .i_agent_plugin_repository import IAgentPluginRepository
 from .plugin_archive_parser import parse_plugin
 
@@ -93,6 +93,6 @@ class AgentPluginService(IAgentPluginService):
                 agent_plugin_type=plugin_type, agent_plugin_name=name
             )
         except Exception as err:
-            raise UninstallPluginError(
+            raise PluginUninstallationError(
                 f"Failed to uninstall the plugin {name} of " f"type {plugin_type}: {err}"
             )

--- a/monkey/monkey_island/cc/services/agent_plugin_service/agent_plugin_service.py
+++ b/monkey/monkey_island/cc/services/agent_plugin_service/agent_plugin_service.py
@@ -16,7 +16,7 @@ from common.decorators import request_cache
 from monkey_island.cc.repositories import RetrievalError
 
 from . import IAgentPluginService
-from .errors import PluginInstallationError
+from .errors import PluginInstallationError, UninstallPluginError
 from .i_agent_plugin_repository import IAgentPluginRepository
 from .plugin_archive_parser import parse_plugin
 
@@ -88,6 +88,9 @@ class AgentPluginService(IAgentPluginService):
             raise RetrievalError("Failed to get agent plugin repository index") from err
 
     def uninstall_agent_plugin(self, plugin_type: AgentPluginType, name: str):
-        self._agent_plugin_repository.remove_agent_plugin(
-            agent_plugin_type=plugin_type, agent_plugin_name=name
-        )
+        try:
+            self._agent_plugin_repository.remove_agent_plugin(
+                agent_plugin_type=plugin_type, agent_plugin_name=name
+            )
+        except Exception as err:
+            raise UninstallPluginError("Failed to uninstall the plugin") from err

--- a/monkey/monkey_island/cc/services/agent_plugin_service/agent_plugin_service.py
+++ b/monkey/monkey_island/cc/services/agent_plugin_service/agent_plugin_service.py
@@ -94,5 +94,5 @@ class AgentPluginService(IAgentPluginService):
             )
         except Exception as err:
             raise PluginUninstallationError(
-                f"Failed to uninstall the plugin {name} of " f"type {plugin_type}: {err}"
+                f"Failed to uninstall the plugin {name} of type {plugin_type}: {err}"
             )

--- a/monkey/monkey_island/cc/services/agent_plugin_service/errors.py
+++ b/monkey/monkey_island/cc/services/agent_plugin_service/errors.py
@@ -2,3 +2,9 @@ class PluginInstallationError(ValueError):
     """
     Raised when a service encounters an error while attempting to install a plugin
     """
+
+
+class UninstallPluginError(Exception):
+    """
+    Raised when a service encounters an error while attempting to uninstall a plugin
+    """

--- a/monkey/monkey_island/cc/services/agent_plugin_service/errors.py
+++ b/monkey/monkey_island/cc/services/agent_plugin_service/errors.py
@@ -4,7 +4,7 @@ class PluginInstallationError(ValueError):
     """
 
 
-class UninstallPluginError(Exception):
+class PluginUninstallationError(Exception):
     """
     Raised when a service encounters an error while attempting to uninstall a plugin
     """

--- a/monkey/monkey_island/cc/services/agent_plugin_service/flask_resources/__init__.py
+++ b/monkey/monkey_island/cc/services/agent_plugin_service/flask_resources/__init__.py
@@ -2,4 +2,5 @@ from .agent_plugins import AgentPlugins
 from .agent_plugins_manifest import AgentPluginsManifest
 from .available_agent_plugins_index import AvailableAgentPluginsIndex
 from .installed_agent_plugins_manifests import InstalledAgentPluginsManifests
+from .uninstall_agent_plugin import UninstallAgentPlugin
 from .register import register_resources

--- a/monkey/monkey_island/cc/services/agent_plugin_service/flask_resources/register.py
+++ b/monkey/monkey_island/cc/services/agent_plugin_service/flask_resources/register.py
@@ -5,6 +5,7 @@ from .agent_plugins_manifest import AgentPluginsManifest
 from .available_agent_plugins_index import AvailableAgentPluginsIndex
 from .install_agent_plugin import InstallAgentPlugin
 from .installed_agent_plugins_manifests import InstalledAgentPluginsManifests
+from .uninstall_agent_plugin import UninstallAgentPlugin
 
 
 def register_resources(api: FlaskDIWrapper):
@@ -13,3 +14,4 @@ def register_resources(api: FlaskDIWrapper):
     api.add_resource(InstallAgentPlugin)
     api.add_resource(InstalledAgentPluginsManifests)
     api.add_resource(AvailableAgentPluginsIndex)
+    api.add_resource(UninstallAgentPlugin)

--- a/monkey/monkey_island/cc/services/agent_plugin_service/flask_resources/uninstall_agent_plugin.py
+++ b/monkey/monkey_island/cc/services/agent_plugin_service/flask_resources/uninstall_agent_plugin.py
@@ -1,0 +1,39 @@
+import logging
+from http import HTTPStatus
+
+from flask import make_response
+from flask_security import auth_token_required, roles_accepted
+
+from common.agent_plugins import AgentPluginType
+from monkey_island.cc.flask_utils import AbstractResource
+from monkey_island.cc.services.authentication_service import AccountRole
+
+from .. import IAgentPluginService
+
+logger = logging.getLogger(__name__)
+
+
+class UninstallAgentPlugin(AbstractResource):
+    urls = ["/api/uninstall-agent-plugin/<string:plugin_type>/<string:name>"]
+
+    def __init__(self, agent_plugin_service: IAgentPluginService):
+        self._agent_plugin_service = agent_plugin_service
+
+    @auth_token_required
+    @roles_accepted(AccountRole.ISLAND_INTERFACE.name)
+    def post(self, plugin_type: str, name: str):
+        """
+        Uninstalls agent plugin of the specified type and name.
+
+        :param plugin_type: The type of plugin (e.g. "Exploiter")
+        :param name: The name of the plugin
+        """
+        try:
+            plugin_type_ = AgentPluginType(plugin_type)
+        except ValueError:
+            message = f"Invalid type '{plugin_type}'."
+            logger.warning(message)
+            return make_response({"message": message}, HTTPStatus.NOT_FOUND)
+
+        self._agent_plugin_service.uninstall_agent_plugin(plugin_type_, name)
+        return make_response({}, HTTPStatus.OK)

--- a/monkey/monkey_island/cc/services/agent_plugin_service/flask_resources/uninstall_agent_plugin.py
+++ b/monkey/monkey_island/cc/services/agent_plugin_service/flask_resources/uninstall_agent_plugin.py
@@ -10,7 +10,6 @@ from monkey_island.cc.flask_utils import AbstractResource, responses
 from monkey_island.cc.services.authentication_service import AccountRole
 
 from .. import IAgentPluginService
-from ..errors import UninstallPluginError
 
 logger = logging.getLogger(__name__)
 
@@ -41,8 +40,5 @@ class UninstallAgentPlugin(AbstractResource):
             logger.warning(message)
             return make_response({"message": message}, HTTPStatus.NOT_FOUND)
 
-        try:
-            self._agent_plugin_service.uninstall_agent_plugin(plugin_type_, name)
-        except UninstallPluginError as err:
-            return make_response(str(err), HTTPStatus.UNPROCESSABLE_ENTITY)
+        self._agent_plugin_service.uninstall_agent_plugin(plugin_type_, name)
         return make_response({}, HTTPStatus.OK)

--- a/monkey/monkey_island/cc/services/agent_plugin_service/flask_resources/uninstall_agent_plugin.py
+++ b/monkey/monkey_island/cc/services/agent_plugin_service/flask_resources/uninstall_agent_plugin.py
@@ -10,6 +10,7 @@ from monkey_island.cc.flask_utils import AbstractResource, responses
 from monkey_island.cc.services.authentication_service import AccountRole
 
 from .. import IAgentPluginService
+from ..errors import UninstallPluginError
 
 logger = logging.getLogger(__name__)
 
@@ -40,5 +41,8 @@ class UninstallAgentPlugin(AbstractResource):
             logger.warning(message)
             return make_response({"message": message}, HTTPStatus.NOT_FOUND)
 
-        self._agent_plugin_service.uninstall_agent_plugin(plugin_type_, name)
+        try:
+            self._agent_plugin_service.uninstall_agent_plugin(plugin_type_, name)
+        except UninstallPluginError as err:
+            return make_response(str(err), HTTPStatus.UNPROCESSABLE_ENTITY)
         return make_response({}, HTTPStatus.OK)

--- a/monkey/monkey_island/cc/services/agent_plugin_service/flask_resources/uninstall_agent_plugin.py
+++ b/monkey/monkey_island/cc/services/agent_plugin_service/flask_resources/uninstall_agent_plugin.py
@@ -38,7 +38,7 @@ class UninstallAgentPlugin(AbstractResource):
         except ValueError:
             message = f"Invalid type '{plugin_type}'."
             logger.warning(message)
-            return make_response({"message": message}, HTTPStatus.NOT_FOUND)
+            return responses.make_response_to_invalid_request(message)
 
         self._agent_plugin_service.uninstall_agent_plugin(plugin_type_, name)
         return make_response({}, HTTPStatus.OK)

--- a/monkey/monkey_island/cc/services/agent_plugin_service/i_agent_plugin_service.py
+++ b/monkey/monkey_island/cc/services/agent_plugin_service/i_agent_plugin_service.py
@@ -84,6 +84,6 @@ class IAgentPluginService(ABC):
 
         :param plugin_type: The type of the plugin
         :param name: The name of the plugin
-        :raises RemovalError: If an error occurs while uninstalling the plugin
+        :raises UninstallPluginError: If an error occurs while uninstalling the plugin
         """
         pass

--- a/monkey/monkey_island/cc/services/agent_plugin_service/i_agent_plugin_service.py
+++ b/monkey/monkey_island/cc/services/agent_plugin_service/i_agent_plugin_service.py
@@ -84,6 +84,6 @@ class IAgentPluginService(ABC):
 
         :param plugin_type: The type of the plugin
         :param name: The name of the plugin
-        :raises UninstallPluginError: If an error occurs while uninstalling the plugin
+        :raises PluginUninstallationError: If an error occurs while uninstalling the plugin
         """
         pass

--- a/monkey/monkey_island/cc/services/agent_plugin_service/i_agent_plugin_service.py
+++ b/monkey/monkey_island/cc/services/agent_plugin_service/i_agent_plugin_service.py
@@ -76,3 +76,14 @@ class IAgentPluginService(ABC):
                                 available plugins from the repository
         """
         pass
+
+    @abstractmethod
+    def uninstall_agent_plugin(self, plugin_type: AgentPluginType, name: str):
+        """
+        Uninstall agent plugin
+
+        :param plugin_type: The type of the plugin
+        :param name: The name of the plugin
+        :raises RemovalError: If an error occurs while uninstalling the plugin
+        """
+        pass

--- a/monkey/tests/monkey_island/in_memory_agent_plugin_repository.py
+++ b/monkey/tests/monkey_island/in_memory_agent_plugin_repository.py
@@ -72,6 +72,18 @@ class InMemoryAgentPluginRepository(IAgentPluginRepository):
         agent_plugin_name: str,
         operating_system: Optional[OperatingSystem] = None,
     ):
+        if operating_system is None:
+            for os in self._plugins.keys():
+                self._remove_os_specific_plugin(agent_plugin_type, agent_plugin_name, os)
+        else:
+            self._remove_os_specific_plugin(agent_plugin_type, agent_plugin_name, operating_system)
+
+    def _remove_os_specific_plugin(
+        self,
+        agent_plugin_type: AgentPluginType,
+        agent_plugin_name: str,
+        operating_system: OperatingSystem,
+    ):
         os_specific_plugins = self._plugins.get(operating_system, None)
         if os_specific_plugins:
             type_specific_plugins = os_specific_plugins.get(agent_plugin_type, None)

--- a/monkey/tests/unit_tests/monkey_island/cc/services/agent_plugin_service/flask_resources/test_uninstall_agent_plugin.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/agent_plugin_service/flask_resources/test_uninstall_agent_plugin.py
@@ -47,7 +47,7 @@ def test_uninstall_agent_plugin(flask_client, agent_plugin_service):
     "type_",
     ["DummyType", "ExploiteR"],
 )
-def test_uninstall_agent_plugin__not_found_if_type_is_invalid(
+def test_uninstall_agent_plugin__bad_request_if_type_is_invalid(
     flask_client, type_, agent_plugin_service
 ):
     resp = flask_client.post(
@@ -55,7 +55,7 @@ def test_uninstall_agent_plugin__not_found_if_type_is_invalid(
         data=f'{{"plugin_type": "{type_}", "name": "name"}}',
     )
 
-    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
     agent_plugin_service.uninstall_agent_plugin.assert_not_called()
 
 

--- a/monkey/tests/unit_tests/monkey_island/cc/services/agent_plugin_service/flask_resources/test_uninstall_agent_plugin.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/agent_plugin_service/flask_resources/test_uninstall_agent_plugin.py
@@ -1,0 +1,86 @@
+from http import HTTPStatus
+
+import pytest
+from tests.common import StubDIContainer
+from tests.monkey_island import InMemoryAgentPluginRepository
+from tests.unit_tests.common.agent_plugins.test_agent_plugin_manifest import FAKE_TYPE
+from tests.unit_tests.monkey_island.cc.fake_agent_plugin_data import FAKE_AGENT_PLUGIN_1
+from tests.unit_tests.monkey_island.conftest import get_url_for_resource
+
+from common import OperatingSystem
+from monkey_island.cc.repositories import RemovalError, UnknownRecordError
+from monkey_island.cc.services.agent_plugin_service import IAgentPluginService
+from monkey_island.cc.services.agent_plugin_service.agent_plugin_service import AgentPluginService
+from monkey_island.cc.services.agent_plugin_service.flask_resources import UninstallAgentPlugin
+
+
+@pytest.fixture
+def agent_plugin_repository():
+    return InMemoryAgentPluginRepository()
+
+
+@pytest.fixture
+def agent_plugin_service(agent_plugin_repository):
+    return AgentPluginService(agent_plugin_repository)
+
+
+@pytest.fixture
+def flask_client(build_flask_client, agent_plugin_service):
+    container = StubDIContainer()
+    container.register_instance(IAgentPluginService, agent_plugin_service)
+
+    with build_flask_client(container) as flask_client:
+        yield flask_client
+
+
+def test_uninstall_agent_plugin(flask_client, agent_plugin_repository):
+    agent_plugin_repository.store_agent_plugin(OperatingSystem.LINUX, FAKE_AGENT_PLUGIN_1)
+
+    resp = flask_client.post(
+        get_url_for_resource(
+            UninstallAgentPlugin,
+            plugin_type=FAKE_TYPE,
+            name=FAKE_AGENT_PLUGIN_1.plugin_manifest.name,
+        )
+    )
+
+    assert resp.status_code == HTTPStatus.OK
+    with pytest.raises(UnknownRecordError):
+        agent_plugin_repository.get_plugin(
+            OperatingSystem.LINUX, FAKE_TYPE, FAKE_AGENT_PLUGIN_1.plugin_manifest.name
+        )
+
+
+# TODO: Ask do we need some kind of UninstallAgentPluginError which will be handled
+# if we can't uninstall a AgentPlugin
+# def test_uninstall_agent_plugin_not_found_if_name_does_not_exist(flask_client):
+#    resp = flask_client.post(
+#        get_url_for_resource(UninstallAgentPlugin, plugin_type="Payload", name="name")
+#    )
+#
+#    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.parametrize(
+    "type_",
+    ["DummyType", "ExploiteR"],
+)
+def test_uninstall_agent_plugin__not_found_if_type_is_invalid(flask_client, type_):
+    resp = flask_client.post(
+        get_url_for_resource(UninstallAgentPlugin, plugin_type=type_, name="name")
+    )
+
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_uninstall_agent_plugin__server_error(flask_client, agent_plugin_repository):
+    def raise_removal_error(plugin_type, name):
+        raise RemovalError
+
+    agent_plugin_repository.remove_agent_plugin = raise_removal_error
+
+    resp = flask_client.post(
+        get_url_for_resource(UninstallAgentPlugin, plugin_type="Payload", name="name")
+    )
+
+    assert resp.status_code == HTTPStatus.INTERNAL_SERVER_ERROR

--- a/monkey/tests/unit_tests/monkey_island/cc/services/agent_plugin_service/flask_resources/test_uninstall_agent_plugin.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/agent_plugin_service/flask_resources/test_uninstall_agent_plugin.py
@@ -1,27 +1,21 @@
 from http import HTTPStatus
+from unittest.mock import MagicMock
 
 import pytest
 from tests.common import StubDIContainer
-from tests.monkey_island import InMemoryAgentPluginRepository
 from tests.unit_tests.common.agent_plugins.test_agent_plugin_manifest import FAKE_TYPE
 from tests.unit_tests.monkey_island.cc.fake_agent_plugin_data import FAKE_AGENT_PLUGIN_1
 from tests.unit_tests.monkey_island.conftest import get_url_for_resource
 
-from common import OperatingSystem
-from monkey_island.cc.repositories import RemovalError, UnknownRecordError
+from common.agent_plugins import AgentPluginType
+from monkey_island.cc.repositories import RemovalError
 from monkey_island.cc.services.agent_plugin_service import IAgentPluginService
-from monkey_island.cc.services.agent_plugin_service.agent_plugin_service import AgentPluginService
 from monkey_island.cc.services.agent_plugin_service.flask_resources import UninstallAgentPlugin
 
 
 @pytest.fixture
-def agent_plugin_repository():
-    return InMemoryAgentPluginRepository()
-
-
-@pytest.fixture
-def agent_plugin_service(agent_plugin_repository):
-    return AgentPluginService(agent_plugin_repository)
+def agent_plugin_service():
+    return MagicMock(spec=IAgentPluginService)
 
 
 @pytest.fixture
@@ -33,9 +27,7 @@ def flask_client(build_flask_client, agent_plugin_service):
         yield flask_client
 
 
-def test_uninstall_agent_plugin(flask_client, agent_plugin_repository):
-    agent_plugin_repository.store_agent_plugin(OperatingSystem.LINUX, FAKE_AGENT_PLUGIN_1)
-
+def test_uninstall_agent_plugin(flask_client, agent_plugin_service):
     resp = flask_client.post(
         get_url_for_resource(
             UninstallAgentPlugin,
@@ -45,10 +37,9 @@ def test_uninstall_agent_plugin(flask_client, agent_plugin_repository):
     )
 
     assert resp.status_code == HTTPStatus.OK
-    with pytest.raises(UnknownRecordError):
-        agent_plugin_repository.get_plugin(
-            OperatingSystem.LINUX, FAKE_TYPE, FAKE_AGENT_PLUGIN_1.plugin_manifest.name
-        )
+    agent_plugin_service.uninstall_agent_plugin.assert_called_with(
+        AgentPluginType(FAKE_TYPE), FAKE_AGENT_PLUGIN_1.plugin_manifest.name
+    )
 
 
 # TODO: Ask do we need some kind of UninstallAgentPluginError which will be handled
@@ -65,19 +56,22 @@ def test_uninstall_agent_plugin(flask_client, agent_plugin_repository):
     "type_",
     ["DummyType", "ExploiteR"],
 )
-def test_uninstall_agent_plugin__not_found_if_type_is_invalid(flask_client, type_):
+def test_uninstall_agent_plugin__not_found_if_type_is_invalid(
+    flask_client, type_, agent_plugin_service
+):
     resp = flask_client.post(
         get_url_for_resource(UninstallAgentPlugin, plugin_type=type_, name="name")
     )
 
     assert resp.status_code == HTTPStatus.NOT_FOUND
+    agent_plugin_service.uninstall_agent_plugin.assert_not_called()
 
 
-def test_uninstall_agent_plugin__server_error(flask_client, agent_plugin_repository):
+def test_uninstall_agent_plugin__server_error(flask_client, agent_plugin_service):
     def raise_removal_error(plugin_type, name):
         raise RemovalError
 
-    agent_plugin_repository.remove_agent_plugin = raise_removal_error
+    agent_plugin_service.uninstall_agent_plugin = raise_removal_error
 
     resp = flask_client.post(
         get_url_for_resource(UninstallAgentPlugin, plugin_type="Payload", name="name")

--- a/monkey/tests/unit_tests/monkey_island/cc/services/agent_plugin_service/flask_resources/test_uninstall_agent_plugin.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/agent_plugin_service/flask_resources/test_uninstall_agent_plugin.py
@@ -9,7 +9,7 @@ from tests.unit_tests.monkey_island.conftest import get_url_for_resource
 
 from common.agent_plugins import AgentPluginType
 from monkey_island.cc.services.agent_plugin_service import IAgentPluginService
-from monkey_island.cc.services.agent_plugin_service.errors import UninstallPluginError
+from monkey_island.cc.services.agent_plugin_service.errors import PluginUninstallationError
 from monkey_island.cc.services.agent_plugin_service.flask_resources import UninstallAgentPlugin
 
 REQUEST_DATA = (
@@ -59,7 +59,7 @@ def test_uninstall_agent_plugin__not_found_if_type_is_invalid(
     agent_plugin_service.uninstall_agent_plugin.assert_not_called()
 
 
-@pytest.mark.parametrize("error", [Exception, UninstallPluginError])
+@pytest.mark.parametrize("error", [Exception, PluginUninstallationError])
 def test_uninstall_agent_plugin__error(flask_client, agent_plugin_service, error):
     def raise_error(plugin_type, name):
         raise error

--- a/monkey/tests/unit_tests/monkey_island/cc/services/agent_plugin_service/flask_resources/test_uninstall_agent_plugin.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/agent_plugin_service/flask_resources/test_uninstall_agent_plugin.py
@@ -59,16 +59,8 @@ def test_uninstall_agent_plugin__not_found_if_type_is_invalid(
     agent_plugin_service.uninstall_agent_plugin.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    "error, expected_status_code",
-    [
-        (Exception, HTTPStatus.INTERNAL_SERVER_ERROR),
-        (UninstallPluginError, HTTPStatus.UNPROCESSABLE_ENTITY),
-    ],
-)
-def test_uninstall_agent_plugin__error(
-    flask_client, agent_plugin_service, error, expected_status_code
-):
+@pytest.mark.parametrize("error", [Exception, UninstallPluginError])
+def test_uninstall_agent_plugin__error(flask_client, agent_plugin_service, error):
     def raise_error(plugin_type, name):
         raise error
 
@@ -79,7 +71,7 @@ def test_uninstall_agent_plugin__error(
         data=b'{"plugin_type": "Payload", "name": "name"}',
     )
 
-    assert resp.status_code == expected_status_code
+    assert resp.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
 
 
 @pytest.mark.parametrize(

--- a/monkey/tests/unit_tests/monkey_island/cc/services/agent_plugin_service/flask_resources/test_uninstall_agent_plugin.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/agent_plugin_service/flask_resources/test_uninstall_agent_plugin.py
@@ -12,6 +12,10 @@ from monkey_island.cc.repositories import RemovalError
 from monkey_island.cc.services.agent_plugin_service import IAgentPluginService
 from monkey_island.cc.services.agent_plugin_service.flask_resources import UninstallAgentPlugin
 
+REQUEST_DATA = (
+    f'{{"plugin_type": "{FAKE_TYPE}", "name": "{FAKE_AGENT_PLUGIN_1.plugin_manifest.name}"}}'
+)
+
 
 @pytest.fixture
 def agent_plugin_service():
@@ -29,11 +33,8 @@ def flask_client(build_flask_client, agent_plugin_service):
 
 def test_uninstall_agent_plugin(flask_client, agent_plugin_service):
     resp = flask_client.post(
-        get_url_for_resource(
-            UninstallAgentPlugin,
-            plugin_type=FAKE_TYPE,
-            name=FAKE_AGENT_PLUGIN_1.plugin_manifest.name,
-        )
+        get_url_for_resource(UninstallAgentPlugin),
+        data=REQUEST_DATA,
     )
 
     assert resp.status_code == HTTPStatus.OK
@@ -60,7 +61,8 @@ def test_uninstall_agent_plugin__not_found_if_type_is_invalid(
     flask_client, type_, agent_plugin_service
 ):
     resp = flask_client.post(
-        get_url_for_resource(UninstallAgentPlugin, plugin_type=type_, name="name")
+        get_url_for_resource(UninstallAgentPlugin),
+        data=f'{{"plugin_type": "{type_}", "name": "name"}}',
     )
 
     assert resp.status_code == HTTPStatus.NOT_FOUND
@@ -74,7 +76,18 @@ def test_uninstall_agent_plugin__server_error(flask_client, agent_plugin_service
     agent_plugin_service.uninstall_agent_plugin = raise_removal_error
 
     resp = flask_client.post(
-        get_url_for_resource(UninstallAgentPlugin, plugin_type="Payload", name="name")
+        get_url_for_resource(UninstallAgentPlugin),
+        data=b'{"plugin_type": "Payload", "name": "name"}',
     )
 
     assert resp.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+
+
+@pytest.mark.parametrize(
+    "request_data", [b"{}", None, "string", b'{"bogus":"vogus"', b'{"bogus": "bogus"}']
+)
+def test_uninstall_agent_plugin__bad_request_data(request_data, flask_client, agent_plugin_service):
+    resp = flask_client.post(get_url_for_resource(UninstallAgentPlugin), data=request_data)
+
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    agent_plugin_service.uninstall_agent_plugin.assert_not_called()

--- a/monkey/tests/unit_tests/monkey_island/cc/services/agent_plugin_service/test_agent_plugin_service.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/agent_plugin_service/test_agent_plugin_service.py
@@ -18,7 +18,7 @@ from monkey_island.cc.services.agent_plugin_service.agent_plugin_service import 
 )
 from monkey_island.cc.services.agent_plugin_service.errors import (
     PluginInstallationError,
-    UninstallPluginError,
+    PluginUninstallationError,
 )
 from monkey_island.cc.services.agent_plugin_service.i_agent_plugin_repository import (
     IAgentPluginRepository,
@@ -242,7 +242,7 @@ def test_agent_plugin_service__unistall_agent_plugin_exception(
         raise Exception
 
     agent_plugin_repository.remove_agent_plugin = raise_exception
-    with pytest.raises(UninstallPluginError):
+    with pytest.raises(PluginUninstallationError):
         agent_plugin_service.uninstall_agent_plugin(
             plugin_type=AgentPluginType("Exploiter"), name="SSH"
         )

--- a/monkey/tests/unit_tests/monkey_island/cc/services/agent_plugin_service/test_agent_plugin_service.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/agent_plugin_service/test_agent_plugin_service.py
@@ -10,12 +10,16 @@ from tests.unit_tests.monkey_island.cc.services.agent_plugin_service.conftest im
 )
 
 from common import OperatingSystem
+from common.agent_plugins import AgentPluginType
 from monkey_island.cc.repositories import RetrievalError
 from monkey_island.cc.services.agent_plugin_service.agent_plugin_service import (
     AGENT_PLUGIN_REPOSITORY_URL,
     AgentPluginService,
 )
-from monkey_island.cc.services.agent_plugin_service.errors import PluginInstallationError
+from monkey_island.cc.services.agent_plugin_service.errors import (
+    PluginInstallationError,
+    UninstallPluginError,
+)
 from monkey_island.cc.services.agent_plugin_service.i_agent_plugin_repository import (
     IAgentPluginRepository,
 )
@@ -228,3 +232,17 @@ def test_agent_plugin_service__get_available_plugins_exception(
     request_mock_instance.get(AGENT_PLUGIN_REPOSITORY_URL, exc=Exception)
     with pytest.raises(RetrievalError):
         agent_plugin_service.get_available_plugins(force_refresh=True)
+
+
+def test_agent_plugin_service__unistall_agent_plugin_exception(
+    agent_plugin_repository: IAgentPluginRepository,
+    agent_plugin_service: IAgentPluginService,
+):
+    def raise_exception(plugin_type, name):
+        raise Exception
+
+    agent_plugin_repository.remove_agent_plugin = raise_exception
+    with pytest.raises(UninstallPluginError):
+        agent_plugin_service.uninstall_agent_plugin(
+            plugin_type=AgentPluginType("Exploiter"), name="SSH"
+        )

--- a/monkey/tests/unit_tests/monkey_island/cc/services/agent_plugin_service/test_agent_plugin_service.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/agent_plugin_service/test_agent_plugin_service.py
@@ -5,16 +5,13 @@ from unittest.mock import MagicMock
 import pytest
 import requests
 import requests_mock
-from tests.monkey_island import InMemoryAgentPluginRepository
-from tests.unit_tests.common.agent_plugins.test_agent_plugin_manifest import FAKE_NAME, FAKE_TYPE
-from tests.unit_tests.monkey_island.cc.fake_agent_plugin_data import FAKE_AGENT_PLUGIN_1
 from tests.unit_tests.monkey_island.cc.services.agent_plugin_service.conftest import (
     build_agent_plugin_tar,
 )
 
 from common import OperatingSystem
 from common.agent_plugins import AgentPluginType
-from monkey_island.cc.repositories import RetrievalError, UnknownRecordError
+from monkey_island.cc.repositories import RetrievalError
 from monkey_island.cc.services.agent_plugin_service.agent_plugin_service import (
     AGENT_PLUGIN_REPOSITORY_URL,
     AgentPluginService,
@@ -251,14 +248,13 @@ def test_agent_plugin_service__unistall_agent_plugin_exception(
         )
 
 
-def test_agent_plugin_service__unistall_agent_plugin():
-    in_memory_agent_plugin_repository = InMemoryAgentPluginRepository()
-    in_memory_agent_plugin_repository.store_agent_plugin(OperatingSystem.LINUX, FAKE_AGENT_PLUGIN_1)
-    real_agent_plugin_service = AgentPluginService(in_memory_agent_plugin_repository)
+def test_agent_plugin_service__unistall_agent_plugin(
+    agent_plugin_repository: IAgentPluginRepository, agent_plugin_service: IAgentPluginService
+):
+    plugin_name = "SSH"
+    plugin_type = AgentPluginType("Exploiter")
+    agent_plugin_service.uninstall_agent_plugin(plugin_type, plugin_name)
 
-    real_agent_plugin_service.uninstall_agent_plugin(AgentPluginType(FAKE_TYPE), FAKE_NAME)
-
-    with pytest.raises(UnknownRecordError):
-        in_memory_agent_plugin_repository.get_plugin(
-            OperatingSystem.LINUX, AgentPluginType(FAKE_TYPE), FAKE_NAME
-        )
+    agent_plugin_repository.remove_agent_plugin.assert_called_with(
+        agent_plugin_type=plugin_type, agent_plugin_name=plugin_name
+    )

--- a/vulture_allowlist.py
+++ b/vulture_allowlist.py
@@ -17,7 +17,12 @@ from flask_security import Security
 
 from common import DIContainer
 from common.agent_configuration import ScanTargetConfiguration
-from common.agent_events import AbstractAgentEvent, CPUConsumptionEvent, FileEncryptionEvent
+from common.agent_events import (
+    AbstractAgentEvent,
+    CPUConsumptionEvent,
+    FileEncryptionEvent,
+    RAMConsumptionEvent,
+)
 from common.agent_plugins import (
     AgentPlugin,
     AgentPluginManifest,
@@ -195,6 +200,8 @@ AgentPluginRepositoryIndex._sort_plugins_by_version
 AgentPluginRepositoryIndex.use_enum_values
 
 CPUConsumptionEvent.cpu_number
+CPUConsumptionEvent.utilization
+RAMConsumptionEvent.utilization
 
 # RDP
 InMemoryFileProvider.get_file_data


### PR DESCRIPTION
# What does this PR do?

Fixes #3422 .

Adda RPC styled endpont to uninstall agent plugins based on type and name.

One TODO remaining in UTs to discuss

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [x] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
