### PR TITLE
UI: Add Plugins page

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/Main.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/Main.tsx
@@ -6,6 +6,7 @@ import RunMonkeyPage from './pages/RunMonkeyPage/RunMonkeyPage';
 import MapPageWrapper from './map/MapPageWrapper';
 import EventPage from './pages/EventPage';
 import ReportPage from './pages/ReportPage';
+import PluginsPage from './pages/PluginsPage';
 import LicensePage from './pages/LicensePage';
 import AuthComponent from './AuthComponent';
 import LoginPageComponent from './pages/LoginPage';
@@ -32,6 +33,10 @@ export const IslandRoutes = {
   Report: '/report',
   SecurityReport: '/report/security',
   RansomwareReport: '/report/ransomware',
+  Plugins: '/plugins',
+  InstalledPlugins: '/plugins/installed',
+  AvailablePlugins: '/plugins/available',
+  UploadPlugin: '/plugins/upload',
   LoginPage: '/login',
   RegisterPage: '/register',
   Logout: '/logout',
@@ -190,6 +195,10 @@ class AppComponent extends AuthComponent {
             {this.renderRoute(IslandRoutes.EventPage,
               <SidebarLayoutComponent component={EventPage} {...defaultSideNavProps}/>)}
             {this.redirectToReport()}
+            {this.renderRoute(IslandRoutes.Plugins, <SidebarLayoutComponent component={PluginsPage} {...defaultSideNavProps}/>)}
+            {this.renderRoute(IslandRoutes.InstalledPlugins, <SidebarLayoutComponent component={PluginsPage} {...defaultSideNavProps}/>)}
+            {this.renderRoute(IslandRoutes.AvailablePlugins, <SidebarLayoutComponent component={PluginsPage} {...defaultSideNavProps}/>)}
+            {this.renderRoute(IslandRoutes.UploadPlugin, <SidebarLayoutComponent component={PluginsPage} {...defaultSideNavProps}/>)}
             {this.renderRoute(IslandRoutes.SecurityReport,
               <SidebarLayoutComponent component={ReportPage}
                                       {...defaultSideNavProps}/>)}

--- a/monkey/monkey_island/cc/ui/src/components/SideNavComponent.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/SideNavComponent.tsx
@@ -101,6 +101,10 @@ const SideNavComponent = ({
                      className={getNavLinkClass()}>
           Configuration
         </NavLink></li>
+        <li><NavLink to='/plugins'
+                     className={getNavLinkClass()}>
+          Plugins
+        </NavLink></li>
         <li><NavLink to='/infection/events'
                      className={getNavLinkClass()}>
           Events

--- a/monkey/monkey_island/cc/ui/src/components/pages/PluginsPage.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/pages/PluginsPage.tsx
@@ -1,0 +1,79 @@
+import React, {useState} from 'react';
+import { Col, Nav } from 'react-bootstrap';
+import AuthComponent from '../AuthComponent';
+import {useNavigate} from 'react-router-dom';
+import AvailablePlugins from '../plugin-components/AvailablePlugins';
+import InstalledPlugins from '../plugin-components/InstalledPlugins';
+import UploadPlugin from '../plugin-components/UploadPlugin';
+
+
+// TODO: Make a component for a tab pane
+// - See if a tab pane component already exists (one does - @mui/material/Tabs, but it's visually inconsistent with our other tabs)
+function PluginsPage (props) {
+    const sections = ['available', 'installed', 'upload'];
+    const [selectedSection, setSelectedSection] = useState(selectTab(sections));
+    const orderedSections = [{key: 'available', title: 'Available Plugins'}, {key: 'installed', title: 'Installed Plugins'}, {key: 'upload', title: 'Upload New Plugin'}];
+    const authComponent = new AuthComponent({});
+
+    function selectTab(tabs) {
+        let url = window.location.href;
+        for (let tab_name in tabs) {
+          if (Object.prototype.hasOwnProperty.call(sections, tab_name) && url.endsWith(sections[tab_name])) {
+            return sections[tab_name];
+          }
+        }
+        return 'installed'; // The default tab
+    };
+
+    function renderNav() {
+        let navigate = useNavigate();
+        return (
+            <Nav variant='tabs'
+                 fill
+                 activeKey={selectedSection}
+                 onSelect={(key) => {
+                   setSelectedSection(key);
+                   navigate("/plugins/" + key);
+                 }}
+                 className={'report-nav'}>
+              {orderedSections.map(section => renderNavButton(section))}
+            </Nav>)
+    };
+
+    function renderNavButton(section) {
+        return (
+          <Nav.Item key={section.key}>
+            <Nav.Link key={section.key}
+                      eventKey={section.key}
+                      onSelect={() => {
+                      }}>
+              {section.title}
+            </Nav.Link>
+          </Nav.Item>)
+      };
+
+    function renderContent() {
+        switch (selectedSection) {
+            case 'available':
+                return <AvailablePlugins />;
+            case 'installed':
+                return <InstalledPlugins />;
+            case 'upload':
+                return <UploadPlugin />;
+        }
+    };
+
+    return (
+        <Col sm={{offset: 3, span: 9}} md={{offset: 3, span: 9}}
+              lg={{offset: 3, span: 9}} xl={{offset: 2, span: 10}}
+              className={'main'}>
+          <h1 className='page-title'>Plugins</h1>
+          {renderNav()}
+          <div style={{'fontSize': '1.2em'}}>
+            {renderContent()}
+          </div>
+        </Col>
+    );
+}
+
+export default PluginsPage;

--- a/monkey/monkey_island/cc/ui/src/components/plugin-components/AvailablePlugins.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/plugin-components/AvailablePlugins.tsx
@@ -1,0 +1,12 @@
+import React, {useState} from 'react';
+
+function AvailablePlugins() {
+    return (
+        <div>
+          <h1>Available Plugins</h1>
+          <span>Please implement me!</span>
+        </div>
+    )
+}
+
+export default AvailablePlugins;

--- a/monkey/monkey_island/cc/ui/src/components/plugin-components/InstalledPlugins.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/plugin-components/InstalledPlugins.tsx
@@ -1,0 +1,12 @@
+import React, {useState} from 'react';
+
+function InstalledPlugins() {
+    return (
+        <div>
+          <h1>Installed Plugins</h1>
+          <span>Please implement me!</span>
+        </div>
+    )
+}
+
+export default InstalledPlugins;

--- a/monkey/monkey_island/cc/ui/src/components/plugin-components/UploadPlugin.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/plugin-components/UploadPlugin.tsx
@@ -1,0 +1,12 @@
+import React, {useState} from 'react';
+
+function UploadPlugin() {
+    return (
+        <div>
+          <h1>Upload Plugins</h1>
+          <span>Please implement me!</span>
+        </div>
+    )
+}
+
+export default UploadPlugin;


### PR DESCRIPTION
# What does this PR do?

Fixes part of #3418.

- Adds Plugins nav item to the sidebar
- Adds a Plugins page with three tabs:
  - Available Plugins
  - Installed Plugins
  - Upload New Plugin

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [x] If applicable, add screenshots or log transcripts of the feature working
    > https://github.com/guardicore/monkey/assets/11077625/8dda5d48-951c-4caa-b210-901704bb190f

