### PR TITLE
Fix mongo agent plugin document too large

### DIFF
--- a/monkey/common/base_models.py
+++ b/monkey/common/base_models.py
@@ -49,7 +49,10 @@ class InfectionMonkeyBaseModel(BaseModel):
     # continue to serve as a wrapper until we can update all references to it.
     def dict(self, simplify=False, **kwargs):
         if simplify:
-            return json.loads(self.json())
+            # Allow keyword arguments to be passed to `json()`
+            # We can pass kwargs to `json()` because the parameters of BaseModel.json() are a
+            # superset of those of BaseModel.dict().
+            return json.loads(self.json(**kwargs))
         return BaseModel.dict(self, **kwargs)
 
 

--- a/monkey/monkey_island/cc/services/agent_plugin_service/mongo_agent_plugin_repository.py
+++ b/monkey/monkey_island/cc/services/agent_plugin_service/mongo_agent_plugin_repository.py
@@ -4,6 +4,7 @@ from contextlib import suppress
 from typing import Any, Dict, Optional
 
 import gridfs
+from bson.errors import BSONError
 from pymongo import MongoClient
 from pymongo.errors import PyMongoError
 
@@ -94,7 +95,7 @@ class MongoAgentPluginRepository(IAgentPluginRepository):
                 {},
                 {"plugin_manifest.plugin_type": 1, "plugin_manifest.name": 1, "config_schema": 1},
             )
-        except PyMongoError as err:
+        except (PyMongoError, BSONError) as err:
             raise RetrievalError("Error retrieving the agent plugin configuration schemas") from err
         configuration_schemas: Dict[
             AgentPluginType, Dict[PluginName, Dict[str, Any]]
@@ -119,7 +120,7 @@ class MongoAgentPluginRepository(IAgentPluginRepository):
     ) -> Dict[AgentPluginType, Dict[PluginName, AgentPluginManifest]]:
         try:
             manifest_dicts = self._agent_plugins_collection.find(projection=["plugin_manifest"])
-        except PyMongoError as err:
+        except (PyMongoError, BSONError) as err:
             raise RetrievalError("Error retrieving the agent plugin manifests") from err
         manifests: Dict[AgentPluginType, Dict[PluginName, AgentPluginManifest]] = defaultdict(dict)
 
@@ -173,7 +174,7 @@ class MongoAgentPluginRepository(IAgentPluginRepository):
                 {"$set": plugin_dict},
                 upsert=True,
             )
-        except PyMongoError as err:
+        except (PyMongoError, BSONError) as err:
             raise StorageError("Failed to store a plugin in the database") from err
 
     def remove_agent_plugin(

--- a/monkey/tests/unit_tests/monkey_island/cc/services/agent_plugin_service/test_mongo_agent_plugin_repository.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/agent_plugin_service/test_mongo_agent_plugin_repository.py
@@ -240,6 +240,16 @@ def test_store_agent_plugin(agent_plugin_repository: MongoAgentPluginRepository)
     assert plugin == FAKE_AGENT_PLUGIN_1
 
 
+def test_store_agent_plugin__excludes_source_archive(
+    mongo_client, agent_plugin_repository: MongoAgentPluginRepository
+):
+    agent_plugin_repository.store_agent_plugin(OperatingSystem.LINUX, FAKE_AGENT_PLUGIN_1)
+
+    assert mongo_client.monkey_island.agent_plugins.count_documents({}) == 1
+    plugin_dict = mongo_client.monkey_island.agent_plugins.find_one({})
+    assert "source_archive" not in plugin_dict
+
+
 def test_store_agent_plugin__overwrites_existing_binary(
     plugin_file, insert_plugin, agent_plugin_repository: MongoAgentPluginRepository
 ):


### PR DESCRIPTION
# What does this PR do?

Fixes the issue in which an error was raised because the agent plugins were too large for Mongo, causing the server to crash.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
