### PR TITLE
Island: Preserve stored binaries when storing plugin

### DIFF
--- a/monkey/monkey_island/cc/services/agent_plugin_service/i_agent_plugin_repository.py
+++ b/monkey/monkey_island/cc/services/agent_plugin_service/i_agent_plugin_repository.py
@@ -46,6 +46,22 @@ class IAgentPluginRepository(ABC):
         """
         pass
 
+    # NOTE: There's a theoretical architectural flaw in this interface. The issue stems from the
+    #       fact that there are effectively two types of plugin objects and we're using one class to
+    #       represent both. A plugin packaged for distribution (hereafter called a "distribution
+    #       plugin") contains the Windows and Linux files needed for the plugin to run whichever OS
+    #       is desired. These distribution plugins get parsed into OS-specific plugins (hereafter
+    #       referred to as "runnables").
+    #
+    #       This interface is confusing because it provides config schemas and manifests for
+    #       distributions, but plugins are stored as runnables, not distributions. In practice, this
+    #       isn't an issue at the present time. However, as a matter of cleanliness, it would be
+    #       nice to refactor this to provide a better interface.
+    #
+    #       The proposed solution is to split this into two Repository interfaces: one for storing
+    #       distribution plugins and one for storing runnables. The distribution plugin repository
+    #       can provide get_all_plugin_{config_schemas,manifests} methods, while the runnable plugin
+    #       repository can provide {get,store}_plugin methods.
     @abstractmethod
     def store_agent_plugin(self, operating_system: OperatingSystem, agent_plugin: AgentPlugin):
         """

--- a/monkey/monkey_island/cc/services/agent_plugin_service/mongo_agent_plugin_repository.py
+++ b/monkey/monkey_island/cc/services/agent_plugin_service/mongo_agent_plugin_repository.py
@@ -143,6 +143,9 @@ class MongoAgentPluginRepository(IAgentPluginRepository):
 
         try:
             plugin_dict = self._get_agent_plugin(plugin_type, plugin_name)
+            # The behavior of this may not be predictable based on the interface definition. See the
+            # note in IAgentPluginRepository.store_agent_plugin for more details and the proposed
+            # solution.
             plugin_dict.update(new_plugin_dict)
         except UnknownRecordError:
             plugin_dict = new_plugin_dict

--- a/monkey/tests/unit_tests/monkey_island/cc/services/agent_plugin_service/test_mongo_agent_plugin_repository.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/agent_plugin_service/test_mongo_agent_plugin_repository.py
@@ -240,6 +240,19 @@ def test_store_agent_plugin(agent_plugin_repository: MongoAgentPluginRepository)
     assert plugin == FAKE_AGENT_PLUGIN_1
 
 
+def test_store_agent_plugin__updates_plugin(
+    mongo_client, agent_plugin_repository: MongoAgentPluginRepository
+):
+    agent_plugin_repository.store_agent_plugin(OperatingSystem.LINUX, FAKE_AGENT_PLUGIN_1)
+    agent_plugin_repository.store_agent_plugin(OperatingSystem.WINDOWS, FAKE_AGENT_PLUGIN_1)
+
+    assert mongo_client.monkey_island.agent_plugins.count_documents({}) == 1
+    plugin_dict = mongo_client.monkey_island.agent_plugins.find_one({})
+    print(plugin_dict)
+    assert "linux" in plugin_dict["binaries"].keys()
+    assert "windows" in plugin_dict["binaries"].keys()
+
+
 def test_store_agent_plugin__excludes_source_archive(
     mongo_client, agent_plugin_repository: MongoAgentPluginRepository
 ):

--- a/monkey/tests/unit_tests/monkey_island/cc/services/agent_plugin_service/test_mongo_agent_plugin_repository.py
+++ b/monkey/tests/unit_tests/monkey_island/cc/services/agent_plugin_service/test_mongo_agent_plugin_repository.py
@@ -245,10 +245,9 @@ def test_store_agent_plugin__updates_plugin(
 ):
     agent_plugin_repository.store_agent_plugin(OperatingSystem.LINUX, FAKE_AGENT_PLUGIN_1)
     agent_plugin_repository.store_agent_plugin(OperatingSystem.WINDOWS, FAKE_AGENT_PLUGIN_1)
+    plugin_dict = mongo_client.monkey_island.agent_plugins.find_one({})
 
     assert mongo_client.monkey_island.agent_plugins.count_documents({}) == 1
-    plugin_dict = mongo_client.monkey_island.agent_plugins.find_one({})
-    print(plugin_dict)
     assert "linux" in plugin_dict["binaries"].keys()
     assert "windows" in plugin_dict["binaries"].keys()
 


### PR DESCRIPTION
# What does this PR do?

Fixes a bug in storing agent plugins.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
