### PR TITLE
UI: Show successfully installed plugins in available plugins tab

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/ui-components/plugins-marketplace/AvailablePlugins.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/ui-components/plugins-marketplace/AvailablePlugins.tsx
@@ -23,7 +23,6 @@ const AvailablePlugins = () => {
   const {availablePlugins} = useContext(PluginsContext);
   const {installedPlugins} = useContext(PluginsContext);
   const {refreshAvailablePlugins} = useContext(PluginsContext);
-  const {refreshInstalledPlugins} = useContext(PluginsContext);
   const [displayedPlugins, setDisplayedPlugins] = useState([]);
 
   const [successfullyInstalledPluginsIds, setSuccessfullyInstalledPluginsIds] = useState([]);
@@ -42,8 +41,6 @@ const AvailablePlugins = () => {
   }
 
   const onInstallClick = (pluginId, pluginName, pluginType, pluginVersion) => {
-    console.log('installing plugin: ', pluginName)
-
     setPluginsInInstallationProcess((prevState) => {
       return shallowAdditionOfUniqueValueToArray(prevState, pluginId);
     });
@@ -52,7 +49,6 @@ const AvailablePlugins = () => {
       setSuccessfullyInstalledPluginsIds((prevState) => {
         return shallowAdditionOfUniqueValueToArray(prevState, pluginId);
       });
-      refreshInstalledPlugins();
     }).catch(() => {
       console.log('error installing plugin');
     }).finally(() => {


### PR DESCRIPTION
# What does this PR do?

Keeps showing the installed plugin so that user has feedback about successful installation:


![downloaded_plugin_stays](https://github.com/guardicore/monkey/assets/36815064/580d7e88-ba49-46e1-93da-2ec49dff6eaa)
