### PR TITLE
Common: Allow '.' characters in Event tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Plugin source is now gzipped. #3392
-- Allowed characters in Agent event tags. #3399
+- Allowed characters in Agent event tags. #3399, #3676
 - Hard-coded Log4Shell exploiter to a plugin. #3388
 - Hard-coded SSH exploiter to a plugin. #3170
 - Identities and secrets can be associated when configuring credentials in the

--- a/monkey/common/agent_events/abstract_agent_event.py
+++ b/monkey/common/agent_events/abstract_agent_event.py
@@ -8,7 +8,7 @@ from pydantic import ConstrainedStr, Field
 from common.base_models import InfectionMonkeyBaseModel, InfectionMonkeyModelConfig
 from common.types import AgentID, MachineID
 
-EVENT_TAG_REGEX = r"^[a-zA-Z0-9_-]+$"
+EVENT_TAG_REGEX = r"^[a-zA-Z0-9._-]+$"
 
 
 class AgentEventTag(ConstrainedStr):


### PR DESCRIPTION
The MITRE ATT&CK framework identifies subtechniques by using a '.' to separate the technique ID from the subtechnique ID. For example, the technique "Defacement" has the ID T1491, whereas the subtechnique "Internal Defacement" has the ID T1491.001.


## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
