### PR TITLE
Update text in reset data modal in UI

### DIFF
--- a/monkey/monkey_island/cc/ui/src/components/ui-components/IslandResetModal.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/ui-components/IslandResetModal.tsx
@@ -32,7 +32,7 @@ const IslandResetModal = (props: Props) => {
       props.onClose()
     }} size={'lg'}>
       <Modal.Header closeButton>
-        <Modal.Title>Delete Gathered Data</Modal.Title>
+        <Modal.Title>Reset simulation</Modal.Title>
       </Modal.Header>
       <Modal.Body>
         {

--- a/monkey/monkey_island/cc/ui/src/components/ui-components/IslandResetModal.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/ui-components/IslandResetModal.tsx
@@ -1,13 +1,13 @@
-import {Button, Col, Container, Modal, NavLink, Row} from 'react-bootstrap';
 import React, {useState} from 'react';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {faExclamationTriangle} from '@fortawesome/free-solid-svg-icons/faExclamationTriangle';
 
 import '../../styles/components/IslandResetModal.scss';
-import {IslandRoutes} from '../Main';
 import LoadingIcon from './LoadingIcon';
 import {faCheck} from '@fortawesome/free-solid-svg-icons';
 import AuthService from '../../services/AuthService';
+import {Modal} from 'react-bootstrap';
+import {Grid} from '@mui/material';
 
 type Props = {
   show: boolean,
@@ -23,25 +23,23 @@ const Done = 3;
 
 const IslandResetModal = (props: Props) => {
 
-  const [resetAllStatus, setResetAll] = useState(Idle);
   const [deleteStatus, setDeleteStatus] = useState(Idle);
   const auth = new AuthService();
 
   return (
     <Modal show={props.show} onHide={() => {
-      setResetAll(Idle);
       setDeleteStatus(Idle);
       props.onClose()
     }} size={'lg'}>
       <Modal.Header closeButton>
-        <Modal.Title>Reset the Island</Modal.Title>
+        <Modal.Title>Delete Gathered Data</Modal.Title>
       </Modal.Header>
       <Modal.Body>
         {
           !props.allMonkeysAreDead ?
             <div className='alert alert-warning'>
               <FontAwesomeIcon icon={faExclamationTriangle} style={{'marginRight': '5px'}}/>
-              Please stop all running agents before attempting to reset the Island.
+              Please stop all running agents before attempting to delete gathered data.
             </div>
             :
             showModalButtons()
@@ -70,32 +68,6 @@ const IslandResetModal = (props: Props) => {
     }
   }
 
-  function displayResetAll() {
-    if (resetAllStatus === Idle) {
-      return (
-        <button type='button' className='btn btn-danger btn-lg' style={{margin: '5px'}}
-                onClick={() => {
-                  setResetAll(Loading);
-                  try {
-                    resetAll().then(() => {
-                      setResetAll(Done);
-                      props.onReset();
-                    });
-                  } catch (err) {
-                    // TODO: Display error message to user
-                    console.error(err)
-                  }
-                }}>
-          Reset the Island
-        </button>
-      )
-    } else if (resetAllStatus === Loading) {
-      return (<LoadingIcon/>)
-    } else if (resetAllStatus === Done) {
-      return (<FontAwesomeIcon icon={faCheck} className={'status-success'} size={'2x'}/>)
-    }
-  }
-
   function clearSimulationData(callback: () => void) {
     auth.authFetch('/api/clear-simulation-data', {method: 'POST'})
       .then(res => {
@@ -105,56 +77,16 @@ const IslandResetModal = (props: Props) => {
       })
   }
 
-  function resetAll(): Promise<void> {
-    return auth.authFetch('/api/reset-agent-configuration', {method: 'POST'})
-      .then(res => {
-        if (res.ok) {
-          return auth.authFetch('/api/clear-simulation-data', {method: 'POST'})
-        }})
-      .then(res => {
-        if (res.ok) {
-          return auth.authFetch('/api/propagation-credentials/configured-credentials', {method: 'PUT', body:'[]'})
-        }})
-      .then(res => {
-        if (res.ok) {
-          return auth.authFetch('/api/agent-binaries/linux/masque', {method: 'PUT'})
-          .then(res => {
-            if (res.ok) {
-              return auth.authFetch('/api/agent-binaries/windows/masque', {method: 'PUT'})
-            }
-          })
-        }})
-      .then(res => {
-        if (! res.ok) {
-          throw 'Error resetting the simulation'
-        }})
-  }
-
   function showModalButtons() {
-    return (<Container className={`text-left island-reset-modal`}>
-      <Row>
-        <Col>
-          <p>Delete data gathered by Monkey Agents.</p>
-          <p>This will reset the map and reports.</p>
-        </Col>
-        <Col sm={4} className={'text-center'}>
+    return (
+    <Grid container rowSpacing={3}>
+      <Grid xs={12} item>
+        <h5 style={{'textAlign': 'center'}}>This action will reset the map and reports.</h5>
+      </Grid>
+      <Grid xs={12} item style={{'textAlign': 'center'}}>
           {displayDeleteData()}
-        </Col>
-      </Row>
-      <hr/>
-      <Row>
-        <Col>
-          <p>Reset everything.</p>
-          <p>This will not uninstall any plugins. You might want
-            to <Button variant={'link'} href={IslandRoutes.ConfigurePage}>export
-            configuration</Button> before doing this.</p>
-          <p></p>
-        </Col>
-        <Col sm={4} className={'text-center'}>
-          {displayResetAll()}
-        </Col>
-      </Row>
-    </Container>)
+      </Grid>
+    </Grid>)
   }
 }
 

--- a/monkey/monkey_island/cc/ui/src/components/ui-components/IslandResetModal.tsx
+++ b/monkey/monkey_island/cc/ui/src/components/ui-components/IslandResetModal.tsx
@@ -134,8 +134,8 @@ const IslandResetModal = (props: Props) => {
     return (<Container className={`text-left island-reset-modal`}>
       <Row>
         <Col>
-          <p>Delete data gathered by Monkey agents.</p>
-          <p>This will reset the Map and reports.</p>
+          <p>Delete data gathered by Monkey Agents.</p>
+          <p>This will reset the map and reports.</p>
         </Col>
         <Col sm={4} className={'text-center'}>
           {displayDeleteData()}
@@ -145,8 +145,10 @@ const IslandResetModal = (props: Props) => {
       <Row>
         <Col>
           <p>Reset everything.</p>
-          <p>You might want to <Button variant={'link'} href={IslandRoutes.ConfigurePage}>export
+          <p>This will not uninstall any plugins. You might want
+            to <Button variant={'link'} href={IslandRoutes.ConfigurePage}>export
             configuration</Button> before doing this.</p>
+          <p></p>
         </Col>
         <Col sm={4} className={'text-center'}>
           {displayResetAll()}


### PR DESCRIPTION
# What does this PR do?

Updates UI to mentions that plugins won't be uninstalled even if you reset the Island completely.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [x] Was the CHANGELOG.md updated to reflect the changes?
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [ ] ~Have you checked that you haven't introduced any duplicate code?~

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [ ] ~Do all unit tests pass?~
* [ ] ~Do all end-to-end tests pass?~
* [x] Any other testing performed?
    > Tested by running UI
* [x] If applicable, add screenshots or log transcripts of the feature working

![image](https://github.com/guardicore/monkey/assets/44770317/ea34e087-ae6d-446a-a6a8-4783019f2ecb)
