### PR TITLE
Remove vendor-windows dir after building the zip

### DIFF
--- a/monkey/agent_plugins/build_windows_vendor_directory.ps1
+++ b/monkey/agent_plugins/build_windows_vendor_directory.ps1
@@ -13,6 +13,7 @@ Set-Location $plugin_path
 
 Remove-Item "$workspace\vendor-windows.zip" -Force
 Remove-Item $plugin_path\venv -Recurse -Force
+Remove-Item "$plugin_path\src\vendor-windows" -Recurse -Force
 & python -m venv "$plugin_path\venv"
 & "$plugin_path\venv\Scripts\Activate.ps1"
 
@@ -35,3 +36,4 @@ Compress-Archive -Path "$plugin_path\src\vendor-windows" -Destination "$workspac
 Set-PSDebug -Trace 1
 
 Remove-Item $plugin_path\venv -Recurse -Force
+Remove-Item "$plugin_path\src\vendor-windows" -Recurse -Force


### PR DESCRIPTION
# What does this PR do?

When building vendor-windows dir for each plugin we forgot to remove the vendor-windows directory which meant that if some plugin is rebuild, some of the dependencies may still be left out.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [x] Was the CHANGELOG.md updated to reflect the changes?
* [x] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [ ] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [x] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [x] If applicable, add screenshots or log transcripts of the feature working
