### PR TITLE
Plugin ports as integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Ports in Hadoop exploiter configuration can no longer be floating-point numbers.
+- Ports in Log4Shell exploiter configuration can no longer be floating-point numbers.
 
 
 ## [2.3.0 - 2023-09-19]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Ports in Hadoop exploiter configuration can no longer be floating-point numbers.
 - Ports in Log4Shell exploiter configuration can no longer be floating-point numbers.
+- Ports in MSSQL exploiter configuration can no longer be floating-point numbers.
 
 
 ## [2.3.0 - 2023-09-19]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ file.
 The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+- Ports in Hadoop exploiter configuration can no longer be floating-point numbers.
+
+
 ## [2.3.0 - 2023-09-19]
 ### Added
 - Ability to filter Agent events by timestamp. #3397

--- a/monkey/agent_plugins/exploiters/hadoop/config-schema.json
+++ b/monkey/agent_plugins/exploiters/hadoop/config-schema.json
@@ -12,7 +12,7 @@
             "type": "array",
             "uniqueItems": true,
             "items": {
-                "type": "number",
+                "type": "integer",
                 "minimum": 0,
                 "maximum": 65535
             },

--- a/monkey/agent_plugins/exploiters/hadoop/manifest.yml
+++ b/monkey/agent_plugins/exploiters/hadoop/manifest.yml
@@ -7,7 +7,7 @@ target_operating_systems:
   - linux
   - windows
 title: Hadoop/YARN Exploiter
-version: 3.0.0
+version: 3.0.1
 description: >-
   Remote code execution on Hadoop server with YARN and default settings.
 

--- a/monkey/agent_plugins/exploiters/log4shell/config-schema.json
+++ b/monkey/agent_plugins/exploiters/log4shell/config-schema.json
@@ -6,7 +6,7 @@
             "type": "array",
             "uniqueItems": true,
             "items": {
-                "type": "number",
+                "type": "integer",
                 "minimum": 0,
                 "maximum": 65535
             },

--- a/monkey/agent_plugins/exploiters/log4shell/manifest.yml
+++ b/monkey/agent_plugins/exploiters/log4shell/manifest.yml
@@ -7,7 +7,7 @@ target_operating_systems:
   - linux
   - windows
 title: Log4Shell Exploiter
-version: 2.0.0
+version: 2.0.1
 description: >-
   Exploits a software vulnerability (CVE-2021-44228) in Apache Log4j, a Java
   logging framework. Exploitation is attempted on the following services —

--- a/monkey/agent_plugins/exploiters/mssql/config-schema.json
+++ b/monkey/agent_plugins/exploiters/mssql/config-schema.json
@@ -6,7 +6,7 @@
             "type": "array",
             "uniqueItems": true,
             "items": {
-                "type": "number",
+                "type": "integer",
                 "minimum": 0,
                 "maximum": 65535
             },

--- a/monkey/agent_plugins/exploiters/mssql/manifest.yaml
+++ b/monkey/agent_plugins/exploiters/mssql/manifest.yaml
@@ -6,7 +6,7 @@ supported_operating_systems:
 target_operating_systems:
   - windows
 title: MSSQL Exploiter
-version: 2.0.0
+version: 2.0.1
 description: >-
     Attempts a brute-force attack against Microsoft SQL using known credentials
     and takes advantage of insecure configuration to execute commands on the


### PR DESCRIPTION
# What does this PR do?

Hadoop, MSSQL, and Log4Shell would allow floating-point numbers for network ports. This PR fixes these three exploiters to allow only integer ports.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] ~Is the TravisCI build passing?~
* [x] Was the CHANGELOG.md updated to reflect the changes?
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [x] Do all unit tests pass?
* [ ] ~Do all end-to-end tests pass?~
* [x] Any other testing performed?
    > Ran depth 1 tests
* [ ] If applicable, add screenshots or log transcripts of the feature working
