### PR TITLE
Pass Agent OTP env var to exploiters

### DIFF
--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -426,6 +426,7 @@ class InfectionMonkey:
                 self._propagation_credentials_repository,
                 self._tcp_port_selector,
                 otp_provider,
+                AGENT_OTP_ENVIRONMENT_VARIABLE,
                 create_plugin,
             ),
             AgentPluginType.PAYLOAD: PayloadPluginFactory(

--- a/monkey/infection_monkey/plugin/exploiter_plugin_factory.py
+++ b/monkey/infection_monkey/plugin/exploiter_plugin_factory.py
@@ -25,6 +25,7 @@ class ExploiterPluginFactory(IPluginFactory):
         propagation_credentials_repository: IPropagationCredentialsRepository,
         tcp_port_selector: TCPPortSelector,
         otp_provider: IAgentOTPProvider,
+        agent_otp_environment_variable: str,
         create_plugin: Callable[..., SingleUsePlugin],
     ):
         self._agent_id = agent_id
@@ -34,6 +35,7 @@ class ExploiterPluginFactory(IPluginFactory):
         self._propagation_credentials_repository = propagation_credentials_repository
         self._tcp_port_selector = tcp_port_selector
         self._otp_provider = otp_provider
+        self._agent_otp_environment_variable = agent_otp_environment_variable
         self._create_plugin = create_plugin
 
     def create(self, plugin_name: str) -> SingleUsePlugin:
@@ -45,5 +47,6 @@ class ExploiterPluginFactory(IPluginFactory):
             propagation_credentials_repository=self._propagation_credentials_repository,
             tcp_port_selector=self._tcp_port_selector,
             otp_provider=self._otp_provider,
+            agent_otp_environment_variable=self._agent_otp_environment_variable,
             http_agent_binary_server_registrar=self._http_agent_binary_server_registrar,
         )


### PR DESCRIPTION
# What does this PR do?

Passes the Agent OTP environment variable to ExploiterPluginFactory and then to plugins when they're built
Fixes a part of #3741

## PR Checklist
* [c] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [x] Do all unit tests pass?
* [ ] ~Do all end-to-end tests pass?~
* [ ] ~Any other testing performed?~
    > ~Tested by {Running the Monkey locally with relevant config/running Island/...}~
* [ ] ~If applicable, add screenshots or log transcripts of the feature working~
