### PR TITLE
Remove logic to delete http_ports option in plugins

### DIFF
--- a/monkey/agent_plugins/exploiters/hadoop/src/plugin.py
+++ b/monkey/agent_plugins/exploiters/hadoop/src/plugin.py
@@ -13,7 +13,6 @@ from monkeytypes import Event
 # common imports
 from common.event_queue import IAgentEventPublisher
 from common.types import AgentID
-from common.utils.code_utils import del_key
 
 # dependencies to get rid of or internalize
 from infection_monkey.exploit import IAgentOTPProvider, IHTTPAgentBinaryServerRegistrar
@@ -58,9 +57,6 @@ class Plugin:
         interrupt: Event,
         **kwargs,
     ) -> ExploiterResult:
-        # HTTP ports options are hack because they are needed in fingerprinters
-        del_key(options, "http_ports")
-
         try:
             logger.debug(f"Parsing options: {pformat(options)}")
             hadoop_options = HadoopOptions(**options)

--- a/monkey/agent_plugins/exploiters/log4shell/src/plugin.py
+++ b/monkey/agent_plugins/exploiters/log4shell/src/plugin.py
@@ -7,7 +7,6 @@ from monkeytypes import Event
 # common imports
 from common.event_queue import IAgentEventPublisher
 from common.types import AgentID, NetworkPort
-from common.utils.code_utils import del_key
 
 # dependencies to get rid of or internalize
 from infection_monkey.exploit import IAgentOTPProvider, IHTTPAgentBinaryServerRegistrar
@@ -72,9 +71,6 @@ class Plugin:
         interrupt: Event,
         **kwargs,
     ) -> ExploiterResult:
-        # HTTP ports options are hack because they are needed in fingerprinters
-        del_key(options, "http_ports")
-
         try:
             logger.debug(f"Parsing options: {pformat(options)}")
             log4shell_options = Log4ShellOptions(**options)

--- a/monkey/agent_plugins/exploiters/mssql/src/plugin.py
+++ b/monkey/agent_plugins/exploiters/mssql/src/plugin.py
@@ -7,7 +7,6 @@ from monkeytypes import Event, Password, Username
 
 from common.event_queue import IAgentEventPublisher
 from common.types import AgentID, NetworkPort, NetworkService
-from common.utils.code_utils import del_key
 
 # dependencies to get rid of or internalize
 from infection_monkey.exploit import (
@@ -67,9 +66,6 @@ class Plugin:
         interrupt: Event,
         **kwargs,
     ) -> ExploiterResult:
-        # HTTP ports options are hack because they are needed in fingerprinters
-        del_key(options, "http_ports")
-
         try:
             logger.debug(f"Parsing options: {pformat(options)}")
             mssql_options = MSSQLOptions(**options)

--- a/monkey/agent_plugins/exploiters/powershell/src/plugin.py
+++ b/monkey/agent_plugins/exploiters/powershell/src/plugin.py
@@ -8,7 +8,6 @@ from monkeytypes import Event, OperatingSystem
 
 from common.event_queue import IAgentEventPublisher
 from common.types import AgentID
-from common.utils.code_utils import del_key
 from common.utils.environment import get_os
 
 # dependencies to get rid of or internalize
@@ -73,9 +72,6 @@ class Plugin:
         interrupt: Event,
         **kwargs,
     ) -> ExploiterResult:
-        # HTTP ports options are hack because they are needed in fingerprinters
-        del_key(options, "http_ports")
-
         try:
             logger.debug(f"Parsing options: {pformat(options)}")
             powershell_options = PowerShellOptions(**options)

--- a/monkey/agent_plugins/exploiters/rdp/src/plugin.py
+++ b/monkey/agent_plugins/exploiters/rdp/src/plugin.py
@@ -9,7 +9,6 @@ from monkeytypes import Event, OperatingSystem
 from common.agent_events import AgentEventTag
 from common.event_queue import IAgentEventPublisher
 from common.types import AgentID
-from common.utils.code_utils import del_key
 from common.utils.environment import get_os
 
 # dependencies to get rid of or internalize
@@ -67,9 +66,6 @@ class Plugin:
         interrupt: Event,
         **kwargs,
     ) -> ExploiterResult:
-        # HTTP ports options are hack because they are needed in fingerprinters
-        del_key(options, "http_ports")
-
         try:
             logger.debug(f"Parsing options: {pformat(options)}")
             rdp_options = RDPOptions(**options)

--- a/monkey/agent_plugins/exploiters/smb/src/plugin.py
+++ b/monkey/agent_plugins/exploiters/smb/src/plugin.py
@@ -8,7 +8,6 @@ from monkeytypes import Event, LMHash, NTHash, Password, Username
 
 from common.event_queue import IAgentEventPublisher
 from common.types import AgentID
-from common.utils.code_utils import del_key
 
 # dependencies to get rid of or internalize
 from infection_monkey.exploit import IAgentBinaryRepository, IAgentOTPProvider
@@ -74,9 +73,6 @@ class Plugin:
         interrupt: Event,
         **kwargs,
     ) -> ExploiterResult:
-        # HTTP ports options are hack because they are needed in fingerprinters
-        del_key(options, "http_ports")
-
         try:
             logger.debug(f"Parsing options: {pformat(options)}")
             smb_options = SMBOptions(**options)

--- a/monkey/agent_plugins/exploiters/snmp/src/plugin.py
+++ b/monkey/agent_plugins/exploiters/snmp/src/plugin.py
@@ -8,7 +8,6 @@ from monkeytypes import Event
 # common imports
 from common.event_queue import IAgentEventPublisher
 from common.types import AgentID
-from common.utils.code_utils import del_key
 
 # dependencies to get rid of or internalize
 from infection_monkey.exploit import (
@@ -82,9 +81,6 @@ class Plugin:
         interrupt: Event,
         **kwargs,
     ) -> ExploiterResult:
-        # HTTP ports options are hack because they are needed in fingerprinters
-        del_key(options, "http_ports")
-
         try:
             logger.debug(f"Parsing options: {pformat(options)}")
             snmp_options = SNMPOptions(**options)

--- a/monkey/agent_plugins/exploiters/ssh/src/plugin.py
+++ b/monkey/agent_plugins/exploiters/ssh/src/plugin.py
@@ -8,7 +8,6 @@ from monkeytypes import Event, Password, SSHKeypair, Username
 
 from common.event_queue import IAgentEventPublisher
 from common.types import AgentID
-from common.utils.code_utils import del_key
 
 # dependencies to get rid of or internalize
 from infection_monkey.exploit import IAgentBinaryRepository, IAgentOTPProvider
@@ -75,9 +74,6 @@ class Plugin:
         interrupt: Event,
         **kwargs,
     ) -> ExploiterResult:
-        # HTTP ports options are hack because they are needed in fingerprinters
-        del_key(options, "http_ports")
-
         try:
             logger.debug(f"Parsing options: {pformat(options)}")
             ssh_options = SSHOptions(**options)

--- a/monkey/agent_plugins/exploiters/wmi/src/plugin.py
+++ b/monkey/agent_plugins/exploiters/wmi/src/plugin.py
@@ -8,7 +8,6 @@ from monkeytypes import Event, LMHash, NTHash, Password, Username
 
 from common.event_queue import IAgentEventPublisher
 from common.types import AgentID
-from common.utils.code_utils import del_key
 
 # dependencies to get rid of or internalize
 from infection_monkey.exploit import IAgentBinaryRepository, IAgentOTPProvider
@@ -76,9 +75,6 @@ class Plugin:
         interrupt: Event,
         **kwargs,
     ) -> ExploiterResult:
-        # HTTP ports options are hack because they are needed in fingerprinters
-        del_key(options, "http_ports")
-
         try:
             logger.debug(f"Parsing options: {pformat(options)}")
             wmi_options = WMIOptions(**options)

--- a/monkey/agent_plugins/exploiters/zerologon/src/plugin.py
+++ b/monkey/agent_plugins/exploiters/zerologon/src/plugin.py
@@ -6,7 +6,6 @@ from monkeytypes import Event
 
 from common.event_queue import IAgentEventPublisher
 from common.types import AgentID
-from common.utils.code_utils import del_key
 from infection_monkey.i_puppet import ExploiterResult, TargetHost
 
 from .zerologon import ZerologonExploiter
@@ -36,9 +35,6 @@ class Plugin:
         interrupt: Event,
         **kwargs,
     ) -> ExploiterResult:
-        # HTTP ports options are hack because they are needed in fingerprinters
-        del_key(options, "http_ports")
-
         try:
             logger.debug(f"Parsing options: {pformat(options)}")
             zerologon_options = ZerologonOptions(**options)

--- a/monkey/agent_plugins/payloads/cryptojacker/src/plugin.py
+++ b/monkey/agent_plugins/payloads/cryptojacker/src/plugin.py
@@ -6,7 +6,6 @@ from monkeytypes import Event
 
 from common.event_queue import IAgentEventPublisher
 from common.types import AgentID, SocketAddress
-from common.utils.code_utils import del_key
 from infection_monkey.i_puppet import PayloadResult
 
 from .cryptojacker_builder import build_cryptojacker
@@ -36,9 +35,6 @@ class Plugin:
         interrupt: Event,
         **kwargs,
     ) -> PayloadResult:
-        # HTTP ports options are hack because they are needed in fingerprinters
-        del_key(options, "http_ports")
-
         try:
             logger.debug(f"Parsing options: {pformat(options)}")
             cryptojacker_options = CryptojackerOptions(**options)

--- a/monkey/agent_plugins/payloads/ransomware/src/plugin.py
+++ b/monkey/agent_plugins/payloads/ransomware/src/plugin.py
@@ -6,7 +6,6 @@ from monkeytypes import Event
 
 from common.event_queue import IAgentEventPublisher
 from common.types import AgentID
-from common.utils.code_utils import del_key
 from infection_monkey.i_puppet import PayloadResult
 
 from .ransomware_builder import build_ransomware
@@ -34,9 +33,6 @@ class Plugin:
         interrupt: Event,
         **kwargs,
     ) -> PayloadResult:
-        # HTTP ports options are hack because they are needed in fingerprinters
-        del_key(options, "http_ports")
-
         try:
             logger.debug(f"Parsing options: {pformat(options)}")
             ransomware_options = RansomwareOptions(**options)


### PR DESCRIPTION
# What does this PR do?

Fixes a part of #3769 

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] ~Was the documentation framework updated to reflect the changes?~
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] ~Added relevant unit tests?~
* [x] Do all unit tests pass?
* [x] Do all end-to-end tests pass?
    > All exploiters pass at least once (~2 tunneling machines didn't communicate back in depth_4_a, probably due to speed issues~ everything passed the second time)
* [ ] ~Any other testing performed?~
    > ~Tested by {Running the Monkey locally with relevant config/running Island/...}~
* [ ] ~If applicable, add screenshots or log transcripts of the feature working~
