### PR TITLE
Agent: Add a typehint for config schema in AgentPlugin

### DIFF
--- a/monkey/common/agent_plugins/agent_plugin.py
+++ b/monkey/common/agent_plugins/agent_plugin.py
@@ -1,8 +1,12 @@
 from base64 import b64encode
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, List, Tuple, Union
 
 from monkeytypes import AgentPluginManifest, B64Bytes, InfectionMonkeyBaseModel, OperatingSystem
 from pydantic import field_serializer
+
+# Replace with JSONSerializable from monkeytypes
+# once this is fixed: https://github.com/pydantic/pydantic/issues/7487
+JSONSerializableValue = Union[str, int, float, bool, None, List[Any], Dict[Any, Any]]
 
 
 class AgentPlugin(InfectionMonkeyBaseModel):
@@ -17,9 +21,7 @@ class AgentPlugin(InfectionMonkeyBaseModel):
     """
 
     plugin_manifest: AgentPluginManifest
-    # Should be JSONSerializable but it's only supported in 3.9:
-    # https://github.com/pydantic/pydantic/pull/1844
-    config_schema: Dict[str, Any]
+    config_schema: Dict[str, JSONSerializableValue]
     source_archive: B64Bytes
     supported_operating_systems: Tuple[OperatingSystem, ...]
 


### PR DESCRIPTION
Typehint is useful because developers will know before runtime that invalid config schema was passed. Due to a limitation/bug in pydantic we can't use self-referencing version, but this should be good enough and catch the majority of cases

