### PR TITLE
SMB: Remove required field from config-schema

### DIFF
--- a/monkey/agent_plugins/exploiters/smb/config-schema.json
+++ b/monkey/agent_plugins/exploiters/smb/config-schema.json
@@ -1,9 +1,4 @@
 {
-    "required": [
-        "agent_binary_upload_timeout",
-        "smb_connect_timeout"
-
-    ],
     "properties": {
         "agent_binary_upload_timeout": {
             "title": "Agent binary upload timeout",


### PR DESCRIPTION
Required is not needed, because we have reasonable defaults that will be used to fill in the values in case the fields are missing

# What does this PR do?

Fixes part of #3839
