### PR TITLE
Hadoop: Remove required field from config-schema

### DIFF
--- a/monkey/agent_plugins/exploiters/hadoop/config-schema.json
+++ b/monkey/agent_plugins/exploiters/hadoop/config-schema.json
@@ -1,10 +1,4 @@
 {
-    "required": [
-        "target_ports",
-        "request_timeout",
-        "agent_binary_download_timeout",
-        "yarn_application_suffix"
-    ],
     "properties": {
         "target_ports": {
             "title": "Target ports",


### PR DESCRIPTION
Required is not needed, because we have reasonable defaults that will be used to fill in the values in case the fields are missing

# What does this PR do?

Fixes part of #3839

