### PR TITLE
3751 reimplement get interface to target

### DIFF
--- a/monkey/infection_monkey/exploit/http_agent_binary_server.py
+++ b/monkey/infection_monkey/exploit/http_agent_binary_server.py
@@ -8,8 +8,8 @@ from uuid import uuid4
 from monkeytypes import Event, Lock, NetworkPort, OperatingSystem
 
 from common.utils.code_utils import insecure_generate_random_string
+from infection_monkey.local_machine_info import LocalMachineInfo
 from infection_monkey.network import TCPPortSelector
-from infection_monkey.network.tools import get_interface_to_target
 from infection_monkey.utils.threading import create_daemon_thread
 
 from .agent_binary_request import (
@@ -45,12 +45,14 @@ class HTTPAgentBinaryServer:
 
     def __init__(
         self,
+        local_machine_info: LocalMachineInfo,
         tcp_port_selector: TCPPortSelector,
         get_handler_class: AgentBinaryHTTPHandlerFactory,
         create_event: Callable[[], Event],
         lock: Lock,
         poll_interval: float = 0.5,
     ):
+        self._local_machine_info = local_machine_info
         self._tcp_port_selector = tcp_port_selector
         self._handler_class = get_handler_class()
         self._create_event = create_event
@@ -103,7 +105,9 @@ class HTTPAgentBinaryServer:
         operating_system: OperatingSystem,
         requestor_ip: IPv4Address,
     ) -> str:
-        server_ip = get_interface_to_target(str(requestor_ip))
+        interface_to_target = self._local_machine_info.get_interface_to_target(requestor_ip)
+
+        server_ip = interface_to_target.ip
         return f"http://{server_ip}:{self._port}/{operating_system.value}/{reservation_id}"
 
     def server_is_running(self) -> bool:

--- a/monkey/infection_monkey/exploit/http_agent_binary_server.py
+++ b/monkey/infection_monkey/exploit/http_agent_binary_server.py
@@ -107,6 +107,11 @@ class HTTPAgentBinaryServer:
     ) -> str:
         interface_to_target = self._local_machine_info.get_interface_to_target(requestor_ip)
 
+        if interface_to_target is None:
+            raise RuntimeError(
+                f"Could not find an interface to the target {requestor_ip} to serve Agent binaries"
+            )
+
         server_ip = interface_to_target.ip
         return f"http://{server_ip}:{self._port}/{operating_system.value}/{reservation_id}"
 

--- a/monkey/infection_monkey/exploit/http_agent_binary_server_factory.py
+++ b/monkey/infection_monkey/exploit/http_agent_binary_server_factory.py
@@ -3,6 +3,7 @@ from multiprocessing.managers import SyncManager
 from typing import Callable, Optional
 
 from infection_monkey.exploit import IAgentBinaryRepository
+from infection_monkey.local_machine_info import LocalMachineInfo
 from infection_monkey.network import TCPPortSelector
 
 from .http_agent_binary_server import AgentBinaryHTTPHandlerFactory, HTTPAgentBinaryServer
@@ -18,12 +19,15 @@ class HTTPAgentBinaryServerWithManagerFactory(HTTPAgentBinaryServer):
 
     def __init__(
         self,
+        local_machine_info: LocalMachineInfo,
         tcp_port_selector: TCPPortSelector,
         get_http_handler: AgentBinaryHTTPHandlerFactory,
     ):
         manager = get_context("spawn").Manager()
         create_event = manager.Event
-        super().__init__(tcp_port_selector, get_http_handler, create_event, manager.Lock())
+        super().__init__(
+            local_machine_info, tcp_port_selector, get_http_handler, create_event, manager.Lock()
+        )
 
 
 class HTTPAgentBinaryServerFactory:
@@ -35,10 +39,12 @@ class HTTPAgentBinaryServerFactory:
 
     def __init__(
         self,
+        local_machine_info: LocalMachineInfo,
         tcp_port_selector: TCPPortSelector,
         agent_binary_repository: IAgentBinaryRepository,
         get_http_handler: Callable[[IAgentBinaryRepository], AgentBinaryHTTPHandlerFactory],
     ):
+        self._local_machine_info = local_machine_info
         self._tcp_port_selector = tcp_port_selector
         self._agent_binary_repository = agent_binary_repository
         self._get_http_handler = get_http_handler
@@ -56,6 +62,7 @@ class HTTPAgentBinaryServerFactory:
     def __call__(self) -> HTTPAgentBinaryServer:
         manager = self._get_manager()
         return manager.HTTPAgentBinaryServer(  # type: ignore[attr-defined]
+            self._local_machine_info,
             self._tcp_port_selector,
             self._get_http_handler(self._agent_binary_repository),
         )

--- a/monkey/infection_monkey/local_machine_info.py
+++ b/monkey/infection_monkey/local_machine_info.py
@@ -25,6 +25,4 @@ class LocalMachineInfo(InfectionMonkeyBaseModel):
         """
         Gets an interface on the local machine that can be reached by the target machine
         """
-        # TODO: Use `network_interfaces` to get the interface
-        interface = get_interface_to_target(str(target))
-        return IPv4Interface(interface) if interface else None
+        return get_interface_to_target(self.network_interfaces, target)

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -156,9 +156,8 @@ class InfectionMonkey:
             / f"infection_monkey_plugins_{self._agent_id}_{secure_generate_random_string(n=20)}"
         )
 
-        self._operating_system = get_os()
         self._local_machine_info = LocalMachineInfo(
-            operating_system=self._operating_system,
+            operating_system=get_os(),
             temporary_directory=get_monkey_dir_path(),
             network_interfaces=get_network_interfaces(),
         )
@@ -456,7 +455,7 @@ class InfectionMonkey:
         )
         plugin_compatibility_verifier = PluginCompatibilityVerifier(
             self._island_api_client,
-            self._operating_system,
+            self._local_machine_info.operating_system,
         )
 
         puppet = Puppet(

--- a/monkey/infection_monkey/monkey.py
+++ b/monkey/infection_monkey/monkey.py
@@ -157,11 +157,10 @@ class InfectionMonkey:
         )
 
         self._operating_system = get_os()
-        self._local_network_interfaces = get_network_interfaces()
         self._local_machine_info = LocalMachineInfo(
             operating_system=self._operating_system,
             temporary_directory=get_monkey_dir_path(),
-            network_interfaces=self._local_network_interfaces,
+            network_interfaces=get_network_interfaces(),
         )
 
         self._island_address, self._island_api_client = self._connect_to_island_api()
@@ -275,7 +274,7 @@ class InfectionMonkey:
             start_time=agent_process.get_start_time(),
             parent_id=self._opts.parent,
             cc_server=self._island_address,
-            network_interfaces=self._local_network_interfaces,
+            network_interfaces=self._local_machine_info.network_interfaces,
             sha256=self._sha256,
         )
         self._island_api_client.register_agent(agent_registration_data)
@@ -387,7 +386,7 @@ class InfectionMonkey:
             servers,
             puppet,
             self._island_api_client,
-            self._local_network_interfaces,
+            self._local_machine_info.network_interfaces,
         )
 
     def _build_server_list(self, relay_port: Optional[NetworkPort]) -> Sequence[str]:

--- a/monkey/infection_monkey/network/tools.py
+++ b/monkey/infection_monkey/network/tools.py
@@ -2,7 +2,8 @@ import logging
 import socket
 import struct
 import sys
-from typing import Optional
+from ipaddress import IPv4Address, IPv4Interface
+from typing import Iterable, Optional
 
 from common.common_consts.timeouts import CONNECTION_TIMEOUT
 from infection_monkey.network.info import get_routes
@@ -13,15 +14,70 @@ BANNER_READ = 1024
 logger = logging.getLogger(__name__)
 
 
-def get_interface_to_target(dst: str) -> Optional[str]:
+def get_interface_to_target(
+    interfaces: Iterable[IPv4Interface], target: IPv4Address
+) -> Optional[IPv4Interface]:
     """
-    :param dst: destination IP address string without port. E.G. '192.168.1.1.'
-    :return: IP address string of an interface that can connect to the target. E.G. '192.168.1.4.'
+    This function attempts to find the interface that can connect to the target. It first attempts
+    to do this rationally by examining network membership. If that fails, it attempts to do this
+    empirically by opening sockets and examining routes.
+
+    :param interfaces: An iterable of interfaces
+    :param target: The IP address of the target
+    :return: The network interface that can connect to the target, or None if no such interface
+             could be found
+    """
+
+    interface_to_target = _rational_get_interface_to_target(interfaces, target)
+
+    if interface_to_target is not None:
+        return interface_to_target
+
+    interface_ip_to_target = _empirical_get_interface_to_target(str(target))
+
+    if interface_ip_to_target is None:
+        return None
+
+    for i in interfaces:
+        if i.ip == interface_ip_to_target:
+            return i
+
+    return None
+
+
+def _rational_get_interface_to_target(
+    interfaces: Iterable[IPv4Interface], target: IPv4Address
+) -> Optional[IPv4Interface]:
+    """
+    This function attempts to find the interface that can connect to the target by looking at the
+    system's network membership and the target's IP address. There are some rare edge cases where
+    this will be incorrect, but this is an acceptable tradeoff, as other approaches involve opening
+    sockets, which can be slow and noisy.
+
+    :param interfaces: An iterable of interfaces
+    :param target: The IP address of the target
+    :return: The network interface that can connect to the target, or None if no such interface
+             could be found
+    """
+    for i in interfaces:
+        if target in i.network:
+            return i
+
+    return None
+
+
+def _empirical_get_interface_to_target(target: str) -> Optional[IPv4Address]:
+    """
+    This function attempts to find the interface that can connect to the target by opening a socket
+
+    :param target: destination IP address string without port. E.G. '192.168.1.1.'
+    :return: IP address string of an interface that can connect to the target, or None if no such
+             interface could be found
     """
     if sys.platform == "win32":
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         try:
-            s.connect((dst, 1))
+            s.connect((target, 1))
             ip_to_dst = s.getsockname()[0]
         except KeyError:
             logger.debug(
@@ -30,7 +86,7 @@ def get_interface_to_target(dst: str) -> Optional[str]:
             ip_to_dst = "127.0.0.1"
         finally:
             s.close()
-        return ip_to_dst
+        return IPv4Address(ip_to_dst)
     else:
         # based on scapy implementation
 
@@ -39,16 +95,16 @@ def get_interface_to_target(dst: str) -> Optional[str]:
             return struct.unpack("!I", ip)[0]
 
         routes = get_routes()
-        dst = atol(dst)
+        target_long = atol(target)
         paths = []
         for d, m, gw, i, a in routes:
             aa = atol(a)
-            if aa == dst:
+            if aa == target_long:
                 paths.append((0xFFFFFFFF, ("lo", a, "0.0.0.0")))
-            if (dst & m) == (d & m):
+            if (target_long & m) == (d & m):
                 paths.append((m, (i, a, gw)))
         if not paths:
             return None
         paths.sort()
         ret = paths[-1][1]
-        return ret[1]
+        return IPv4Address(ret[1])

--- a/monkey/tests/unit_tests/infection_monkey/exploit/test_http_agent_binary_server.py
+++ b/monkey/tests/unit_tests/infection_monkey/exploit/test_http_agent_binary_server.py
@@ -146,6 +146,20 @@ def test_register__fails_if_handler_registration_fails(
 
 
 @pytest.mark.xdist_group(name="tcp_port_selector")
+def test_register__fails_if_interface_to_target_returns_none(
+    mock_local_machine_info: MockLocalMachineInfo,
+    http_agent_binary_server: HTTPAgentBinaryServer,
+    mock_agent_binary_http_handler: Type[AgentBinaryHTTPRequestHandler],
+):
+    mock_local_machine_info.get_interface_to_target = lambda *args, **kwargs: None
+
+    with pytest.raises(RuntimeError):
+        http_agent_binary_server.register(OperatingSystem.LINUX, REQUESTOR_IP)
+
+    http_agent_binary_server.stop()
+
+
+@pytest.mark.xdist_group(name="tcp_port_selector")
 def test_register__starts_the_server_if_not_started(
     http_agent_binary_server: HTTPAgentBinaryServer,
 ):

--- a/monkey/tests/unit_tests/infection_monkey/exploit/test_http_agent_binary_server.py
+++ b/monkey/tests/unit_tests/infection_monkey/exploit/test_http_agent_binary_server.py
@@ -1,9 +1,11 @@
+import tempfile
 import threading
 from dataclasses import dataclass
 from http import HTTPStatus
-from ipaddress import IPv4Address
+from ipaddress import IPv4Address, IPv4Interface
 from multiprocessing import get_context
 from multiprocessing.managers import SyncManager
+from pathlib import Path
 from queue import Queue
 from typing import List, Tuple, Type
 from unittest.mock import MagicMock
@@ -43,6 +45,28 @@ class MockAgentBinaryHTTPRequestHandlerMT(AgentBinaryHTTPRequestHandler):
         cls.cleared_reservations.append(reservation_id)
 
 
+class MockLocalMachineInfo:
+    def __init__(self, temporary_directory=None):
+        self.operating_system = (OperatingSystem.LINUX,)
+
+        if temporary_directory is None:
+            self.temporary_directory = Path(tempfile.gettempdir())
+        else:
+            self.temporary_directory = temporary_directory
+
+        self.network_interfaces = [IPv4Interface("127.0.0.1/32")]
+
+    def get_interface_to_target(self, target: IPv4Address) -> IPv4Interface:
+        return self.network_interfaces[0]
+
+
+@pytest.fixture
+def mock_local_machine_info(tmp_path: Path) -> MockLocalMachineInfo:
+    return MockLocalMachineInfo(
+        temporary_directory=tmp_path,
+    )
+
+
 @pytest.fixture
 def mock_agent_binary_http_handler() -> Type[AgentBinaryHTTPRequestHandler]:
     class MockAgentBinaryHTTPRequestHandler(AgentBinaryHTTPRequestHandler):
@@ -73,10 +97,12 @@ def mock_agent_binary_http_handler() -> Type[AgentBinaryHTTPRequestHandler]:
 
 @pytest.fixture
 def http_agent_binary_server(
+    mock_local_machine_info: MockLocalMachineInfo,
     tcp_port_selector: TCPPortSelector,
     mock_agent_binary_http_handler: Type[AgentBinaryHTTPRequestHandler],
 ) -> HTTPAgentBinaryServer:
     return HTTPAgentBinaryServer(
+        mock_local_machine_info,
         tcp_port_selector,
         lambda: mock_agent_binary_http_handler,
         lambda: threading.Event(),
@@ -202,7 +228,8 @@ class GetHTTPHandler:
 
 
 class HTTPAgentBinaryServerFactory:
-    def __init__(self, tcp_port_selector, get_http_handler):
+    def __init__(self, local_machine_info, tcp_port_selector, get_http_handler):
+        self._local_machine_info = local_machine_info
         self._tcp_port_selector = tcp_port_selector
         self._get_http_handler = get_http_handler
         self._manager = None
@@ -211,6 +238,7 @@ class HTTPAgentBinaryServerFactory:
         if self._manager is None:
             self._manager = get_context("spawn").Manager()
         return HTTPAgentBinaryServer(
+            self._local_machine_info,
             self._tcp_port_selector,
             self._get_http_handler,
             self._manager.Event,
@@ -246,6 +274,7 @@ def test_request__download_completed_threading(
 
 @pytest.mark.xdist_group(name="tcp_port_selector")
 def test_request__download_completed_multiprocessing():
+    SyncManager.register("LocalMachineInfo", MockLocalMachineInfo)
     SyncManager.register("TCPPortSelector", TCPPortSelector)
     # Register a type that I can use to get the data
     SyncManager.register(
@@ -255,9 +284,12 @@ def test_request__download_completed_multiprocessing():
     )
     context = get_context("spawn")
     _manager = context.Manager()
+    mock_local_machine_info = _manager.LocalMachineInfo()  # type: ignore[attr-defined]
     tcp_port_selector = _manager.TCPPortSelector()  # type: ignore[attr-defined]
     handler_factory = _manager.HTTPHandlerFactory()  # type: ignore[attr-defined]
-    server_factory = HTTPAgentBinaryServerFactory(tcp_port_selector, handler_factory)
+    server_factory = HTTPAgentBinaryServerFactory(
+        mock_local_machine_info, tcp_port_selector, handler_factory
+    )
     SyncManager.register("HTTPAgentBinaryServer", server_factory)
 
     manager = context.Manager()

--- a/monkey/tests/unit_tests/infection_monkey/network/test_tools.py
+++ b/monkey/tests/unit_tests/infection_monkey/network/test_tools.py
@@ -1,0 +1,65 @@
+from ipaddress import IPv4Address, IPv4Interface
+from types import MappingProxyType
+
+import pytest
+
+from infection_monkey.network.tools import get_interface_to_target
+
+INTERFACES = (
+    IPv4Interface("192.168.1.0/24"),
+    IPv4Interface("192.168.2.2/32"),
+    IPv4Interface("10.0.0.0/16"),
+)
+
+INCLUDED_IPS = MappingProxyType(
+    {
+        IPv4Address("192.168.1.10"): INTERFACES[0],
+        IPv4Address("192.168.1.254"): INTERFACES[0],
+        IPv4Address("192.168.2.2"): INTERFACES[1],
+        IPv4Address("10.0.254.5"): INTERFACES[2],
+        IPv4Address("10.0.0.1"): INTERFACES[2],
+        IPv4Address("10.0.16.123"): INTERFACES[2],
+    }
+)
+
+EXCLUDED_IPS = (
+    IPv4Address("192.168.2.10"),
+    IPv4Address("192.168.2.3"),
+    IPv4Address("192.168.3.4"),
+    IPv4Address("172.1.2.3"),
+    IPv4Address("10.1.254.5"),
+    IPv4Address("10.2.0.1"),
+    IPv4Address("10.3.16.123"),
+)
+
+
+def test_empty_interfaces(monkeypatch):
+    monkeypatch.setattr(
+        "infection_monkey.network.tools._empirical_get_interface_to_target",
+        lambda *args, **kwargs: None,
+    )
+    assert get_interface_to_target([], IPv4Address("192.168.1.10")) is None
+
+
+@pytest.mark.parametrize("ip", INCLUDED_IPS.keys())
+def test_target_reachable(ip):
+    assert get_interface_to_target(INTERFACES, ip) == INCLUDED_IPS[ip]
+
+
+@pytest.mark.parametrize("ip", EXCLUDED_IPS)
+def test_target_unreachable(ip, monkeypatch):
+    monkeypatch.setattr(
+        "infection_monkey.network.tools._empirical_get_interface_to_target",
+        lambda *args, **kwargs: None,
+    )
+    assert get_interface_to_target(INTERFACES, ip) is None
+
+
+@pytest.mark.parametrize("ip", EXCLUDED_IPS)
+def test_empirical_fallback(monkeypatch, ip):
+    monkeypatch.setattr(
+        "infection_monkey.network.tools._empirical_get_interface_to_target",
+        lambda *args, **kwargs: INTERFACES[2].ip,
+    )
+    # import pudb; pu.db
+    assert get_interface_to_target(INTERFACES, ip) == INTERFACES[2]


### PR DESCRIPTION
# What does this PR do?

Reimplements `get_interface_to_target()`
Issue #3751

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] ~Was the CHANGELOG.md updated to reflect the changes?~
* [ ] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [ ] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
