### PR TITLE
Python patch version update (3.11.7)

### DIFF
--- a/build_scripts/appimage/appimage.sh
+++ b/build_scripts/appimage/appimage.sh
@@ -2,7 +2,7 @@
 
 # Changes: python version
 LINUXDEPLOY_URL="https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
-PYTHON_VERSION="3.11.6"
+PYTHON_VERSION="3.11.7"
 PYTHON_APPIMAGE_URL="https://github.com/niess/python-appimage/releases/download/python3.11/python${PYTHON_VERSION}-cp311-cp311-manylinux_2_28_x86_64.AppImage"
 APPIMAGE_DIR=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
 APPDIR="$APPIMAGE_DIR/squashfs-root"


### PR DESCRIPTION
# What does this PR do?

Fixes broken build due to 3.11.6 appimage no longer being available

Add any further explanations here.

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Do all unit tests pass?
* [x] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
