### PR TITLE
3945 keep relay open for descendants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
 - Inconsistent error messages on login screen. #3702
 - A bug that prevented filtering on certain event types. #3864
 - Link-local IPs are no longer shown under Run Monkey -> Manual in the UI. #3825
+- A bug that would allow tunnels/relays to prematurely close. #3947
 
 ### Removed
 - Fingerprinter configuration from UI. #3769, #3826

--- a/monkey/infection_monkey/network/relay/relay_connection_handler.py
+++ b/monkey/infection_monkey/network/relay/relay_connection_handler.py
@@ -34,7 +34,18 @@ class RelayConnectionHandler:
             self._relay_user_handler.disconnect_user(addr)
         else:
             try:
-                self._pipe_spawner.spawn_pipe(sock)
+                self._pipe_spawner.spawn_pipe(sock, self._handle_pipe_data)
                 self._relay_user_handler.add_relay_user(addr)
             except OSError as err:
                 logger.debug(f"Failed to spawn pipe: {err}")
+
+    def _handle_pipe_data(self, sock: socket.socket, _: bytes):
+        """
+        Handle data received on a pipe.
+
+        :param sock: The socket the data was received on.
+        :param data: The data received.
+        """
+        addr_str, _ = sock.getpeername()
+        addr = IPv4Address(addr_str)
+        self._relay_user_handler.renew_relay_user_membership(addr)

--- a/monkey/infection_monkey/network/relay/relay_connection_handler.py
+++ b/monkey/infection_monkey/network/relay/relay_connection_handler.py
@@ -35,16 +35,15 @@ class RelayConnectionHandler:
         else:
             try:
                 self._relay_user_handler.add_relay_user(addr)
-                self._pipe_spawner.spawn_pipe(sock, self._handle_pipe_data)
+                self._pipe_spawner.spawn_pipe(sock, self._renew_relay_user_membership_for_socket)
             except OSError as err:
                 logger.debug(f"Failed to spawn pipe: {err}")
 
-    def _handle_pipe_data(self, sock: socket.socket, _: bytes):
+    def _renew_relay_user_membership_for_socket(self, sock: socket.socket, _: bytes):
         """
-        Handle data received on a pipe.
+        Renew the membership of a relay user, if the provided socket is associated with one.
 
-        :param sock: The socket the data was received on.
-        :param data: The data received.
+        :param sock: The socket from which to determine the relay user.
         """
         addr_str, _ = sock.getpeername()
         addr = IPv4Address(addr_str)

--- a/monkey/infection_monkey/network/relay/relay_connection_handler.py
+++ b/monkey/infection_monkey/network/relay/relay_connection_handler.py
@@ -34,8 +34,8 @@ class RelayConnectionHandler:
             self._relay_user_handler.disconnect_user(addr)
         else:
             try:
-                self._pipe_spawner.spawn_pipe(sock, self._handle_pipe_data)
                 self._relay_user_handler.add_relay_user(addr)
+                self._pipe_spawner.spawn_pipe(sock, self._handle_pipe_data)
             except OSError as err:
                 logger.debug(f"Failed to spawn pipe: {err}")
 

--- a/monkey/infection_monkey/network/relay/relay_user_handler.py
+++ b/monkey/infection_monkey/network/relay/relay_user_handler.py
@@ -88,6 +88,16 @@ class RelayUserHandler:
                 logger.debug(f"Disconnected user {user_address}")
                 del_key(self._relay_users, user_address)
 
+    def renew_relay_user_membership(self, user_address: IPv4Address):
+        """
+        Renew the membership of a relay user.
+
+        :param user_address: The address of the user to renew.
+        """
+        with self._lock:
+            if user_address in self._relay_users:
+                self._relay_users[user_address].timer.reset()
+
     def has_potential_users(self) -> bool:
         """
         Return whether or not we have any potential users.

--- a/monkey/infection_monkey/network/relay/sockets_pipe.py
+++ b/monkey/infection_monkey/network/relay/sockets_pipe.py
@@ -22,16 +22,16 @@ class SocketsPipe(Thread):
         self,
         source,
         dest,
-        pipe_closed: Callable[[SocketsPipe], None],
-        pipe_received_data: Callable[[socket.socket, bytes], None],
+        on_pipe_closed: Callable[[SocketsPipe], None],
+        on_pipe_received_data: Callable[[socket.socket, bytes], None],
         timeout=SOCKET_TIMEOUT,
     ):
         self.source = source
         self.dest = dest
         self.timeout = timeout
         super().__init__(name=f"SocketsPipeThread-{self._next_thread_num()}", daemon=True)
-        self._pipe_closed = pipe_closed
-        self._pipe_received_data = pipe_received_data
+        self._on_pipe_closed = on_pipe_closed
+        self._on_pipe_received_data = on_pipe_received_data
 
     @classmethod
     def _next_thread_num(cls):
@@ -55,7 +55,7 @@ class SocketsPipe(Thread):
                 data = r.recv(READ_BUFFER_SIZE)
                 if data:
                     other.sendall(data)
-                    self._pipe_received_data(r, data)
+                    self._on_pipe_received_data(r, data)
                 else:
                     socket_closed = True
                     break
@@ -76,4 +76,4 @@ class SocketsPipe(Thread):
         except OSError as err:
             logger.debug(f"Error while closing destination socket: {err}")
 
-        self._pipe_closed(self)
+        self._on_pipe_closed(self)

--- a/monkey/infection_monkey/network/relay/sockets_pipe.py
+++ b/monkey/infection_monkey/network/relay/sockets_pipe.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import select
+import socket
 from logging import getLogger
 from threading import Thread
 from typing import Callable
@@ -22,6 +23,7 @@ class SocketsPipe(Thread):
         source,
         dest,
         pipe_closed: Callable[[SocketsPipe], None],
+        pipe_received_data: Callable[[socket.socket, bytes], None],
         timeout=SOCKET_TIMEOUT,
     ):
         self.source = source
@@ -29,6 +31,7 @@ class SocketsPipe(Thread):
         self.timeout = timeout
         super().__init__(name=f"SocketsPipeThread-{self._next_thread_num()}", daemon=True)
         self._pipe_closed = pipe_closed
+        self._pipe_received_data = pipe_received_data
 
     @classmethod
     def _next_thread_num(cls):
@@ -52,6 +55,7 @@ class SocketsPipe(Thread):
                 data = r.recv(READ_BUFFER_SIZE)
                 if data:
                     other.sendall(data)
+                    self._pipe_received_data(r, data)
                 else:
                     socket_closed = True
                     break

--- a/monkey/infection_monkey/network/relay/tcp_connection_handler.py
+++ b/monkey/infection_monkey/network/relay/tcp_connection_handler.py
@@ -19,11 +19,11 @@ class TCPConnectionHandler(Thread, InterruptableThreadMixin):
         self,
         bind_host: str,
         bind_port: NetworkPort,
-        client_connected: List[Callable[[socket.socket], None]] = [],
+        client_connected_listeners: List[Callable[[socket.socket], None]] = [],
     ):
         self.bind_host = bind_host
         self.bind_port = int(bind_port)
-        self._client_connected = client_connected
+        self._client_connected_listeners = client_connected_listeners
 
         Thread.__init__(self, name="TCPConnectionHandler", daemon=True)
         InterruptableThreadMixin.__init__(self)
@@ -42,7 +42,7 @@ class TCPConnectionHandler(Thread, InterruptableThreadMixin):
                     continue
 
                 logging.debug(f"New connection received from: {source.getpeername()}")
-                for notify_client_connected in self._client_connected:
+                for notify_client_connected in self._client_connected_listeners:
                     notify_client_connected(source)
         except OSError:
             logging.exception("Uncaught error in TCPConnectionHandler thread")

--- a/monkey/infection_monkey/network/relay/tcp_pipe_spawner.py
+++ b/monkey/infection_monkey/network/relay/tcp_pipe_spawner.py
@@ -23,12 +23,13 @@ class TCPPipeSpawner:
         self._lock = Lock()
 
     def spawn_pipe(
-        self, source: socket.socket, handle_pipe_data: Callable[[socket.socket, bytes], None]
+        self, source: socket.socket, on_data_received: Callable[[socket.socket, bytes], None]
     ):
         """
         Attempt to create a pipe on between the configured client and the provided socket
 
         :param source: A socket to the connecting client.
+        :param on_data_received: A callback to handle data received on the pipe.
         :raises OSError: If a socket to the configured client could not be created.
         """
         dest = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -44,7 +45,7 @@ class TCPPipeSpawner:
             source,
             dest,
             self._handle_pipe_closed,
-            handle_pipe_data,
+            on_data_received,
         )
         with self._lock:
             self._pipes.add(pipe)

--- a/monkey/infection_monkey/network/relay/tcp_pipe_spawner.py
+++ b/monkey/infection_monkey/network/relay/tcp_pipe_spawner.py
@@ -1,7 +1,7 @@
 import socket
 from logging import getLogger
 from threading import Lock
-from typing import Set
+from typing import Callable, Set
 
 from monkeytypes import SocketAddress
 
@@ -22,7 +22,9 @@ class TCPPipeSpawner:
         self._pipes: Set[SocketsPipe] = set()
         self._lock = Lock()
 
-    def spawn_pipe(self, source: socket.socket):
+    def spawn_pipe(
+        self, source: socket.socket, handle_pipe_data: Callable[[socket.socket, bytes], None]
+    ):
         """
         Attempt to create a pipe on between the configured client and the provided socket
 
@@ -38,7 +40,12 @@ class TCPPipeSpawner:
             dest.close()
             raise err
 
-        pipe = SocketsPipe(source, dest, self._handle_pipe_closed)
+        pipe = SocketsPipe(
+            source,
+            dest,
+            self._handle_pipe_closed,
+            handle_pipe_data,
+        )
         with self._lock:
             self._pipes.add(pipe)
 

--- a/monkey/infection_monkey/network/relay/tcp_relay.py
+++ b/monkey/infection_monkey/network/relay/tcp_relay.py
@@ -36,7 +36,7 @@ class TCPRelay(Thread, InterruptableThreadMixin):
         self._connection_handler = TCPConnectionHandler(
             bind_host="",
             bind_port=relay_port,
-            client_connected=[
+            client_connected_listeners=[
                 relay_filter.handle_new_connection,
             ],
         )

--- a/monkey/tests/unit_tests/infection_monkey/network/relay/test_relay_connection_handler.py
+++ b/monkey/tests/unit_tests/infection_monkey/network/relay/test_relay_connection_handler.py
@@ -53,7 +53,8 @@ def test_connection_spawns_pipe(pipe_spawner, relay_user_handler, data_socket):
 
     connection_handler.handle_new_connection(data_socket)
 
-    pipe_spawner.spawn_pipe.assert_called_once_with(data_socket)
+    pipe_spawner.spawn_pipe.assert_called_once()
+    assert pipe_spawner.spawn_pipe.call_args[0][0] == data_socket
 
 
 def test_connection_adds_user(pipe_spawner, relay_user_handler, data_socket):

--- a/monkey/tests/unit_tests/infection_monkey/network/relay/test_relay_user_handler.py
+++ b/monkey/tests/unit_tests/infection_monkey/network/relay/test_relay_user_handler.py
@@ -1,5 +1,4 @@
 from ipaddress import IPv4Address
-from time import sleep
 
 import pytest
 
@@ -26,11 +25,11 @@ def test_potential_user_removed_on_matching_user_added(handler):
     assert not handler.has_potential_users()
 
 
-def test_potential_users_time_out():
-    handler = RelayUserHandler(new_client_timeout=0.0001)
+def test_potential_users_time_out(freezer):
+    handler = RelayUserHandler(new_client_timeout=10)
 
     handler.add_potential_user(USER_ADDRESS)
-    sleep(0.02)
+    freezer.tick(20)
 
     assert not handler.has_potential_users()
 
@@ -41,10 +40,21 @@ def test_relay_users_added(handler):
     assert handler.has_connected_users()
 
 
-def test_relay_users_time_out():
-    handler = RelayUserHandler(client_disconnect_timeout=0.0001)
+def test_relay_users_time_out(freezer):
+    handler = RelayUserHandler(client_disconnect_timeout=10)
 
     handler.add_relay_user(USER_ADDRESS)
-    sleep(0.02)
+    freezer.tick(20)
 
     assert not handler.has_connected_users()
+
+
+def test_relay_users_renew_membership(freezer):
+    handler = RelayUserHandler(client_disconnect_timeout=10)
+    handler.add_relay_user(USER_ADDRESS)
+    freezer.tick(8)
+
+    handler.renew_relay_user_membership(USER_ADDRESS)
+    freezer.tick(8)
+
+    assert handler.has_connected_users()

--- a/monkey/tests/unit_tests/infection_monkey/network/relay/test_sockets_pipe.py
+++ b/monkey/tests/unit_tests/infection_monkey/network/relay/test_sockets_pipe.py
@@ -7,8 +7,8 @@ def test_sockets_pipe__name_increments():
     sock_in = MagicMock()
     sock_out = MagicMock()
 
-    pipe1 = SocketsPipe(sock_in, sock_out, None)
+    pipe1 = SocketsPipe(sock_in, sock_out, None, None)
     assert pipe1.name.endswith("1")
 
-    pipe2 = SocketsPipe(sock_in, sock_out, None)
+    pipe2 = SocketsPipe(sock_in, sock_out, None, None)
     assert pipe2.name.endswith("2")


### PR DESCRIPTION
# What does this PR do?

Fixes #3945.

Refreshes the RelayUser timeout whenever traffic comes from that relay user.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [x] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Do all unit tests pass?
* [x] Do all end-to-end tests pass?
* [x] Any other testing performed?
    > Tested by running the depth_3 tunneling test, and verifying that the relay remains open for new connections longer than the original timeout would have allowed
* [x] If applicable, add screenshots or log transcripts of the feature working
    > 2023-12-12 19:24:51,774 [2863:TCPConnectionHandler:DEBUG] tcp_connection_handler.run.44: New connection received from: ('10.2.1.10', 43068)
2023-12-12 19:24:51,777 [2863:TCPConnectionHandler:DEBUG] relay_user_handler.add_relay_user.64: Added relay user RelayUser(address='10.2.1.10', time_remaining=20.000)
2023-12-12 19:24:51,826 [2863:SocketsPipeThread-1:DEBUG] tcp_pipe_spawner._handle_pipe_closed.65: Closing pipe <SocketsPipe(SocketsPipeThread-1, started daemon 139867111532288)>
2023-12-12 19:24:52,226 [2863:AutomatedMasterThread:DEBUG] automated_master._run_master_thread.80: Waiting for the simulation thread to stop
2023-12-12 19:24:52,227 [2863:MainThread:INFO] automated_master.start.63: The simulation has been shutdown.
2023-12-12 19:24:52,227 [2863:MainThread:INFO] monkey.cleanup.531: Agent cleanup started
2023-12-12 19:24:53,754 [2863:AgentEventForwarder:DEBUG] agent_event_forwarder.flush.95: Sending 2 Agent events to the Island: [ExploitationEvent(source=UUID('30958694-90b8-4179-b0d0-076778b7353f'), target=IPv4Address('10.2.1.10'), timestamp=1702409088.6900778, tags=frozenset({'ssh-exploiter', 'attack-t1110', 'attack-t1021'}), success=True, exploiter_name='SSH', error_message=''), PropagationEvent(source=UUID('30958694-90b8-4179-b0d0-076778b7353f'), target=IPv4Address('10.2.1.10'), timestamp=1702409088.813586, tags=frozenset({'attack-t1222', 'attack-t1105', 'attack-t1059', 'attack-t1021', 'ssh-exploiter'}), success=True, exploiter_name='SSH', error_message='')]
2023-12-12 19:24:56,791 [2863:TCPConnectionHandler:DEBUG] tcp_connection_handler.run.44: New connection received from: ('10.2.1.10', 43074)
2023-12-12 19:24:56,793 [2863:TCPConnectionHandler:DEBUG] relay_user_handler.add_relay_user.64: Added relay user RelayUser(address='10.2.1.10', time_remaining=20.000)
2023-12-12 19:25:19,700 [2863:TCPConnectionHandler:DEBUG] tcp_connection_handler.run.44: New connection received from: ('10.2.1.11', 49720)
2023-12-12 19:25:19,703 [2863:TCPConnectionHandler:DEBUG] relay_user_handler.add_relay_user.64: Added relay user RelayUser(address='10.2.1.11', time_remaining=20.000)
2023-12-12 19:25:19,750 [2863:SocketsPipeThread-3:DEBUG] tcp_pipe_spawner._handle_pipe_closed.65: Closing pipe <SocketsPipe(SocketsPipeThread-3, started daemon 139867111532288)>
2023-12-12 19:25:24,727 [2863:TCPConnectionHandler:DEBUG] tcp_connection_handler.run.44: New connection received from: ('10.2.1.11', 43780)
2023-12-12 19:25:24,730 [2863:TCPConnectionHandler:DEBUG] relay_user_handler.add_relay_user.64: Added relay user RelayUser(address='10.2.1.11', time_remaining=20.000)
2023-12-12 19:25:28,107 [2863:TCPConnectionHandler:DEBUG] tcp_connection_handler.run.44: New connection received from: ('10.2.1.11', 43788)
2023-12-12 19:25:28,108 [2863:TCPConnectionHandler:DEBUG] relay_user_handler.disconnect_user.88: Disconnected user 10.2.1.11
