### PR TITLE
Remove hash length assert in depth 2B

### DIFF
--- a/envs/monkey_zoo/blackbox/test_blackbox.py
+++ b/envs/monkey_zoo/blackbox/test_blackbox.py
@@ -658,9 +658,6 @@ class TestMonkeyBlackbox:
         )
         exploitation_test.run()
 
-        # asserting that Agent hashes are not unique
-        assert len({a.sha256 for a in exploitation_test.agents}) == 2
-
         TestMonkeyBlackbox.assert_depth_restriction(
             agents=exploitation_test.agents,
             configured_depth=depth_2_b_test_configuration.agent_configuration.propagation.maximum_depth,  # noqa: E501


### PR DESCRIPTION
# What does this PR do?

Fixes part of #3583.

Since the test contains only Windows machine the assertion is not needed. We will have two hashes when running from Linux/ Docker and one when running from MSI.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [x] Was the CHANGELOG.md updated to reflect the changes?
* [x] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Do all unit tests pass?
* [x] Do all end-to-end tests pass?
* [x] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [x] If applicable, add screenshots or log transcripts of the feature working
