### PR TITLE
3583 rdp machines

### DIFF
--- a/envs/monkey_zoo/docs/zoo_network.md
+++ b/envs/monkey_zoo/docs/zoo_network.md
@@ -1138,7 +1138,7 @@ setting:
 <tbody>
 <tr class="odd">
 <td>OS:</td>
-<td><strong>Windows Server 2016 x64</strong></td>
+<td><strong>Windows Server 2012 R2 (custom image)</strong></td>
 </tr>
 <tr class="even">
 <td>Software:</td>

--- a/envs/monkey_zoo/docs/zoo_network.md
+++ b/envs/monkey_zoo/docs/zoo_network.md
@@ -19,6 +19,7 @@ This document describes Infection Monkey’s test network.
 [Nr. 21 Scan](#_Toc526517196)<br>
 [Nr. 22 Scan](#_Toc526517197)<br>
 [Nr. 25 Zerologon](#_Toc536021478)<br>
+[Nr. 3-44 Powershell](#_Toc536021579)<br>
 [Nr. 3-45 Powershell](#_Toc536021479)<br>
 [Nr. 3-46 Powershell](#_Toc536021480)<br>
 [Nr. 3-47 Powershell](#_Toc536021481)<br>
@@ -594,7 +595,7 @@ We decided to keep it this way to ensure that plugins run even if the OS of a ta
 <table>
 <thead>
 <tr class="header">
-<th><p><span id="_Toc536021479" class="anchor"></span>Nr. <strong>3-44 Powershell</strong></p>
+<th><p><span id="_Toc536021579" class="anchor"></span>Nr. <strong>3-44 Powershell</strong></p>
 <p>(10.2.3.44)</p></th>
 <th>(Vulnerable)</th>
 </tr>
@@ -666,8 +667,7 @@ the same credentials on both machines</td>
 </tr>
 <tr class="even">
 <td>Software:</td>
-<td>WinRM service</td>
-<td>Tomcat 8.0.36</td>
+<td>WinRM service and Tomcat 8.0.36</td>
 </tr>
 <tr class="odd">
 <td>Default server’s port:8080</td>
@@ -1016,8 +1016,7 @@ setting:
 </tr>
 <tr class="even">
 <td>Software:</td>
-<td>Logstash 5.5.0</td>
-<td>Java 1.8.0</td>
+<td>Logstash 5.5.0 and Java 1.8.0</td>
 </tr>
 <tr class="odd">
 <td>Default server’s port:</td>
@@ -1046,8 +1045,7 @@ setting:
 </tr>
 <tr class="even">
 <td>Software:</td>
-<td>Logstash 5.5.0</td>
-<td>Java 1.8.0</td>
+<td>Logstash 5.5.0 and Java 1.8.0</td>
 </tr>
 <tr class="odd">
 <td>Default server’s port:</td>
@@ -1132,8 +1130,7 @@ setting:
 </tr>
 <tr class="even">
 <td>Software:</td>
-<td>Remote Desktop Protocol</td>
-<td>Google Chrome</td>
+<td>Remote Desktop Protocol and Google Chrome</td>
 </tr>
 <tr class="odd">
 <td>Default RDP port:</td>
@@ -1302,7 +1299,3 @@ Password: blahblahblah
 </tr>
 </tbody>
 </table>
-
-# Network topography:
-
-<img src="/envs/monkey_zoo/docs/images/networkTopography.jpg" >

--- a/envs/monkey_zoo/docs/zoo_network.md
+++ b/envs/monkey_zoo/docs/zoo_network.md
@@ -12,7 +12,6 @@ This document describes Infection Monkey’s test network.
 [Nr. 13 Tunneling M2](#_Toc536021466)<br>
 [Nr. 11 SSH key steal](#_Toc526517190)<br>
 [Nr. 12 SSH key steal](#_Toc526517191)<br>
-[Nr. 13 RDP grinder](#_Toc526517192)<br>
 [Nr. 14 Mimikatz](#_Toc536021467)<br>
 [Nr. 15 Mimikatz](#_Toc536021468)<br>
 [Nr. 16 MsSQL](#_Toc536021469)<br>
@@ -364,44 +363,6 @@ We decided to keep it this way to ensure that plugins run even if the OS of a ta
 <tr class="even">
 <td>Notes:</td>
 <td>Don’t add this machine’s credentials to exploit configuration.</td>
-</tr>
-</tbody>
-</table>
-
-<table>
-<thead>
-<tr class="header">
-<th><p><span id="_Toc526517192" class="anchor"></span>Nr. <strong>13</strong> RDP grinder</p>
-<p>(10.2.2.13)</p></th>
-<th>(Not implemented)</th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td>OS:</td>
-<td><strong>Windows 10 x64</strong></td>
-</tr>
-<tr class="even">
-<td>Software:</td>
-<td>-</td>
-</tr>
-<tr class="odd">
-<td>Default connection port:</td>
-<td>3389</td>
-</tr>
-<tr class="even">
-<td>Root password:</td>
-<td>2}p}aR]&amp;=M</td>
-</tr>
-<tr class="odd">
-<td>Server’s config:</td>
-<td><p>Remote desktop enabled</p>
-<p>Admin user’s credentials:</p>
-<p>m0nk3y, 2}p}aR]&amp;=M</p></td>
-</tr>
-<tr class="even">
-<td>Notes:</td>
-<td></td>
 </tr>
 </tbody>
 </table>

--- a/envs/monkey_zoo/packer/rdp.pkr.hcl
+++ b/envs/monkey_zoo/packer/rdp.pkr.hcl
@@ -19,7 +19,7 @@ source "googlecompute" "rdp-64" {
 source "googlecompute" "rdp-65" {
     image_name = "rdp-65"
     project_id = "${var.project_id}"
-    source_image = "windows-server-2012-r2-dc-v20230510"
+    source_image = "windows-2012-r2"  # We use Windows 2012 R2 because PTH over RDP works only on Windows 8.1 and Windows 2012 R2. We use custom Windows Server 2012 R2 image
     zone = "${var.zone}"
     disk_size = 50
     machine_type = "${var.machine_type}"

--- a/envs/monkey_zoo/packer/setup_rdp_64.yml
+++ b/envs/monkey_zoo/packer/setup_rdp_64.yml
@@ -21,6 +21,11 @@
       win_command:
         cmd: netsh advfirewall firewall add rule name="Allow Port 8080" dir=in action=allow protocol=TCP localport=8080
 
+    # Disallow PowerShell to this machine from internal ips
+    - import_tasks: tasks/windows_disallow_powershell_remoting_on_subnet.yml
+      vars:
+        subnet_ip: "10.2.0.0/16"
+
     - name: Change the hostname to {{ host_name }}
       ansible.windows.win_hostname:
         name: "{{ host_name }}"

--- a/envs/monkey_zoo/packer/setup_rdp_64.yml
+++ b/envs/monkey_zoo/packer/setup_rdp_64.yml
@@ -3,41 +3,27 @@
   hosts: all
   become_method: runas
   vars:
+    host_name: rdp-64
+    user_name: m0nk3y
+    user_password: P@ssw0rd!
     ansible_remote_tmp: C:\Windows\Temp
     ansible_become_password: P@ssw0rd!
   tasks:
-    - name: Create user
-      win_user:
-        name: m0nk3y
-        password: P@ssw0rd!
-        password_never_expires: yes
-        state: present
-        update_password: on_create
-        groups_action: add
-        groups:
-          - Administrators
-          - "Remote Desktop Users"
+    - import_tasks: tasks/windows_create_user.yml
+      vars:
+        username: "{{ user_name }}"
+        password: "{{ user_password }}"
+        user_groups: [Administrators, "Remote Desktop Users"]
+    - import_tasks: tasks/windows_disable_automatic_updates.yml
+    - import_tasks: tasks/windows_disable_windows_defender.yml
 
     - name: Allow port 8080
       win_command:
         cmd: netsh advfirewall firewall add rule name="Allow Port 8080" dir=in action=allow protocol=TCP localport=8080
 
-    - name: Disable Windows Defender using registry
-      win_regedit:
-        path: HKLM:\SOFTWARE\Policies\Microsoft\Windows Defender
-        name: DisableAntiSpyware
-        data: 1
-        type: dword
-        state: present
-
-    - name: Disable Windows Defender
-      win_shell: Set-MpPreference -DisableIntrusionPreventionSystem $true -DisableIOAVProtection $true -DisableRealtimeMonitoring $true -EnableNetworkProtection AuditMode -Force
-      become: yes
-      become_user: m0nk3y
-
-    - name: Change the hostname to rdp-64
+    - name: Change the hostname to {{ host_name }}
       ansible.windows.win_hostname:
-        name: rdp-64
+        name: "{{ host_name }}"
       register: res
 
     - name: Reboot

--- a/envs/monkey_zoo/packer/setup_rdp_64.yml
+++ b/envs/monkey_zoo/packer/setup_rdp_64.yml
@@ -43,3 +43,8 @@
     - name: Reboot
       ansible.windows.win_reboot:
       when: res.reboot_required
+
+    - name: Delete packer_user
+      win_user:
+        name: packer_user
+        state: absent

--- a/envs/monkey_zoo/packer/setup_rdp_65.yml
+++ b/envs/monkey_zoo/packer/setup_rdp_65.yml
@@ -31,3 +31,8 @@
     - name: Reboot
       ansible.windows.win_reboot:
       when: res.reboot_required
+
+    - name: Delete packer_user
+      win_user:
+        name: packer_user
+        state: absent

--- a/envs/monkey_zoo/packer/setup_rdp_65.yml
+++ b/envs/monkey_zoo/packer/setup_rdp_65.yml
@@ -24,6 +24,11 @@
         data: 0
         type: dword
 
+    # Disallow PowerShell to this machine from internal ips
+    - import_tasks: tasks/windows_disallow_powershell_remoting_on_subnet.yml
+      vars:
+        subnet_ip: "10.2.0.0/16"
+
     - name: Change the hostname to {{ host_name }}
       ansible.windows.win_hostname:
         name: "{{ host_name }}"

--- a/envs/monkey_zoo/packer/setup_rdp_65.yml
+++ b/envs/monkey_zoo/packer/setup_rdp_65.yml
@@ -2,20 +2,21 @@
 - name: Create a new user and allow RDP access
   hosts: all
   vars:
+    host_name: rdp-65
+    user_name: m0nk3y
+    user_password: S3Cr3T1#
     ansible_remote_tmp: C:\Windows\Temp
+    ansible_become_password: S3Cr3T1#
   tasks:
-    - name: Create user
-      win_user:
-        name: m0nk3y
-        password: S3Cr3T1#
-        password_never_expires: yes
-        state: present
-        update_password: on_create
-        groups_action: add
-        groups:
-          - Administrators
-          - "Remote Desktop Users"
+    - import_tasks: tasks/windows_create_user.yml
+      vars:
+        username: "{{ user_name }}"
+        password: "{{ user_password }}"
+        user_groups: [Administrators, "Remote Desktop Users"]
+    - import_tasks: tasks/windows_disable_automatic_updates.yml
+    - import_tasks: tasks/windows_disable_windows_defender.yml
 
+    # This is done so we can use NT hash to RDP to the machine
     - name: Add disablerestrictedadmin key to enable Restricted Admin mode
       ansible.windows.win_regedit:
         path: HKLM:\System\CurrentControlSet\Control\Lsa
@@ -23,9 +24,9 @@
         data: 0
         type: dword
 
-    - name: Change the hostname to rdp-65
+    - name: Change the hostname to {{ host_name }}
       ansible.windows.win_hostname:
-        name: rdp-65
+        name: "{{ host_name }}"
       register: res
 
     - name: Reboot


### PR DESCRIPTION
# What does this PR do?

Fixes #3583 .
Disables PowerShell Remoting on the RDP machines and uses custom Windows Server 2012 R2 for .65

Things left to do:
- [ ] Rebuild the actual images in every environment (After addressing all comments in this PR)

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [x] Was the CHANGELOG.md updated to reflect the changes?
* [x] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Do all unit tests pass?
* [x] Do all end-to-end tests pass?
* [x] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [x] If applicable, add screenshots or log transcripts of the feature working

<img width="1253" alt="image" src="https://github.com/guardicore/monkey/assets/15820737/af5c8ea2-e0cd-4278-a986-bfe1466b74e2">
