### PR TITLE
3964 docker feature flags

### DIFF
--- a/build_scripts/docker/docker.sh
+++ b/build_scripts/docker/docker.sh
@@ -26,9 +26,9 @@ setup_build_dir() {
   generate_ssl_cert "$build_dir"
 
   if [[ $FEATURE_FLAGS == *"NEXT_JS_UI"* ]]; then
-    build_nextjs_frontend "$BUILD_DIR" "$is_release_build"
+    build_nextjs_frontend "$build_dir" "$is_release_build"
   else
-    build_frontend "$BUILD_DIR" "$is_release_build"
+    build_frontend "$build_dir" "$is_release_build"
   fi
 }
 


### PR DESCRIPTION
# What does this PR do?

Fixes #3964 

Running of docker with feature flags:

```bash
sudo docker run \   
    --tty \
    --interactive \
    --name monkey-island \
    --network=host \
    --env FEATURE_FLAGS="NEXT_JS_UI" \
    infectionmonkey/monkey-island:614b9f658
```

Or for multiple environments check [this](https://docs.docker.com/engine/reference/commandline/run/#env)

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [x] Was the CHANGELOG.md updated to reflect the changes?
* [x] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [x] Added relevant unit tests?
* [x] Do all unit tests pass?
* [x] Do all end-to-end tests pass?
* [x] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [x] If applicable, add screenshots or log transcripts of the feature working
