### PR TITLE
UI: Rename sign[in/up] into registration/login

### DIFF
--- a/monkey/monkey_island/cc/next_ui/src/app/(auth)/login/page.tsx
+++ b/monkey/monkey_island/cc/next_ui/src/app/(auth)/login/page.tsx
@@ -23,9 +23,9 @@ import {
 import { setAuthenticationTimer } from '@/redux/features/api/authentication/lib/authenticationTimer';
 import handleAuthToken from '@/redux/features/api/authentication/lib/handleAuthToken';
 import { instanceOfError } from '@/lib/typeChecks';
-import useRedirectToRegistration from '@/app/(auth)/signin/useRedirectToRegistration';
+import useRedirectToRegistration from '@/app/(auth)/login/useRedirectToRegistration';
 
-const SignInPage = () => {
+const LoginPage = () => {
     const router = useRouter();
     const [loginFormValues, setLoginFormValues] = useState({
         username: '',
@@ -77,7 +77,7 @@ const SignInPage = () => {
                             <LockOutlinedIcon />
                         </Avatar>
                         <Typography component="h1" variant="h5">
-                            Sign in
+                            Login
                         </Typography>
                         <Box
                             component="form"
@@ -121,7 +121,7 @@ const SignInPage = () => {
                                 fullWidth
                                 variant="contained"
                                 sx={{ mt: 3, mb: 2 }}>
-                                Sign In
+                                Login
                             </Button>
 
                             {isError &&
@@ -138,11 +138,6 @@ const SignInPage = () => {
                                         Forgot password?
                                     </Link>
                                 </Grid>
-                                <Grid item>
-                                    <Link href="#" variant="body2">
-                                        {"Don't have an account? Sign Up"}
-                                    </Link>
-                                </Grid>
                             </Grid>
                         </Box>
                     </Box>
@@ -153,4 +148,4 @@ const SignInPage = () => {
 
     return renderLoginForm();
 };
-export default SignInPage;
+export default LoginPage;

--- a/monkey/monkey_island/cc/next_ui/src/app/(auth)/login/useRedirectToRegistration.tsx
+++ b/monkey/monkey_island/cc/next_ui/src/app/(auth)/login/useRedirectToRegistration.tsx
@@ -2,9 +2,8 @@ import { useRouter } from 'next/navigation';
 import { useRegistrationStatusQuery } from '@/redux/features/api/authentication/authenticationEndpoints';
 import { useEffect } from 'react';
 import { PATHS } from '@/constants/paths.constants';
-import { tokenIsStored } from '@/lib/authenticationToken';
 
-const useRedirectToLogin = () => {
+const useRedirectToRegistration = () => {
     const router = useRouter();
     const { data: registrationStatus, isLoading: isRegistrationStatusLoading } =
         useRegistrationStatusQuery();
@@ -12,12 +11,11 @@ const useRedirectToLogin = () => {
     useEffect(() => {
         if (
             !isRegistrationStatusLoading &&
-            !registrationStatus?.registrationNeeded &&
-            !tokenIsStored()
+            registrationStatus?.registrationNeeded
         ) {
-            router.push(PATHS.SIGN_IN);
+            router.push(PATHS.REGISTRATION);
         }
     }, [isRegistrationStatusLoading, registrationStatus, router]);
 };
 
-export default useRedirectToLogin;
+export default useRedirectToRegistration;

--- a/monkey/monkey_island/cc/next_ui/src/app/(auth)/registration/page.tsx
+++ b/monkey/monkey_island/cc/next_ui/src/app/(auth)/registration/page.tsx
@@ -20,7 +20,7 @@ import {
 import { setAuthenticationTimer } from '@/redux/features/api/authentication/lib/authenticationTimer';
 import handleAuthToken from '@/redux/features/api/authentication/lib/handleAuthToken';
 import { instanceOfError } from '@/lib/typeChecks';
-import useRedirectToLogin from '@/app/(auth)/signup/useRedirectToLogin';
+import useRedirectToLogin from '@/app/(auth)/registration/useRedirectToLogin';
 
 const RegisterPage = () => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -114,7 +114,7 @@ const RegisterPage = () => {
                                 fullWidth
                                 variant="contained"
                                 sx={{ mt: 3, mb: 2 }}>
-                                Sign Up
+                                Register
                             </Button>
                             {/* @ts-ignore */}
                             {isError &&

--- a/monkey/monkey_island/cc/next_ui/src/app/(auth)/registration/useRedirectToLogin.tsx
+++ b/monkey/monkey_island/cc/next_ui/src/app/(auth)/registration/useRedirectToLogin.tsx
@@ -2,8 +2,9 @@ import { useRouter } from 'next/navigation';
 import { useRegistrationStatusQuery } from '@/redux/features/api/authentication/authenticationEndpoints';
 import { useEffect } from 'react';
 import { PATHS } from '@/constants/paths.constants';
+import { tokenIsStored } from '@/lib/authenticationToken';
 
-const useRedirectToRegistration = () => {
+const useRedirectToLogin = () => {
     const router = useRouter();
     const { data: registrationStatus, isLoading: isRegistrationStatusLoading } =
         useRegistrationStatusQuery();
@@ -11,11 +12,12 @@ const useRedirectToRegistration = () => {
     useEffect(() => {
         if (
             !isRegistrationStatusLoading &&
-            registrationStatus?.registrationNeeded
+            !registrationStatus?.registrationNeeded &&
+            !tokenIsStored()
         ) {
-            router.push(PATHS.SIGN_UP);
+            router.push(PATHS.LOGIN);
         }
     }, [isRegistrationStatusLoading, registrationStatus, router]);
 };
 
-export default useRedirectToRegistration;
+export default useRedirectToLogin;

--- a/monkey/monkey_island/cc/next_ui/src/app/(protected)/_lib/useRedirectionOnLogout.tsx
+++ b/monkey/monkey_island/cc/next_ui/src/app/(protected)/_lib/useRedirectionOnLogout.tsx
@@ -9,7 +9,7 @@ export default function useRedirectionOnLogout() {
     const router = useRouter();
     const checkToken = () => {
         if (!tokenIsStored()) {
-            router.push(PATHS.SIGN_IN);
+            router.push(PATHS.REGISTRATION);
         }
     };
 

--- a/monkey/monkey_island/cc/next_ui/src/app/(protected)/_lib/useRedirectionWhenUnauthenticated.tsx
+++ b/monkey/monkey_island/cc/next_ui/src/app/(protected)/_lib/useRedirectionWhenUnauthenticated.tsx
@@ -15,9 +15,9 @@ export default function useRedirectionWhenUnauthenticated() {
             return;
         }
         if (registrationStatus?.registrationNeeded) {
-            router.push(PATHS.SIGN_UP);
+            router.push(PATHS.REGISTRATION);
         } else if (!tokenIsStored()) {
-            router.push(PATHS.SIGN_IN);
+            router.push(PATHS.LOGIN);
         }
     }, [router, isLoading, registrationStatus]);
 }

--- a/monkey/monkey_island/cc/next_ui/src/constants/paths.constants.tsx
+++ b/monkey/monkey_island/cc/next_ui/src/constants/paths.constants.tsx
@@ -2,12 +2,10 @@ export enum PATHS {
     HOME = '/home',
     MAP = '/map',
     EVENTS = '/events',
-    SIGN_IN = '/signin',
-    SIGN_UP = '/signup',
+    REGISTRATION = '/registration',
+    LOGIN = '/login',
     ROOT = '/'
 }
-
-export const AUTHENTICATION_PATHS = [PATHS.SIGN_IN, PATHS.SIGN_UP];
 
 export const getApiPath = () => {
     if (typeof window !== 'undefined') {


### PR DESCRIPTION
# What does this PR do?

Fixes authentication page names.
Login and registration are easier to comprehend for non-native speakers.
## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [x] Any other testing performed?
    > Tested by navigating to the pages, doing basic auth flow
* [ ] If applicable, add screenshots or log transcripts of the feature working
