### PR TITLE
Enable selective package upgrades

### DIFF
--- a/monkey/infection_monkey/Pipfile
+++ b/monkey/infection_monkey/Pipfile
@@ -12,9 +12,9 @@ psutil = ">=5.7.0"
 requests = ">=2.24"
 urllib3 = "==1.26.5"
 "WinSys-3.x" = "*"
-pywin32-ctypes = {version = "*", sys_platform = "== 'win32'"} # Pyinstaller requirement on windows
-pywin32 = {version = "*", sys_platform = "== 'win32'"} # Lock file is not created with sys_platform win32 requirement if not explicitly specified
-pefile = {version = "*", sys_platform = "== 'win32'"} # Pyinstaller requirement on windows
+pywin32-ctypes = {version = "*", markers = "sys_platform == 'win32'"} # Pyinstaller requirement on windows
+pywin32 = {version = "*", markers = "sys_platform == 'win32'"} # Lock file is not created with sys_platform win32 requirement if not explicitly specified
+pefile = {version = "*", markers = "sys_platform == 'win32'"} # Pyinstaller requirement on windows
 pypubsub = "*"
 pydantic = "==2.5.*"
 egg-timer = "*"

--- a/monkey/monkey_island/Pipfile
+++ b/monkey/monkey_island/Pipfile
@@ -22,9 +22,9 @@ Werkzeug = "==2.*"
 pyaescrypt = "*"
 python-dateutil = "*"
 cffi = "*"  # Without explicit install: ModuleNotFoundError: No module named '_cffi_backend'
-pywin32-ctypes = {version = "*", sys_platform = "== 'win32'"} # Pyinstaller requirement on windows
-pywin32 = {version = "*", sys_platform = "== 'win32'"} # Lock file is not created with sys_platform win32 requirement if not explicitly specified
-pefile = {version = "*", sys_platform = "== 'win32'"} # Pyinstaller requirement on windows
+pywin32-ctypes = {version = "*", markers = "sys_platform == 'win32'"} # Pyinstaller requirement on windows
+pywin32 = {version = "*", markers = "sys_platform == 'win32'"} # Lock file is not created with sys_platform win32 requirement if not explicitly specified
+pefile = {version = "*", markers = "sys_platform == 'win32'"} # Pyinstaller requirement on windows
 readerwriterlock = "*"
 pymongo = "*"
 cryptography = "*"


### PR DESCRIPTION
# What does this PR do?

Updates the Island and Agent pipfiles to use markers instead of setting sys_platform directly. This enables selective package upgrades `pipenv upgrade <package>` on more recent versions of pipenv.

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
