### PR TITLE
3916 refresh plugins button

### DIFF
--- a/monkey/monkey_island/cc/next_ui/src/_components/icons/MonkeyLoadingIcon.tsx
+++ b/monkey/monkey_island/cc/next_ui/src/_components/icons/MonkeyLoadingIcon.tsx
@@ -1,0 +1,13 @@
+import Autorenew from '@mui/icons-material/Autorenew';
+import React from 'react';
+import { spinningIcon } from '@/_components/icons/style';
+
+type LoadingIconProps = {
+    sx?: React.CSSProperties;
+};
+
+const MonkeyLoadingIcon = (props: LoadingIconProps) => {
+    return <Autorenew sx={{ ...spinningIcon, ...props.sx }} />;
+};
+
+export default MonkeyLoadingIcon;

--- a/monkey/monkey_island/cc/next_ui/src/_components/icons/MonkeyLoadingIcon.tsx
+++ b/monkey/monkey_island/cc/next_ui/src/_components/icons/MonkeyLoadingIcon.tsx
@@ -1,9 +1,10 @@
 import Autorenew from '@mui/icons-material/Autorenew';
 import React from 'react';
 import { spinningIcon } from '@/_components/icons/style';
+import { SxProps } from '@mui/material';
 
 type LoadingIconProps = {
-    sx?: React.CSSProperties;
+    sx?: SxProps;
 };
 
 const MonkeyLoadingIcon = (props: LoadingIconProps) => {

--- a/monkey/monkey_island/cc/next_ui/src/_components/icons/MonkeyRefreshIcon.tsx
+++ b/monkey/monkey_island/cc/next_ui/src/_components/icons/MonkeyRefreshIcon.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import { spinningIcon } from '@/_components/icons/style';
+
+type RefreshIconSpinningProps = {
+    sx?: React.CSSProperties;
+    isSpinning?: boolean;
+};
+
+const MonkeyRefreshIcon = (props: RefreshIconSpinningProps) => {
+    if (props.isSpinning) {
+        return <RefreshIcon {...props} sx={{ ...spinningIcon, ...props.sx }} />;
+    } else {
+        return <RefreshIcon {...props} sx={{ ...props.sx }} />;
+    }
+};
+
+export default MonkeyRefreshIcon;

--- a/monkey/monkey_island/cc/next_ui/src/_components/icons/loading-icon/LoadingIcon.tsx
+++ b/monkey/monkey_island/cc/next_ui/src/_components/icons/loading-icon/LoadingIcon.tsx
@@ -1,9 +1,0 @@
-import Autorenew from '@mui/icons-material/Autorenew';
-import React from 'react';
-import { loadingIcon } from '@/_components/icons/loading-icon/style';
-
-const LoadingIcon = (props) => {
-    return <Autorenew {...props} sx={{ ...loadingIcon, ...props.sx }} />;
-};
-
-export default LoadingIcon;

--- a/monkey/monkey_island/cc/next_ui/src/_components/icons/style.ts
+++ b/monkey/monkey_island/cc/next_ui/src/_components/icons/style.ts
@@ -1,4 +1,4 @@
-export const loadingIcon = {
+export const spinningIcon = {
     animation: 'rotate 0.75s infinite',
     display: 'inline-block',
 

--- a/monkey/monkey_island/cc/next_ui/src/app/(auth)/login/page.tsx
+++ b/monkey/monkey_island/cc/next_ui/src/app/(auth)/login/page.tsx
@@ -21,7 +21,7 @@ import handleAuthToken from '@/redux/features/api/authentication/lib/handleAuthT
 import { instanceOfError } from '@/lib/typeChecks';
 import useRedirectToRegistration from '@/app/(auth)/login/useRedirectToRegistration';
 import ErrorList from '@/_components/errors/ErrorList';
-import LoadingIcon from '@/_components/icons/loading-icon/LoadingIcon';
+import MonkeyLoadingIcon from '@/_components/icons/MonkeyLoadingIcon';
 import BrandHeader from '@/_components/icons/monkey-logo/BrandHeader';
 import { useTheme } from '@mui/material/styles';
 import { cardStyle, containerStyle } from '@/app/(auth)/login/style';
@@ -133,7 +133,7 @@ const LoginPage = () => {
 
     const renderSubmitButtonContent = () => {
         if (isLoading) {
-            return <LoadingIcon />;
+            return <MonkeyLoadingIcon />;
         } else if (isSuccess) {
             return 'Success!';
         }

--- a/monkey/monkey_island/cc/next_ui/src/app/(auth)/registration/page.tsx
+++ b/monkey/monkey_island/cc/next_ui/src/app/(auth)/registration/page.tsx
@@ -21,7 +21,7 @@ import ErrorList from '@/_components/errors/ErrorList';
 import Card from '@mui/material/Card';
 import BrandHeader from '@/_components/icons/monkey-logo/BrandHeader';
 import Stack from '@mui/material/Stack';
-import LoadingIcon from '@/_components/icons/loading-icon/LoadingIcon';
+import MonkeyLoadingIcon from '@/_components/icons/MonkeyLoadingIcon';
 import { useTheme } from '@mui/material/styles';
 import { cardStyle, containerStyle } from '@/app/(auth)/registration/style';
 
@@ -134,7 +134,7 @@ const RegisterPage = () => {
 
     const renderSubmitButtonContent = () => {
         if (isLoading) {
-            return <LoadingIcon />;
+            return <MonkeyLoadingIcon />;
         } else if (isSuccess) {
             return 'Success!';
         }

--- a/monkey/monkey_island/cc/next_ui/src/app/(protected)/plugins/_lib/InstallAllSafePluginsButton.tsx
+++ b/monkey/monkey_island/cc/next_ui/src/app/(protected)/plugins/_lib/InstallAllSafePluginsButton.tsx
@@ -5,7 +5,7 @@ import MonkeyButton, {
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import { agentPluginEndpoints } from '@/redux/features/api/agentPlugins/agentPluginEndpoints';
 import { filterOutDangerousPlugins } from '@/app/(protected)/plugins/_lib/filters/SafetyFilter';
-import LoadingIcon from '@/_components/icons/loading-icon/LoadingIcon';
+import MonkeyLoadingIcon from '@/_components/icons/MonkeyLoadingIcon';
 import { useDispatch } from 'react-redux';
 import useInstallablePlugins from '@/app/(protected)/plugins/_lib/useInstallablePlugins';
 
@@ -46,7 +46,7 @@ const InstallAllSafePluginsButton = () => {
     const isDisabled = installableSafePlugins.length === 0;
 
     const buttonIcon = loading ? (
-        <LoadingIcon sx={{ mr: '5px' }} />
+        <MonkeyLoadingIcon sx={{ mr: '5px' }} />
     ) : (
         <FileDownloadIcon sx={{ mr: '5px' }} />
     );

--- a/monkey/monkey_island/cc/next_ui/src/app/(protected)/plugins/_lib/PluginTable.tsx
+++ b/monkey/monkey_island/cc/next_ui/src/app/(protected)/plugins/_lib/PluginTable.tsx
@@ -12,7 +12,7 @@ import { Typography } from '@mui/material';
 import Box from '@mui/material/Box';
 import MonkeyTooltip from '@/_components/tooltips/MonkeyTooltip';
 import MonkeyButton from '@/_components/buttons/MonkeyButton';
-import LoadingIcon from '@/_components/icons/loading-icon/LoadingIcon';
+import MonkeyLoadingIcon from '@/_components/icons/MonkeyLoadingIcon';
 import { GridAlignment } from '@mui/x-data-grid';
 
 const HEADER_SUFFIX = '--header';
@@ -173,7 +173,7 @@ const PluginTable = (props: PluginTableProps) => {
         <Box>
             {loading ? (
                 <Box sx={{ textAlign: 'center' }}>
-                    <LoadingIcon sx={{ height: '50px', width: '50px' }} />
+                    <MonkeyLoadingIcon sx={{ height: '50px', width: '50px' }} />
                 </Box>
             ) : (
                 <MonkeyDataGrid

--- a/monkey/monkey_island/cc/next_ui/src/app/(protected)/plugins/available/PluginInstallationButton.tsx
+++ b/monkey/monkey_island/cc/next_ui/src/app/(protected)/plugins/available/PluginInstallationButton.tsx
@@ -2,7 +2,7 @@ import { GridActionsCellItem } from '@mui/x-data-grid';
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import React from 'react';
 import { useInstallPluginMutation } from '@/redux/features/api/agentPlugins/agentPluginEndpoints';
-import LoadingIcon from '@/_components/icons/loading-icon/LoadingIcon';
+import MonkeyLoadingIcon from '@/_components/icons/MonkeyLoadingIcon';
 import DownloadDoneIcon from '@mui/icons-material/DownloadDone';
 
 type PluginInstallationButtonProps = {
@@ -57,7 +57,7 @@ const InstallationInProgressButton = (pluginId: string) => {
     return (
         <GridActionsCellItem
             key={pluginId}
-            icon={<LoadingIcon />}
+            icon={<MonkeyLoadingIcon />}
             label="Downloading"
             className="textPrimary"
             color="inherit"

--- a/monkey/monkey_island/cc/next_ui/src/app/(protected)/plugins/available/page.tsx
+++ b/monkey/monkey_island/cc/next_ui/src/app/(protected)/plugins/available/page.tsx
@@ -13,14 +13,16 @@ import InstallAllSafePluginsButton from '@/app/(protected)/plugins/_lib/InstallA
 import MonkeyButton, {
     ButtonVariant
 } from '@/_components/buttons/MonkeyButton';
-import RefreshIcon from '@mui/icons-material/Refresh';
 import PluginInstallationButton from '@/app/(protected)/plugins/available/PluginInstallationButton';
+import MonkeyRefreshIcon from '@/_components/icons/MonkeyRefreshIcon';
 
 export default function AvailablePluginsPage() {
     const {
         data: availablePlugins,
         isLoading: isLoadingAvailablePlugins,
-        isError
+        isError,
+        refetch: refreshAvailablePlugins,
+        isFetching: isFetchingAvailablePlugins
     } = useGetAvailablePluginsQuery();
     const [displayedRows, setDisplayedRows] = React.useState<PluginRow[]>([]);
     const [isLoadingRows, setIsLoadingRows] = React.useState(false);
@@ -79,9 +81,11 @@ export default function AvailablePluginsPage() {
                         </Grid>
                         <Grid item xs={2} md={4} lg={1}>
                             <MonkeyButton
-                                onClick={() => {}}
+                                onClick={refreshAvailablePlugins}
                                 variant={ButtonVariant.Contained}>
-                                <RefreshIcon />
+                                <MonkeyRefreshIcon
+                                    isSpinning={isFetchingAvailablePlugins}
+                                />
                             </MonkeyButton>
                         </Grid>
                     </Grid>
@@ -90,7 +94,7 @@ export default function AvailablePluginsPage() {
             <PluginTable
                 rows={displayedRows}
                 columns={generatePluginsTableColumns(getRowActions)}
-                loading={isLoadingRows || isLoadingRows}
+                loading={isFetchingAvailablePlugins || isLoadingRows}
                 noRowsOverlayMessage={getOverlayMessage()}
             />
         </Stack>

--- a/monkey/monkey_island/cc/next_ui/src/app/(protected)/plugins/available/page.tsx
+++ b/monkey/monkey_island/cc/next_ui/src/app/(protected)/plugins/available/page.tsx
@@ -1,5 +1,8 @@
 'use client';
-import { useGetAvailablePluginsQuery } from '@/redux/features/api/agentPlugins/agentPluginEndpoints';
+import {
+    useGetAvailablePluginsQuery,
+    useGetInstalledPluginsQuery
+} from '@/redux/features/api/agentPlugins/agentPluginEndpoints';
 import React from 'react';
 import Stack from '@mui/material/Stack';
 import PluginTable, {
@@ -24,6 +27,10 @@ export default function AvailablePluginsPage() {
         refetch: refreshAvailablePlugins,
         isFetching: isFetchingAvailablePlugins
     } = useGetAvailablePluginsQuery();
+    const {
+        refetch: refreshInstalledPlugins,
+        isFetching: isFetchingInstalledPlugins
+    } = useGetInstalledPluginsQuery();
     const [displayedRows, setDisplayedRows] = React.useState<PluginRow[]>([]);
     const [isLoadingRows, setIsLoadingRows] = React.useState(false);
 
@@ -81,7 +88,10 @@ export default function AvailablePluginsPage() {
                         </Grid>
                         <Grid item xs={2} md={4} lg={1}>
                             <MonkeyButton
-                                onClick={refreshAvailablePlugins}
+                                onClick={() => {
+                                    refreshAvailablePlugins();
+                                    refreshInstalledPlugins();
+                                }}
                                 variant={ButtonVariant.Contained}>
                                 <MonkeyRefreshIcon
                                     isSpinning={isFetchingAvailablePlugins}
@@ -94,7 +104,11 @@ export default function AvailablePluginsPage() {
             <PluginTable
                 rows={displayedRows}
                 columns={generatePluginsTableColumns(getRowActions)}
-                loading={isFetchingAvailablePlugins || isLoadingRows}
+                loading={
+                    isFetchingAvailablePlugins ||
+                    isLoadingRows ||
+                    isFetchingInstalledPlugins
+                }
                 noRowsOverlayMessage={getOverlayMessage()}
             />
         </Stack>

--- a/monkey/monkey_island/cc/next_ui/src/redux/features/api/agentPlugins/agentPluginEndpoints.tsx
+++ b/monkey/monkey_island/cc/next_ui/src/redux/features/api/agentPlugins/agentPluginEndpoints.tsx
@@ -24,7 +24,7 @@ export const agentPluginEndpoints = islandApiSlice.injectEndpoints({
     endpoints: (builder: EndpointBuilder<any, any, any>) => ({
         getAvailablePlugins: builder.query<AvailablePlugin[], void>({
             query: () => ({
-                url: BackendEndpoints.PLUGIN_INDEX,
+                url: BackendEndpoints.PLUGIN_INDEX_FORCE_REFRESH,
                 method: HTTP_METHODS.GET
             }),
             transformResponse: (response: {


### PR DESCRIPTION
# What does this PR do?

Fixes part of #3916

## TODO

- After this is merged, don't forget to add an issue to remove the force-refectch option from the island API as we no longer need it.

## Screen
![refetch_button](https://github.com/guardicore/monkey/assets/36815064/46d944bd-85b0-4beb-865c-1f931fd4b504)



## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
