### PR TITLE
Island: Use MONGO_URL instead of hard-coded values for flask-security

### DIFF
--- a/monkey/monkey_island/cc/mongo_consts.py
+++ b/monkey/monkey_island/cc/mongo_consts.py
@@ -1,9 +1,11 @@
 import os
 
-MONGO_DB_NAME = "monkey_island"
-MONGO_DB_HOST = "localhost"
-MONGO_DB_PORT = 27017
+DEFAULT_MONGO_DB_NAME = "monkey_island"
+DEFAULT_MONGO_DB_HOST = "localhost"
+DEFAULT_MONGO_DB_PORT = 27017
 MONGO_URL = os.environ.get(
     "MONKEY_MONGO_URL",
-    "mongodb://{0}:{1}/{2}".format(MONGO_DB_HOST, MONGO_DB_PORT, MONGO_DB_NAME),
+    f"mongodb://{0}:{1}/{2}".format(
+        DEFAULT_MONGO_DB_HOST, DEFAULT_MONGO_DB_PORT, DEFAULT_MONGO_DB_NAME
+    ),
 )

--- a/monkey/monkey_island/cc/services/authentication_service/configure_flask_security.py
+++ b/monkey/monkey_island/cc/services/authentication_service/configure_flask_security.py
@@ -2,6 +2,7 @@ import json
 import secrets
 from pathlib import Path
 from typing import Any, Dict
+from urllib.parse import urlparse
 
 from flask.sessions import SecureCookieSessionInterface
 from flask_mongoengine import MongoEngine
@@ -9,7 +10,7 @@ from flask_security import ConfirmRegisterForm, MongoEngineUserDatastore, Securi
 from monkeytoolbox import open_new_securely_permissioned_file
 from wtforms import StringField
 
-from monkey_island.cc.mongo_consts import MONGO_DB_HOST, MONGO_DB_NAME, MONGO_DB_PORT, MONGO_URL
+from monkey_island.cc.mongo_consts import MONGO_URL
 
 from . import AccountRole
 from .role import Role
@@ -71,11 +72,12 @@ def configure_flask_security(app, data_dir: Path) -> Security:
 
 def _setup_flask_mongo(app):
     app.config["MONGO_URI"] = MONGO_URL
+    url = urlparse(MONGO_URL)
     app.config["MONGODB_SETTINGS"] = [
         {
-            "db": MONGO_DB_NAME,
-            "host": MONGO_DB_HOST,
-            "port": MONGO_DB_PORT,
+            "db": url.path.strip("/"),
+            "host": url.hostname,
+            "port": url.port,
         }
     ]
 


### PR DESCRIPTION
# What does this PR do?

Addresses the issue by parsing MONGO_URL into its constituent parts and using them to set the values provided to flask-security.

Issue #4170.

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [x] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [x] Any other testing performed?
    > Tested by running monkey-island and mongo in a docker-compose script, setting the MONKEY_MONGO_URL using the mongo service name
* [ ] If applicable, add screenshots or log transcripts of the feature working
