### PR TITLE
Island: Add a small throttle to shorten the OTP

### DIFF
--- a/monkey/monkey_island/cc/services/authentication_service/authentication_facade.py
+++ b/monkey/monkey_island/cc/services/authentication_service/authentication_facade.py
@@ -16,6 +16,7 @@ from .i_otp_repository import IOTPRepository
 from .user import User
 
 OTP_EXPIRATION_TIME = 2 * 60  # 2 minutes
+OTP_LENGTH = 16
 
 
 class AuthenticationFacade:
@@ -87,7 +88,9 @@ class AuthenticationFacade:
 
         The generated OTP is saved to the `IOTPRepository`
         """
-        otp = OTP(secure_generate_random_string(32, string.ascii_letters + string.digits + "._-"))
+        otp = OTP(
+            secure_generate_random_string(OTP_LENGTH, string.ascii_letters + string.digits + "._-")
+        )
         expiration_time = time.monotonic() + OTP_EXPIRATION_TIME
         self._otp_repository.insert_otp(otp, expiration_time)
 


### PR DESCRIPTION
# What does this PR do?

Part of  #4187 

## Calculations

7 chars (alphanumeric + 3 special characters) gives total of 4,764,996,883,946 combinations (based on [this](https://www.omnicalculator.com/statistics/password-combination)
The current throttle is 0.001, so the result is that you're able to check 120 000 passwords per 2 minutes. 
This means that you chance of guessing the OTP is 1 in 39,708,307. In practice it's much higher if you account for network latency. I think this is sufficient security for a problem whose real solution is NAC.

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?
