### PR TITLE
Support newer hugo versions

### DIFF
--- a/docs/content/FAQ/_index.md
+++ b/docs/content/FAQ/_index.md
@@ -131,7 +131,7 @@ See the [logs reference page](../reference/logs).
 
 The Infection Monkey leaves hardly any trace on the target system. It will leave:
 
-- Log files in [temporary directories]({{< ref "/faq/#infection-monkey-agent-logs">}}):
+- Log files in [temporary directories]({{< ref "/faq#infection-monkey-agent-logs">}}):
   - Path on Linux: `/tmp/infection-monky-agent-<TIMESTAMP>-<RANDOM_STRING>.log`
   - Path on Windows: `%temp%\\infection-monky-agent-<TIMESTAMP>-<RANDOM_STRING>.log`
 

--- a/docs/content/howtos/_index.md
+++ b/docs/content/howtos/_index.md
@@ -11,6 +11,6 @@ tags = ["how tos"]
 
 Here you can find "how to" guides (or recipes) for accomplishing common tasks.
 
-{{% children %}}
+{{% children /%}}
 
 <br />

--- a/docs/content/reference/_index.md
+++ b/docs/content/reference/_index.md
@@ -11,4 +11,4 @@ tags = ["reference"]
 
 Find detailed information about the Infection Monkey:
 
-{{% children %}}
+{{% children /%}}

--- a/docs/content/reference/credentials_collectors/_index.md
+++ b/docs/content/reference/credentials_collectors/_index.md
@@ -12,4 +12,4 @@ tags: ["reference", "credentials collectors"]
 
 Infection Monkey has multiple ways to steal credentials from compromised machines:
 
-{{% children %}}
+{{% children /%}}

--- a/docs/content/reference/exploiters/_index.md
+++ b/docs/content/reference/exploiters/_index.md
@@ -11,4 +11,4 @@ tags = ["reference", "exploit"]
 
 The Infection Monkey uses various remote code execution (RCE) exploiters. To our best knowledge, most of these pose no risk to performance or services on victim machines. This documentation serves as a quick introduction to the exploiters currently implemented and the vulnerabilities they use:
 
-{{% children %}}
+{{% children /%}}

--- a/docs/content/reports/_index.md
+++ b/docs/content/reports/_index.md
@@ -10,4 +10,4 @@ pre = "<i class='fas fa-scroll'></i> "
 
 Infection Monkey offers the following reports:
 
-{{% children description=true style="p"%}}
+{{% children description=true style="p" /%}}

--- a/docs/content/setup/_index.md
+++ b/docs/content/setup/_index.md
@@ -14,7 +14,7 @@ Setting up the Infection Monkey is easy! First, you need to
 
 Once you've downloaded an installer, follow the relevant guide for your environment:
 
-{{% children %}}
+{{% children /%}}
 
 After setting the Monkey up, check out our [Getting Started](/usage/getting-started) guide!
 

--- a/docs/content/setup/linux.md
+++ b/docs/content/setup/linux.md
@@ -55,7 +55,7 @@ which requires setting the `CAP_NET_BIND_SERVICE` capability on the AppImage pac
 {{% notice info %}}
 If you're prompted to delete your data directory and you're not sure what to
 do, see the [FAQ]({{< ref
-"/faq/#i-updated-to-a-new-version-of-the-infection-monkey-and-im-being-asked-to-delete-my-existing-data-directory-why"
+"/faq#i-updated-to-a-new-version-of-the-infection-monkey-and-im-being-asked-to-delete-my-existing-data-directory-why"
 >}}) for more information.
 {{% /notice %}}
 

--- a/docs/content/setup/windows.md
+++ b/docs/content/setup/windows.md
@@ -24,7 +24,7 @@ collect more data on the current machine, consider running as Administrator.
 {{% notice info %}}
 If you're prompted to delete your data directory and you're not sure what to
 do, see the [FAQ]({{< ref
-"/faq/#i-updated-to-a-new-version-of-the-infection-monkey-and-im-being-asked-to-delete-my-existing-data-directory-why"
+"/faq#i-updated-to-a-new-version-of-the-infection-monkey-and-im-being-asked-to-delete-my-existing-data-directory-why"
 >}}) for more information.
 {{% /notice %}}
 

--- a/docs/content/tutorials/_index.md
+++ b/docs/content/tutorials/_index.md
@@ -11,6 +11,6 @@ tags = ["tutorials"]
 
 Learn how to use Infection Monkey:
 
-{{% children %}}
+{{% children /%}}
 
 <br />

--- a/docs/content/usage/configuration/_index.md
+++ b/docs/content/usage/configuration/_index.md
@@ -17,4 +17,4 @@ This section of the documentation is incomplete and under active construction.
 
 See these documentation pages for information on each configuration value:
 
-{{% children description=true style="p"%}}
+{{% children description=true style="p" /%}}

--- a/docs/content/usage/integrations/_index.md
+++ b/docs/content/usage/integrations/_index.md
@@ -11,4 +11,4 @@ pre: "<i class='fas fa-directions'></i> "
 
 The Infection Monkey likes working together! See these documentation pages for information on each integration the Infection Monkey currently offers:
 
-{{% children description=true style="p"%}}
+{{% children description=true style="p" /%}}

--- a/docs/content/usage/plugins/_index.md
+++ b/docs/content/usage/plugins/_index.md
@@ -23,4 +23,4 @@ Plugins page consists of three tabs:
 ## Troubleshooting
 
 First, make sure that the machine running Monkey Island has access to the internet. If it does,
-check the [Island logs]({{< ref "/FAQ/#monkey-island-server-logs" >}}).
+check the [Island logs]({{< ref "/FAQ#monkey-island-server-logs" >}}).

--- a/docs/content/usage/scenarios/_index.md
+++ b/docs/content/usage/scenarios/_index.md
@@ -18,4 +18,4 @@ You can enhance, optimize, and fine-tune the Monkey's behavior.
 
 Here are some examples with instructions on how to configure them.
 
-{{% children description=True style="p"%}}
+{{% children description=True style="p" /%}}


### PR DESCRIPTION
# What does this PR do?

I'm stuck using a newer version of Hugo (v0.123.1) than is mentioned as supported in the docs (v0.92.0). These changes allow the documentation to be compiled with more recent versions of Hugo (tested on v0.123.1 and v0.127.0).

## PR Checklist
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [x] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
