### PR TITLE
Island: Suppress pymongo logging

### DIFF
--- a/monkey/monkey_island/cc/setup/mongo/mongo_setup.py
+++ b/monkey/monkey_island/cc/setup/mongo/mongo_setup.py
@@ -18,6 +18,9 @@ MINIMUM_MONGO_DB_VERSION_REQUIRED = "4.2.0"
 
 logger = logging.getLogger(__name__)
 
+# Suppress (most) pymongo logging
+logging.getLogger("pymongo").setLevel(logging.WARNING)
+
 
 def start_mongodb(data_dir: Path) -> MongoDbProcess:
     db_dir = _create_db_dir(data_dir)


### PR DESCRIPTION
Since the upgrade to pymongo 4.6.3 (commit 8fe2603c7), the pymongo client has been dumping copious debug logs. Most of these are of no interest to us. Logs with level WARNING or higher maybe of interest.

# What does this PR do?


## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
