### PR TITLE
Add Helm chart for Infection Monkey deployment

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: monkey-chart
+description: A Helm chart to deploy Monkey resources
+version: 1.0.0
+appVersion: 1.0.0
+license: GPL-3.0
+

--- a/helm-chart/templates/clusterrolebinding.yaml
+++ b/helm-chart/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.clusterRoleBinding.name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.clusterRoleBinding.roleRef.name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name }}
+    namespace: default

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.deployment.name }}
+  labels:
+    app: {{ .Values.pod.labels.app }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Values.pod.labels.app }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.pod.labels.app }}
+    spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      containers:
+        {{- range .Values.pod.containers }}
+        - name: {{ .name }}
+          image: {{ .image }}
+          imagePullPolicy: {{ .imagePullPolicy }}
+          ports:
+            {{- range .ports }}
+            - containerPort: {{ .containerPort }}
+            {{- end }}
+          {{- if .volumeMounts }}
+          volumeMounts:
+            {{- range .volumeMounts }}
+            - mountPath: {{ .mountPath }}
+              name: {{ .name }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+      volumes:
+        {{- range .Values.pod.volumes }}
+        - name: {{ .name }}
+          hostPath:
+            path: {{ .hostPath.path }}
+        {{- end }}

--- a/helm-chart/templates/service.yaml
+++ b/helm-chart/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.service.name }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ .Values.pod.labels.app }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      nodePort: {{ .Values.service.nodePort }}

--- a/helm-chart/templates/serviceaccount.yaml
+++ b/helm-chart/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  namespace: default

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -1,0 +1,38 @@
+deployment:
+  name: monkey-deployment
+
+serviceAccount:
+  name: monkey
+
+service:
+  name: monkey-svc
+  type: NodePort
+  port: 5000
+  targetPort: 5000
+  nodePort: 30007
+
+pod:
+  name: monkey-island
+  labels:
+    app: monkey
+  containers:
+    - name: monkey-island
+      image: artifactory.f5net.com/dockerhub-remote/infectionmonkey/monkey-island:latest
+      imagePullPolicy: IfNotPresent
+      ports:
+        - containerPort: 5000
+    - name: monkey-mongo
+      image: artifactory.f5net.com/dockerhub-remote/mongo:6.0
+      imagePullPolicy: IfNotPresent
+      volumeMounts:
+        - mountPath: /data/db
+          name: monkey-data
+  volumes:
+    - name: monkey-data
+      hostPath:
+        path: /var/monkey-mongo/data/db
+
+clusterRoleBinding:
+  name: monkey-bind
+  roleRef:
+    name: cluster-admin

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -17,12 +17,12 @@ pod:
     app: monkey
   containers:
     - name: monkey-island
-      image: artifactory.f5net.com/dockerhub-remote/infectionmonkey/monkey-island:latest
+      image: infectionmonkey/monkey-island:latest
       imagePullPolicy: IfNotPresent
       ports:
         - containerPort: 5000
     - name: monkey-mongo
-      image: artifactory.f5net.com/dockerhub-remote/mongo:6.0
+      image: mongo:6.0
       imagePullPolicy: IfNotPresent
       volumeMounts:
         - mountPath: /data/db


### PR DESCRIPTION
# What does this PR do?

This PR introduces a Helm chart for deploying Infection Monkey resources on a Kubernetes cluster. The chart simplifies the deployment process by defining Kubernetes resources such as:

ServiceAccount
ClusterRoleBinding
Deployment (with Monkey container and MongoDB)
Service (NodePort for accessing the Infection Monkey UI)

## PR Checklist
* [* ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running helm lint to verify the Helm chart syntax and structure}
    > Tested by {Running helm install/unintall}
* [ ] If applicable, add screenshots or log transcripts of the feature working
