### PR TITLE
4297-update-docker-installation-instructions

### DIFF
--- a/docs/content/setup/docker.md
+++ b/docs/content/setup/docker.md
@@ -30,6 +30,11 @@ If you are upgrading Infection Monkey to a new version, be sure to remove
 any MongoDB containers or volumes associated with the previous version.
 {{% /notice %}}
 
+{{% notice warning %}}
+Warning: The MongoDB server used by Monkey Island is **unsecured (no authentication enabled)**.
+It listens only on the **localhost**, but it is strongly recommended to run Infection Monkey on a **dedicated host or VM** to avoid any potential security risks.
+{{% /notice %}}
+
 1. Start a MongoDB Docker container:
 
     ```bash
@@ -49,6 +54,11 @@ user [provide Infection Monkey with a
 certificate](#start-monkey-island-with-user-provided-certificate) that has
 been signed by a private certificate authority.
 
+{{% notice warning %}}
+Warning: The MongoDB server used by Monkey Island is **unsecured (no authentication enabled)**.
+It listens only on the **localhost**, but it is strongly recommended to run Infection Monkey on a **dedicated host or VM** to avoid any potential security risks.
+{{% /notice %}}
+
 1. Run the Monkey Island Server
     ```bash
     sudo docker run \
@@ -66,6 +76,11 @@ After the Monkey Island docker container starts, you can access Monkey Island by
 Once you have access to the Monkey Island server, check out the [getting started page](/usage/getting-started).
 
 ## Configuring the server
+
+{{% notice warning %}}
+Warning: The MongoDB server used by Monkey Island is **unsecured (no authentication enabled)**.
+It listens only on the **localhost**, but it is strongly recommended to run Infection Monkey on a **dedicated host or VM** to avoid any potential security risks.
+{{% /notice %}}
 
 You can configure the server by mounting a volume and specifying a
  [server configuration file](../../reference/server-configuration):

--- a/docs/content/setup/docker.md
+++ b/docs/content/setup/docker.md
@@ -35,7 +35,7 @@ any MongoDB containers or volumes associated with the previous version.
     ```bash
     sudo docker run \
         --name monkey-mongo \
-        --network=host \
+        -p 127.0.0.1:27017:27017 \
         --volume monkey-db:/data/db \
         --detach \
         mongo:6.0


### PR DESCRIPTION
# What does this PR do?
Update Docker installation instructions.
Modify the docker installation instructions so that the MongoDB process is only listening on the localhost.
Add a caveat to all installation instructions that the Monkey Island is intended to be run on its own host/VM.

Issue #4297

Add any further explanations here.

## PR Checklist
* [ ] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Is the TravisCI build passing?
* [ ] Was the CHANGELOG.md updated to reflect the changes?
* [ ] Was the documentation framework updated to reflect the changes?
* [ ] Have you checked that you haven't introduced any duplicate code?

## Testing Checklist

* [ ] Added relevant unit tests?
* [ ] Do all unit tests pass?
* [ ] Do all end-to-end tests pass?
* [ ] Any other testing performed?
    > Tested by {Running the Monkey locally with relevant config/running Island/...}
* [ ] If applicable, add screenshots or log transcripts of the feature working
